### PR TITLE
ignore rustpkg_db.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 bin/
 lib/
 src/generated
+/rustpkg_db.json


### PR DESCRIPTION
From what i've gathered, you don't want to track the `rustpkg_db.json` file, in git, if your repo is set up as a workspace (which `rust-sdl2` is).
