### PR TITLE
`std::vec_ng` moved to `std::vec` in rust@master

### DIFF
--- a/src/codegen/branchify.rs
+++ b/src/codegen/branchify.rs
@@ -3,7 +3,7 @@
 use std::io::BufferedWriter;
 use std::io::{File, Writer};
 use std::str::Chars;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 struct ParseBranch {
     matches: Vec<u8>,

--- a/src/codegen/keycode.rs
+++ b/src/codegen/keycode.rs
@@ -1,6 +1,6 @@
 use std::io::{IoResult,Writer};
+use std::vec::Vec;
 use super::get_writer;
-use std::vec_ng::Vec;
 
 struct Key {
     code: uint,

--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::io::stdio::println;
 use std::io::fs::mkdir_recursive;
 use std::path::GenericPath;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 pub mod branchify;
 pub mod keycode;
 pub mod scancode;

--- a/src/codegen/scancode.rs
+++ b/src/codegen/scancode.rs
@@ -1,6 +1,6 @@
 use std::io::{IoResult,Writer};
+use std::vec::Vec;
 use super::get_writer;
-use std::vec_ng::Vec;
 
 struct ScanCode {
     code: uint,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -2,7 +2,7 @@ use std::cast;
 use std::libc::{c_int, c_void, uint32_t};
 use std::num::FromPrimitive;
 use std::str;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 use controller;
 use controller::{ControllerAxis, ControllerButton};

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -1,4 +1,4 @@
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 #[allow(non_camel_case_types)]
 pub mod ll {

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -2,8 +2,8 @@ use collections::hashmap::HashMap;
 use std::num::FromPrimitive;
 use std::ptr;
 use std::str;
-use std::vec;
-use std::vec_ng::Vec;
+use std::slice;
+use std::vec::Vec;
 
 use keycode::KeyCode;
 use rect::Rect;
@@ -102,7 +102,7 @@ pub fn get_keyboard_state() -> ~HashMap<ScanCode, bool> {
     let mut state: ~HashMap<ScanCode, bool> = ~HashMap::new();
     let count = 0;
 
-    let raw = unsafe { vec::raw::from_buf_raw(ll::SDL_GetKeyboardState(&count),
+    let raw = unsafe { slice::raw::from_buf_raw(ll::SDL_GetKeyboardState(&count),
                                               count as uint) };
 
     let mut current = 0;

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -1,5 +1,5 @@
 use std::ptr;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 use get_error;
 use surface;

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -9,7 +9,7 @@ use std::cast;
 use rect::Point;
 use rect::Rect;
 use std::num::FromPrimitive;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 #[allow(non_camel_case_types)]
 pub mod ll {

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,6 +1,6 @@
 use std::cast;
 use std::str;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 // Setup linking for all targets.
 #[cfg(target_os="macos")]

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -2,7 +2,7 @@ use std::libc::{c_int, c_float, uint32_t};
 use std::ptr;
 use std::str;
 use std::cast;
-use std::vec_ng::Vec;
+use std::vec::Vec;
 
 use rect::Rect;
 use surface::Surface;


### PR DESCRIPTION
### NOTE: Will not build on Travis Yet

You may wish to delay the merge of this PR until the rust nightly PPA is rebuilt. Not sure when that will be.

---

Turns out `rust-sdl2` was not happy with my "morningly" rebuild of rustc.
These are some very minor fixes to the imports so that we continue to build against rust@master
Relevant [commit](https://github.com/mozilla/rust/commit/4224147bab87a191cfc935e2e763889c11e63111) and [pull request](https://github.com/mozilla/rust/pull/13028) on the `mozilla/rust` repo.

Builds on my machine as of:  `rustc 0.10-pre (95ee0a0 2014-03-20 04:36:50 -0700)` ( mozilla/rust@95ee0a0 )
