### PR TITLE
fix libc glob reexports change: use c_char instead of c_schar

### DIFF
--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -3,7 +3,7 @@ use libc::c_int;
 #[allow(non_camel_case_types)]
 pub mod ll {
     use std::cast;
-    use libc::{c_int, c_schar, c_uchar, c_uint, c_void, int16_t, uint8_t};
+    use libc::{c_int, c_char, c_uchar, c_uint, c_void, int16_t, uint8_t};
     use joystick::ll::{SDL_Joystick, SDL_JoystickGUID};
 
     pub type SDL_bool = c_int;
@@ -72,18 +72,18 @@ pub mod ll {
     pub static SDL_CONTROLLER_BUTTON_MAX: SDL_GameControllerButton = 15;
 
     extern "C" {
-        pub fn SDL_GameControllerAddMapping(mappingString: *c_schar) -> c_int;
+        pub fn SDL_GameControllerAddMapping(mappingString: *c_char) -> c_int;
         pub fn SDL_GameControllerMappingForGUID(guid: SDL_JoystickGUID) ->
-                  *c_schar;
+                  *c_char;
         pub fn SDL_GameControllerMapping(gamecontroller: *SDL_GameController)
-                  -> *c_schar;
+                  -> *c_char;
         pub fn SDL_IsGameController(joystick_index: c_int) -> SDL_bool;
         pub fn SDL_GameControllerNameForIndex(joystick_index: c_int) ->
-                  *c_schar;
+                  *c_char;
         pub fn SDL_GameControllerOpen(joystick_index: c_int) ->
                   *SDL_GameController;
         pub fn SDL_GameControllerName(gamecontroller: *SDL_GameController) ->
-                  *c_schar;
+                  *c_char;
         pub fn SDL_GameControllerGetAttached(gamecontroller:
                                                        *SDL_GameController) ->
                   SDL_bool;
@@ -92,11 +92,11 @@ pub mod ll {
                   *SDL_Joystick;
         pub fn SDL_GameControllerEventState(state: c_int) -> c_int;
         pub fn SDL_GameControllerUpdate();
-        pub fn SDL_GameControllerGetAxisFromString(pchString: *c_schar) ->
+        pub fn SDL_GameControllerGetAxisFromString(pchString: *c_char) ->
                   SDL_GameControllerAxis;
         pub fn SDL_GameControllerGetStringForAxis(axis:
                                                             SDL_GameControllerAxis)
-                  -> *c_schar;
+                  -> *c_char;
         pub fn SDL_GameControllerGetBindForAxis(gamecontroller:
                                                           *SDL_GameController,
                                                       axis: SDL_GameControllerAxis)
@@ -104,11 +104,11 @@ pub mod ll {
         pub fn SDL_GameControllerGetAxis(gamecontroller: *SDL_GameController,
                                                axis: SDL_GameControllerAxis) ->
                   int16_t;
-        pub fn SDL_GameControllerGetButtonFromString(pchString: *c_schar) ->
+        pub fn SDL_GameControllerGetButtonFromString(pchString: *c_char) ->
                   SDL_GameControllerButton;
         pub fn SDL_GameControllerGetStringForButton(button:
                                                           SDL_GameControllerButton)
-                  -> *c_schar;
+                  -> *c_char;
         pub fn SDL_GameControllerGetBindForButton(gamecontroller:
                                                             *SDL_GameController,
                                                         button:

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -20,7 +20,7 @@ use video;
 #[allow(non_camel_case_types)]
 pub mod ll {
     use std::cast;
-    use libc::{c_float, c_int, c_schar, c_uint, c_void, int16_t,
+    use libc::{c_float, c_int, c_char, c_uint, c_void, int16_t,
                int32_t, uint8_t, uint16_t, uint32_t};
     use gesture::ll::SDL_GestureID;
     use keyboard::ll::SDL_Keysym;
@@ -112,7 +112,7 @@ pub mod ll {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
         pub windowID: uint32_t,
-        pub text: [c_schar, ..32u],
+        pub text: [c_char, ..32u],
         pub start: int32_t,
         pub length: int32_t,
     }
@@ -121,7 +121,7 @@ pub mod ll {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
         pub windowID: uint32_t,
-        pub text: [c_schar, ..32u],
+        pub text: [c_char, ..32u],
     }
 
     pub struct SDL_MouseMotionEvent {
@@ -274,7 +274,7 @@ pub mod ll {
     pub struct SDL_DropEvent {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
-        pub file: *c_schar,
+        pub file: *c_char,
     }
 
     pub struct SDL_QuitEvent {

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -2,7 +2,7 @@ use std::vec::Vec;
 
 #[allow(non_camel_case_types)]
 pub mod ll {
-    use libc::{c_int, c_schar, c_void, int32_t, int16_t, int8_t, uint8_t};
+    use libc::{c_int, c_char, c_void, int32_t, int16_t, int8_t, uint8_t};
 
     pub type SDL_bool = c_int;
 
@@ -14,16 +14,16 @@ pub mod ll {
 
     extern "C" {
         pub fn SDL_NumJoysticks() -> c_int;
-        pub fn SDL_JoystickNameForIndex(device_index: c_int) -> *c_schar;
+        pub fn SDL_JoystickNameForIndex(device_index: c_int) -> *c_char;
         pub fn SDL_JoystickOpen(device_index: c_int) -> *SDL_Joystick;
-        pub fn SDL_JoystickName(joystick: *SDL_Joystick) -> *c_schar;
+        pub fn SDL_JoystickName(joystick: *SDL_Joystick) -> *c_char;
         pub fn SDL_JoystickGetDeviceGUID(device_index: c_int) ->
                   SDL_JoystickGUID;
         pub fn SDL_JoystickGetGUID(joystick: *SDL_Joystick) ->
                   SDL_JoystickGUID;
         pub fn SDL_JoystickGetGUIDString(guid: SDL_JoystickGUID,
-                                               pszGUID: *c_schar, cbGUID: c_int);
-        pub fn SDL_JoystickGetGUIDFromString(pchGUID: *c_schar) ->
+                                               pszGUID: *c_char, cbGUID: c_int);
+        pub fn SDL_JoystickGetGUIDFromString(pchGUID: *c_char) ->
                   SDL_JoystickGUID;
         pub fn SDL_JoystickGetAttached(joystick: *SDL_Joystick) -> SDL_bool;
         pub fn SDL_JoystickInstanceID(joystick: *SDL_Joystick) -> int32_t;

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -12,7 +12,7 @@ use video::Window;
 
 #[allow(non_camel_case_types)]
 pub mod ll {
-    use libc::{c_int, c_schar, c_uint, int32_t, uint8_t, uint16_t,
+    use libc::{c_int, c_char, c_uint, int32_t, uint8_t, uint16_t,
                     uint32_t};
     use rect::Rect;
     use video::ll::SDL_Window;
@@ -38,10 +38,10 @@ pub mod ll {
         pub fn SDL_SetModState(modstate: SDL_Keymod);
         pub fn SDL_GetKeyFromScancode(scancode: SDL_Scancode) -> SDL_Keycode;
         pub fn SDL_GetScancodeFromKey(key: SDL_Keycode) -> SDL_Scancode;
-        pub fn SDL_GetScancodeName(scancode: SDL_Scancode) -> *c_schar;
-        pub fn SDL_GetScancodeFromName(name: *c_schar) -> SDL_Scancode;
-        pub fn SDL_GetKeyName(key: SDL_Keycode) -> *c_schar;
-        pub fn SDL_GetKeyFromName(name: *c_schar) -> SDL_Keycode;
+        pub fn SDL_GetScancodeName(scancode: SDL_Scancode) -> *c_char;
+        pub fn SDL_GetScancodeFromName(name: *c_char) -> SDL_Scancode;
+        pub fn SDL_GetKeyName(key: SDL_Keycode) -> *c_char;
+        pub fn SDL_GetKeyFromName(name: *c_char) -> SDL_Keycode;
         pub fn SDL_StartTextInput();
         pub fn SDL_IsTextInputActive() -> SDL_bool;
         pub fn SDL_StopTextInput();

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -5,7 +5,7 @@ use libc::{c_void, c_int, size_t};
 
 #[allow(non_camel_case_types)]
 pub mod ll {
-    use libc::{c_uchar, uint32_t, c_schar, FILE, c_void};
+    use libc::{c_uchar, uint32_t, c_char, FILE, c_void};
     use libc::{c_int, int64_t, size_t};
 
     struct SDL_RWops_Anon {
@@ -31,7 +31,7 @@ pub mod ll {
     }
 
     extern "C" {
-        pub fn SDL_RWFromFile(file: *c_schar, mode: *c_schar) -> *SDL_RWops;
+        pub fn SDL_RWFromFile(file: *c_char, mode: *c_char) -> *SDL_RWops;
         pub fn SDL_RWFromFP(fp: *FILE, autoclose: SDL_bool) -> *SDL_RWops;
         pub fn SDL_RWFromMem(mem: *c_void, size: c_int) -> *SDL_RWops;
         pub fn SDL_RWFromConstMem(mem: *c_void, size: c_int) -> *SDL_RWops;

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -24,7 +24,7 @@ mod others {
 
 #[allow(non_camel_case_types)]
 pub mod ll {
-    use libc::{c_int, c_uint, c_schar, uint32_t};
+    use libc::{c_int, c_uint, c_char, uint32_t};
 
     pub type SDL_errorcode = c_uint;
     pub static SDL_ENOMEM: SDL_errorcode = 0;
@@ -49,8 +49,8 @@ pub mod ll {
     extern "C" {
         pub fn SDL_ClearError();
         pub fn SDL_Error(code: SDL_errorcode) -> c_int;
-        pub fn SDL_SetError(fmt: *c_schar) -> c_int;
-        pub fn SDL_GetError() -> *c_schar;
+        pub fn SDL_SetError(fmt: *c_char) -> c_int;
+        pub fn SDL_GetError() -> *c_char;
 
         //SDL.h
         pub fn SDL_Init(flags: uint32_t) -> c_int;


### PR DESCRIPTION
mozilla/rust/bfaf171c6df removes all the glob reexports from liblibc, making `c_schar` missing from libc top level. (now only in `libc::types::os::arch::c95::c_schar`)

https://github.com/mozilla/rust/commit/bfaf171c6dff38faecf4de29abcedc6a128c4cec

switch to `c_char` is ok, because they are the same type. :)
