### PR TITLE
Fix Makefile's attempt to infer value for SDL_MODE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UNAME=$(shell uname)
 
 ifeq ($(UNAME),Darwin)
   # If the user wasn't explicit, see if SDL2 library exists
-  ifeq ($(strip $(SDL_MODE)),"")
+  ifeq ("$(strip $(SDL_MODE))","")
     SDL_CHECK=$(shell pkg-config --exists sdl2)
     ifeq ($(SDL_CHECK),0)
       SDL_MODE = dylib


### PR DESCRIPTION
The `ifeq` check does not work without surrounding double-quotes if
SDL_MODE is unset.
