### PR TITLE
version.rs: remove use of mem::init; add doc

### DIFF
--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -33,7 +33,7 @@ pub struct Version {
 }
 
 impl Version {
-    /// Converts a raw *SDL_version to Version
+    /// Convert a raw *SDL_version to Version.
     pub fn from_ll(sv: *ll::SDL_version) -> Version {
         unsafe {
             let v = *sv;


### PR DESCRIPTION
- Remove use of `mem::init()`, which is deprecated.
- Add rustdoc-style comment to version.rs
