### PR TITLE
A few fixes for compatibility with rust-master

### DIFF
--- a/src/codegen/branchify.rs
+++ b/src/codegen/branchify.rs
@@ -1,8 +1,8 @@
 #[macro_escape];
 
-use std::io::buffered::BufferedWriter;
+use std::io::BufferedWriter;
 use std::io::{File, Writer};
-use std::str::CharIterator;
+use std::str::Chars;
 
 struct ParseBranch {
     matches: ~[u8],
@@ -23,7 +23,7 @@ impl ParseBranch {
 pub fn branchify(options: &[(&str, &str)], case_sensitive: bool) -> ~[ParseBranch] {
     let mut root = ParseBranch::new();
 
-    fn go_down_moses(branch: &mut ParseBranch, mut chariter: CharIterator, result: &str, case_sensitive: bool) {
+    fn go_down_moses(branch: &mut ParseBranch, mut chariter: Chars, result: &str, case_sensitive: bool) {
         match chariter.next() {
             Some(c) => {
                 let first_case = if case_sensitive { c as u8 } else { c.to_ascii().to_upper().to_byte() };

--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -2,7 +2,7 @@
 #[crate_id = "codegen#0.1"];
 
 use std::os;
-use std::io::buffered::BufferedWriter;
+use std::io::BufferedWriter;
 use std::io::File;
 use std::io;
 use std::io::stdio::println;

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -685,8 +685,10 @@ fn wrap_event(raw: ll::SDL_Event) -> Event {
                     Ok(window) => window,
                 };
 
-                let text = str::from_utf8_owned(event.text.iter().take_while(|b| (**b) != 0i8).map(|b| b.to_u8().unwrap()).collect::<~[u8]>());
-
+                let text = match str::from_utf8_owned(event.text.iter().take_while(|b| (**b) != 0i8).map(|b| b.to_u8().unwrap()).collect::<~[u8]>()) {
+                    Some(t) => t,
+                    None => ~""
+                };
                 TextEditingEvent(event.timestamp as uint, window, text,
                                  event.start as int, event.length as int)
             }
@@ -701,8 +703,10 @@ fn wrap_event(raw: ll::SDL_Event) -> Event {
                     Ok(window) => window,
                 };
 
-                let text = str::from_utf8_owned(event.text.iter().take_while(|b| (**b) != 0i8).map(|b| b.to_u8().unwrap()).collect::<~[u8]>());
-
+                let text = match str::from_utf8_owned(event.text.iter().take_while(|b| (**b) != 0i8).map(|b| b.to_u8().unwrap()).collect::<~[u8]>()) {
+                    Some(t) => t,
+                    None => ~""
+                };
                 TextInputEvent(event.timestamp as uint, window, text)
             }
 


### PR DESCRIPTION
- std::str::CharIterator is now std::str::Chars
- std::io::buffered::BufferedWriter is now std::io::BufferedWriter
- std::from_utf8_owned returns Option<~str> now instead of simply ~str
