### PR TITLE
Provide string conversions for various enums

### DIFF
--- a/src/codegen/keycode.rs
+++ b/src/codegen/keycode.rs
@@ -309,7 +309,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(Eq, TotalEq)]
+#[deriving(Eq, TotalEq, Show)]
 pub enum KeyCode {
 ".as_bytes()));
     for &entry in entries.iter() {

--- a/src/codegen/scancode.rs
+++ b/src/codegen/scancode.rs
@@ -315,7 +315,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(Eq, TotalEq)]
+#[deriving(Eq, TotalEq, Show)]
 pub enum ScanCode {
 ".as_bytes()));
     for &entry in entries.iter() {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -500,6 +500,7 @@ pub enum EventType {
     LastEventType = ll::SDL_LASTEVENT,
 }
 
+#[deriving(Show)]
 /// An enum of window events.
 pub enum WindowEventId {
     NoneWindowEventId,
@@ -617,6 +618,52 @@ pub enum Event {
 
     /// (timestamp, Window, type, code)
     UserEvent(uint, ~video::Window, uint, int),
+}
+
+impl ::std::fmt::Show for Event {
+    fn fmt(&self, out: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        out.buf.write_str(match *self {
+            NoEvent => "NoEvent",
+            QuitEvent(..) => "QuitEvent",
+            AppTerminatingEvent(..) => "AppTerminatingEvent",
+            AppLowMemoryEvent(..) => "AppLowMemoryEvent",
+            AppWillEnterBackgroundEvent(..) => "AppWillEnterBackgroundEvent",
+            AppDidEnterBackgroundEvent(..) => "AppDidEnterBackgroundEvent",
+            AppWillEnterForegroundEvent(..) => "AppWillEnterForegroundEvent",
+            AppDidEnterForegroundEvent(..) => "AppDidEnterForegroundEvent",
+            WindowEvent(..) => "WindowEvent",
+            KeyDownEvent(..) => "KeyDownEvent",
+            KeyUpEvent(..) => "KeyUpEvent",
+            TextEditingEvent(..) => "TextEditingEvent",
+            TextInputEvent(..) => "TextInputEvent",
+            MouseMotionEvent(..) => "MouseMotionEvent",
+            MouseButtonDownEvent(..) => "MouseButtonDownEvent",
+            MouseButtonUpEvent(..) => "MouseButtonUpEvent",
+            MouseWheelEvent(..) => "MouseWheelEvent",
+            JoyAxisMotionEvent(..) => "JoyAxisMotionEvent",
+            JoyBallMotionEvent(..) => "JoyBallMotionEvent",
+            JoyHatMotionEvent(..) => "JoyHatMotionEvent",
+            JoyButtonDownEvent(..) => "JoyButtonDownEvent",
+            JoyButtonUpEvent(..) => "JoyButtonUpEvent",
+            JoyDeviceAddedEvent(..) => "JoyDeviceAddedEvent",
+            JoyDeviceRemovedEvent(..) => "JoyDeviceRemovedEvent",
+            ControllerAxisMotionEvent(..) => "ControllerAxisMotionEvent",
+            ControllerButtonDownEvent(..) => "ControllerButtonDownEvent",
+            ControllerButtonUpEvent(..) => "ControllerButtonUpEvent",
+            ControllerDeviceAddedEvent(..) => "ControllerDeviceAddedEvent",
+            ControllerDeviceRemovedEvent(..) => "ControllerDeviceRemovedEvent",
+            ControllerDeviceRemappedEvent(..) => "ControllerDeviceRemappedEvent",
+            FingerDownEvent(..) => "FingerDownEvent",
+            FingerUpEvent(..) => "FingerUpEvent",
+            FingerMotionEvent(..) => "FingerMotionEvent",
+            DollarGestureEvent(..) => "DollarGestureEvent",
+            DollarRecordEvent(..) => "DollarRecordEvent",
+            MultiGestureEvent(..) => "MultiGestureEvent",
+            ClipboardUpdateEvent(..) => "ClipboardUpdateEvent",
+            DropFileEvent(..) => "DropFileEvent",
+            UserEvent(..) => "UserEvent",
+        })
+    }
 }
 
 // TODO: Remove this when from_utf8 is updated in Rust

--- a/src/sdl2/generated/keycode.rs
+++ b/src/sdl2/generated/keycode.rs
@@ -6,7 +6,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(Eq, TotalEq)]
+#[deriving(Eq, TotalEq, Show)]
 pub enum KeyCode {
     UnknownKey            = 0,
     BackspaceKey          = 8,

--- a/src/sdl2/generated/scancode.rs
+++ b/src/sdl2/generated/scancode.rs
@@ -6,7 +6,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(Eq, TotalEq)]
+#[deriving(Eq, TotalEq, Show)]
 pub enum ScanCode {
     UnknownScanCode            = 0,
     AScanCode                  = 4,


### PR DESCRIPTION
This lets WindowEventId, KeyCode, and ScanCode use the derived Show trait.
The extra data provided for KeyCode and ScanCode is trivial to obtain,
given that ToPrimitive is implemented for both, while WindowEventId has no
specific data, thus any custom implementation is unwarranted.

Event cannot use the derived Show trait without many of the sub types
providing an implementation as well. Provided is now a simple relation of
Event type to its identifier as a string.
