### PR TITLE
Make check for empty SDL_MODE environment variable more robust

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -16,7 +16,7 @@ fn main() {
     let args = os::args();
     match args.len() {
         0 => {
-            println!("usage: codegen [keycode|scancode].rs destdir");
+            println("usage: codegen [keycode|scancode].rs destdir");
             os::set_exit_status(1);
         },
         3 => {


### PR DESCRIPTION
And here is the next one of my pull requests for my own convenience ;-)
I use homebrew to install SDL as dylibs and always need to set SDL_MODE to dylib manually. Since pkg-config returns zero, this should have to do with the check for SDL_MODE's emptiness (and a little testing seemed to confirm this). The fix was taken from the [GNU make manual page](https://www.gnu.org/software/make/manual/html_node/Text-Functions.html).
