### PR TITLE
Fixes for compatibility with Rust master

### DIFF
--- a/src/codegen/keycode.rs
+++ b/src/codegen/keycode.rs
@@ -1,4 +1,4 @@
-extern mod extra;
+extern crate extra;
 use std::io::Writer;
 use super::get_writer;
 

--- a/src/codegen/scancode.rs
+++ b/src/codegen/scancode.rs
@@ -1,4 +1,4 @@
-extern mod extra;
+extern crate extra;
 use std::io::Writer;
 use super::get_writer;
 

--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -1,5 +1,5 @@
-extern mod sdl2;
-extern mod native;
+extern crate sdl2;
+extern crate native;
 
 mod video;
 

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -3,7 +3,6 @@ use std::libc::c_int;
 pub mod ll {
     use std::cast;
     use std::libc::{c_int, c_schar, c_uchar, c_uint, c_void, int16_t, uint8_t};
-    use std::ptr;
     use joystick::ll::{SDL_Joystick, SDL_JoystickGUID};
 
     pub type SDL_bool = c_int;
@@ -32,13 +31,13 @@ pub mod ll {
 
     impl SDL_GameControllerButtonBindData {
         pub fn button(&self) -> *c_int {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
         pub fn axis(&self) -> *c_int {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
         pub fn hat(&self) -> *SDL_GameControllerButtonBindDataHat {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
     }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -20,7 +20,6 @@ pub mod ll {
     use std::cast;
     use std::libc::{c_float, c_int, c_schar, c_uint, c_void, int16_t,
                     int32_t, uint8_t, uint16_t, uint32_t};
-    use std::ptr;
     use gesture::ll::SDL_GestureID;
     use keyboard::ll::SDL_Keysym;
     use touch::ll::SDL_FingerID;
@@ -307,99 +306,99 @@ pub mod ll {
 
     impl SDL_Event {
         pub fn _type(&self) -> *uint32_t {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn common(&self) -> *SDL_CommonEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn window(&self) -> *SDL_WindowEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn key(&self) -> *SDL_KeyboardEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn edit(&self) -> *SDL_TextEditingEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn text(&self) -> *SDL_TextInputEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn motion(&self) -> *SDL_MouseMotionEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn button(&self) -> *SDL_MouseButtonEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn wheel(&self) -> *SDL_MouseWheelEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn jaxis(&self) -> *SDL_JoyAxisEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn jball(&self) -> *SDL_JoyBallEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn jhat(&self) -> *SDL_JoyHatEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn jbutton(&self) -> *SDL_JoyButtonEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn jdevice(&self) -> *SDL_JoyDeviceEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn caxis(&self) -> *SDL_ControllerAxisEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn cbutton(&self) -> *SDL_ControllerButtonEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn cdevice(&self) -> *SDL_ControllerDeviceEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn quit(&self) -> *SDL_QuitEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn user(&self) -> *SDL_UserEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn syswm(&self) -> *SDL_SysWMEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn tfinger(&self) -> *SDL_TouchFingerEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn mgesture(&self) -> *SDL_MultiGestureEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn dgesture(&self) -> *SDL_DollarGestureEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
 
         pub fn drop(&self) -> *SDL_DropEvent {
-            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&self) }
         }
     }
 
@@ -572,7 +571,7 @@ fn wrap_event(raw: ll::SDL_Event) -> Event {
         let raw_type = if raw_type.is_null() { return NoEvent; }
                        else { *raw_type };
 
-        // FIXME: This should error-check 
+        // FIXME: This should error-check
         let event_type: EventType = FromPrimitive::from_uint(raw_type as uint).unwrap();
         match event_type {
             QuitEventType => {


### PR DESCRIPTION
Changes:
- `extern mod` is now `extern crate` (mozilla/rust#12017)
- `std::ptr::to_unsafe_ptr` has been removed (mozilla/rust#12282)
