### PR TITLE
Replace ~"string" with "string.to_owned()", except in fail!, where it wa...

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -28,12 +28,12 @@ fn main() {
                 Ok(_) => {},
             };
 
-            if *args.get(1) == ~"keycode.rs" {
+            if *args.get(1) == "keycode.rs".to_owned() {
                 match keycode::generate(&output_dir) {
                     Ok(_) => {},
                     Err(e) => fail!("Could not automatically generate sources for keycodes: {:s}", e.desc),
                 };
-            } else if *args.get(1) == ~"scancode.rs" {
+            } else if *args.get(1) == "scancode.rs".to_owned() {
                 match scancode::generate(&output_dir) {
                     Ok(_)    => {},
                     Err(e) => fail!("Could not automatically generate sources for scancodes: {:s}", e.desc),

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -347,7 +347,7 @@ impl AudioCVT {
 
         unsafe {
             if (*self.raw).needed != 1 {
-                return Err(~"no convertion needed!")
+                return Err("no convertion needed!".to_owned())
             }
             // set len
             (*self.raw).len = src.len() as c_int;

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -141,7 +141,7 @@ pub fn wrap_controller_axis(bitflags: u8) -> ControllerAxis {
         ll::SDL_CONTROLLER_AXIS_RIGHTY       => RightYAxis,
         ll::SDL_CONTROLLER_AXIS_TRIGGERLEFT  => TriggerLeftAxis,
         ll::SDL_CONTROLLER_AXIS_TRIGGERRIGHT => TriggerRightAxis,
-        _ => fail!(~"unhandled controller axis")
+        _ => fail!("unhandled controller axis")
     }
 }
 
@@ -182,6 +182,6 @@ pub fn wrap_controller_button(bitflags: u8) -> ControllerButton {
         ll::SDL_CONTROLLER_BUTTON_DPAD_DOWN     => DPadDownButton,
         ll::SDL_CONTROLLER_BUTTON_DPAD_LEFT     => DPadLeftButton,
         ll::SDL_CONTROLLER_BUTTON_DPAD_RIGHT    => DPadRightButton,
-        _ => fail!(~"unhandled controller button")
+        _ => fail!("unhandled controller button")
     }
 }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -738,7 +738,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                let text = str::from_utf8_owned(event.text.iter().take_while(|&b| (*b) != 0i8).map(|&b| b as u8).collect::<~[u8]>()).unwrap_or(~"");
+                let text = str::from_utf8_owned(event.text.iter().take_while(|&b| (*b) != 0i8).map(|&b| b as u8).collect::<~[u8]>()).unwrap_or("".to_owned());
                 TextEditingEvent(event.timestamp as uint, window, text,
                                  event.start as int, event.length as int)
             }
@@ -751,7 +751,7 @@ impl Event {
                     Ok(window) => window,
                 };
 
-                let text = str::from_utf8_owned(event.text.iter().take_while(|&b| (*b) != 0i8).map(|&b| b as u8).collect::<~[u8]>()).unwrap_or(~"");
+                let text = str::from_utf8_owned(event.text.iter().take_while(|&b| (*b) != 0i8).map(|&b| b as u8).collect::<~[u8]>()).unwrap_or("".to_owned());
                 TextInputEvent(event.timestamp as uint, window, text)
             }
 
@@ -1094,7 +1094,7 @@ pub fn push_event(event: Event) -> Result<(), ~str> {
             else { Err(get_error()) }
         },
         None => {
-            Err(~"Unsupport event type to push back to queue.")
+            Err("Unsupport event type to push back to queue.".to_owned())
         }
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -719,7 +719,7 @@ impl Texture {
         if result {
             Ok((texw as f64, texh as f64))
         } else {
-            Err(~"Operation not supported")
+            Err("Operation not supported".to_owned())
         }
     }
 
@@ -731,7 +731,7 @@ impl Texture {
         unsafe {
             let texw: c_float = 0.0;
             let texh: c_float = 0.0;
-            if ll::SDL_GL_BindTexture(self.raw, &texw, &texh) != 0 { fail!(~"could not bind texture"); }
+            if ll::SDL_GL_BindTexture(self.raw, &texw, &texh) != 0 { fail!("could not bind texture"); }
             let rv = f(texw as f64, texh as f64);
             ll::SDL_GL_UnbindTexture(self.raw);
             rv

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -148,7 +148,7 @@ impl Surface {
     /// Locks a surface so that the pixels can be directly accessed safely.
     pub fn with_lock<R>(&self, f: |pixels: &mut [u8]| -> R) -> R {
         unsafe {
-            if ll::SDL_LockSurface(self.raw) != 0 { fail!(~"could not lock surface"); }
+            if ll::SDL_LockSurface(self.raw) != 0 { fail!("could not lock surface"); }
             let len = (*self.raw).pitch as uint * ((*self.raw).h as uint);
             let pixels: &mut [u8] = cast::transmute(((*self.raw).pixels, len));
             let rv = f(pixels);


### PR DESCRIPTION
Replace ~"string" with "string.to_owned()", except in fail!, where it was changed to "string"
