### PR TITLE
Address io::io_error removal

### DIFF
--- a/src/codegen/keycode.rs
+++ b/src/codegen/keycode.rs
@@ -330,7 +330,7 @@ impl ToPrimitive for KeyCode {
     for primitive_type in types.iter() {
         out.write(format!("fn to_{}(&self) -> Option<{}> \\{
             Some(self.code() as {})
-        \\}\n", *primitive_type, *primitive_type, *primitive_type).into_bytes())
+        \\}\n", *primitive_type, *primitive_type, *primitive_type).into_bytes());
     }
 
 out.write("

--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -42,7 +42,7 @@ fn main() {
 
 pub fn get_writer(output_dir: &Path, filename: &str) -> ~BufferedWriter<File> {
     match File::open_mode(&output_dir.join(filename), io::Truncate, io::Write) {
-        Some(writer) => ~BufferedWriter::new(writer),
-        None => fail!("Unable to write file"),
+        Ok(writer) => ~BufferedWriter::new(writer),
+        Err(e) => fail!("Unable to write file: {:s}", e.desc),
     }
 }

--- a/src/codegen/scancode.rs
+++ b/src/codegen/scancode.rs
@@ -339,7 +339,7 @@ impl ToPrimitive for ScanCode {
     for primitive_type in types.iter() {
         out.write(format!("fn to_{}(&self) -> Option<{}> \\{
             Some(self.code() as {})
-        \\}\n", *primitive_type, *primitive_type, *primitive_type).into_bytes())
+        \\}\n", *primitive_type, *primitive_type, *primitive_type).into_bytes());
     }
 
 out.write("


### PR DESCRIPTION
Rust PR: mozilla/rust#11946

Description of changes:
- `src/codegen/{keycode.rs,scancode.rs}`: `for..in` expects a result type of `()`; with the IO changes all the `Writer` methods now return `IoResult<()>`, so a trailing `;` is required.
- `src/codegen/main.rs`: `open_mode` returns an `IoResult<File>` (an alias for `Result<File, IoError>`), so `Some`/`None` need to be replaced with `Ok`/`Err`.

An unfortunate side effect of this change is that there are now a bunch of warnings during compilation because nothing is being done with the `IoResult`s:
`warning: unused result which must be used, #[warn(unused_must_use)] on by default`
I haven't done anything to address this because I'm not sure what the best course of action is.
