### PR TITLE
Some changes to be compatible with rust master

### DIFF
--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -2,11 +2,6 @@ extern mod sdl2;
 
 mod video;
 
-#[start]
-fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
-}
-
 #[main]
 fn main() {
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -207,9 +207,15 @@ impl RendererInfo {
 }
 
 #[deriving(Eq)]
+enum RendererParent {
+    Window(~video::Window),
+    Surface(~surface::Surface)
+}
+
+#[deriving(Eq)]
 pub struct Renderer {
     raw: *ll::SDL_Renderer,
-    parent: Either<~video::Window, ~surface::Surface>,
+    parent: RendererParent,
     owned: bool
 }
 
@@ -238,7 +244,7 @@ impl Renderer {
         if raw == ptr::null() {
             Err(get_error())
         } else {
-            Ok(~Renderer{ raw: raw, parent: Left(window), owned: true,})
+            Ok(~Renderer{ raw: raw, parent: Window(window), owned: true,})
         }
     }
 
@@ -254,7 +260,7 @@ impl Renderer {
             };
             Ok(~Renderer {
                 raw: raw_renderer,
-                parent: Left(window),
+                parent: Window(window),
                 owned: true 
             })
         } else {
@@ -267,7 +273,7 @@ impl Renderer {
         if result == ptr::null() {
             Ok(~Renderer {
                 raw: result,
-                parent: Right(surface),
+                parent: Surface(surface),
                 owned: true 
             })
         } else {


### PR DESCRIPTION
- Either was removed from master, so I replaced it here too
- #[start] was removed from the demo.
  I'm not sure that was it the best solution, but the "start_on_main_thread" function was removed from std::rt in the rust master.
