### PR TITLE
Use Rust nightly builds for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 before_install:
-  - yes | sudo add-apt-repository ppa:hansjorg/rust
-  - sudo apt-get update
+  - wget http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+  - tar xf rust-nightly-x86_64-unknown-linux-gnu.tar.gz
 install:
-  - sudo apt-get install rust-nightly
+  - sudo ./rust-nightly-x86_64-unknown-linux-gnu/install.sh
   - wget http://www.libsdl.org/release/SDL2-2.0.0.tar.gz
   - tar -zxvf SDL2-2.0.0.tar.gz
   - cd SDL2-2.0.0


### PR DESCRIPTION
Given the uncertain state of rust-ci, I think it would be best to switch to the official rust-nightly builds for now. This PR will fix all of the Travis failures stemming from outdated versions of Rust.
