### PR TITLE
println is not in prelude anymore, the println! macro should be used

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -16,7 +16,7 @@ fn main() {
     let args = os::args();
     match args.len() {
         0 => {
-            println("usage: codegen [keycode|scancode].rs destdir");
+            println!("usage: codegen [keycode|scancode].rs destdir");
             os::set_exit_status(1);
         },
         3 => {


### PR DESCRIPTION
Hi. It bugged me having to change this every time I cloned a fresh copy, so I thought maybe you wanted to merge this  as well.
