### PR TITLE
Convert vec::raw::to_ptr(*) to *.as_ptr()

### DIFF
--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -1,5 +1,4 @@
 use std::ptr;
-use std::vec;
 
 use get_error;
 use surface;
@@ -89,8 +88,8 @@ impl Drop for Cursor {
 impl Cursor {
     pub fn new(data: &[u8], mask: &[u8], width: int, height: int, hot_x: int, hot_y: int) -> Result<~Cursor, ~str> {
         unsafe {
-            let raw = ll::SDL_CreateCursor(vec::raw::to_ptr(data),
-                                           vec::raw::to_ptr(mask),
+            let raw = ll::SDL_CreateCursor(data.as_ptr(),
+                                           mask.as_ptr(),
                                            width as i32, height as i32,
                                            hot_x as i32, hot_y as i32);
 

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -1,7 +1,6 @@
 use std::cast;
 use std::libc::c_int;
 use std::ptr;
-use std::vec;
 
 #[deriving(Eq)]
 #[deriving(Clone)]
@@ -70,7 +69,7 @@ impl Rect {
 
         let result = unsafe {
             ll::SDL_EnclosePoints(
-                cast::transmute(vec::raw::to_ptr(points)),
+                cast::transmute(points.as_ptr()),
                 points.len() as c_int,
                 match clip { Some(ref rect) => cast::transmute(rect), None => ptr::null() },
                 &out

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -8,7 +8,6 @@ use std::str;
 use std::cast;
 use rect::Point;
 use rect::Rect;
-use std::vec;
 use std::num::FromPrimitive;
 
 pub mod ll {
@@ -427,7 +426,7 @@ impl Renderer {
 
     pub fn draw_points(&self, points: &[Point]) -> bool {
         unsafe {
-            ll::SDL_RenderDrawPoints(self.raw, cast::transmute(vec::raw::to_ptr(points)), points.len() as c_int) == 0
+            ll::SDL_RenderDrawPoints(self.raw, cast::transmute(points.as_ptr()), points.len() as c_int) == 0
         }
     }
 
@@ -437,7 +436,7 @@ impl Renderer {
 
     pub fn draw_lines(&self, points: &[Point]) -> bool {
         unsafe {
-            ll::SDL_RenderDrawLines(self.raw, cast::transmute(vec::raw::to_ptr(points)), points.len() as c_int) == 0
+            ll::SDL_RenderDrawLines(self.raw, cast::transmute(points.as_ptr()), points.len() as c_int) == 0
         }
     }
 
@@ -447,7 +446,7 @@ impl Renderer {
 
     pub fn draw_rects(&self, rects: &[Rect]) -> bool {
         unsafe {
-            ll::SDL_RenderDrawRects(self.raw, cast::transmute(vec::raw::to_ptr(rects)), rects.len() as c_int) == 0
+            ll::SDL_RenderDrawRects(self.raw, cast::transmute(rects.as_ptr()), rects.len() as c_int) == 0
         }
     }
 
@@ -457,7 +456,7 @@ impl Renderer {
 
     pub fn fill_rects(&self, rects: &[Rect]) -> bool {
         unsafe {
-            ll::SDL_RenderFillRects(self.raw, cast::transmute(vec::raw::to_ptr(rects)), rects.len() as c_int) == 0
+            ll::SDL_RenderFillRects(self.raw, cast::transmute(rects.as_ptr()), rects.len() as c_int) == 0
         }
     }
 
@@ -605,7 +604,7 @@ impl Texture {
                 None => ptr::null()
             };
 
-            ll::SDL_UpdateTexture(self.raw, actual_rect, cast::transmute(vec::raw::to_ptr(pixel_data)), pitch as c_int) == 0
+            ll::SDL_UpdateTexture(self.raw, actual_rect, cast::transmute(pixel_data.as_ptr()), pitch as c_int) == 0
         }
     }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -547,7 +547,7 @@ impl Window {
     }
 
     pub fn update_surface_rects(&self, rects: &[Rect]) -> bool {
-        unsafe { ll::SDL_UpdateWindowSurfaceRects(self.raw, cast::transmute(vec::raw::to_ptr(rects)), rects.len() as c_int) == 0}
+        unsafe { ll::SDL_UpdateWindowSurfaceRects(self.raw, cast::transmute(rects.as_ptr()), rects.len() as c_int) == 0}
     }
 
     pub fn set_grab(&self, grabbed: bool) {
@@ -569,15 +569,15 @@ impl Window {
     pub fn set_gamma_ramp(&self, red: Option<&[u16, ..256]>, green: Option<&[u16, ..256]>, blue: Option<&[u16, ..256]>) -> bool {
         unsafe {
             let unwrapped_red = match red {
-                Some(values) => cast::transmute(vec::raw::to_ptr(*values)),
+                Some(values) => cast::transmute((*values).as_ptr()),
                 None => ptr::null()
             };
             let unwrapped_green = match green {
-                Some(values) => cast::transmute(vec::raw::to_ptr(*values)),
+                Some(values) => cast::transmute((*values).as_ptr()),
                 None => ptr::null()
             };
             let unwrapped_blue = match blue {
-                Some(values) => cast::transmute(vec::raw::to_ptr(*values)),
+                Some(values) => cast::transmute((*values).as_ptr()),
                 None => ptr::null()
             };
             ll::SDL_SetWindowGammaRamp(self.raw, unwrapped_red, unwrapped_green, unwrapped_blue) == 0
@@ -588,7 +588,7 @@ impl Window {
         let red: ~[u16] = vec::with_capacity(256);
         let green: ~[u16] = vec::with_capacity(256);
         let blue: ~[u16] = vec::with_capacity(256);
-        let result = unsafe {ll::SDL_GetWindowGammaRamp(self.raw, cast::transmute(vec::raw::to_ptr(red)), cast::transmute(vec::raw::to_ptr(green)), cast::transmute(vec::raw::to_ptr(blue))) == 0};
+        let result = unsafe {ll::SDL_GetWindowGammaRamp(self.raw, cast::transmute(red.as_ptr()), cast::transmute(green.as_ptr()), cast::transmute(blue.as_ptr())) == 0};
         if result {
             Ok((red, green, blue))
         } else {


### PR DESCRIPTION
New version of Rust master removed the vec::raw::to_ptr function and replaced it with as_ptr.
