### PR TITLE
Update to rustc version b981add

### DIFF
--- a/src/codegen/keycode.rs
+++ b/src/codegen/keycode.rs
@@ -27,7 +27,7 @@ impl PartialEq for Key {
     }
 }
 
-impl TotalOrd for Key {
+impl Ord for Key {
     fn cmp(&self, other: &Key) -> Ordering {
         if self.code < other.code {
             Less
@@ -36,7 +36,7 @@ impl TotalOrd for Key {
         } else { Equal }
     }
 }
-impl TotalEq for Key {
+impl Eq for Key {
 }
 
 #[allow(non_snake_case_functions)]
@@ -310,7 +310,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(PartialEq, TotalEq, Show)]
+#[deriving(PartialEq, Eq, Show)]
 pub enum KeyCode {
 ".as_bytes()));
     for &entry in entries.iter() {

--- a/src/codegen/scancode.rs
+++ b/src/codegen/scancode.rs
@@ -27,7 +27,7 @@ impl PartialEq for ScanCode {
     }
 }
 
-impl TotalOrd for ScanCode {
+impl Ord for ScanCode {
     fn cmp(&self, other: &ScanCode) -> Ordering {
         if self.code < other.code {
             Less
@@ -36,7 +36,7 @@ impl TotalOrd for ScanCode {
         } else { Equal }
     }
 }
-impl TotalEq for ScanCode {
+impl Eq for ScanCode {
 }
 
 #[allow(non_snake_case_functions)]
@@ -317,7 +317,7 @@ use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
 
-#[deriving(PartialEq, TotalEq, Show)]
+#[deriving(PartialEq, Eq, Show)]
 pub enum ScanCode {
 ".as_bytes()));
     for &entry in entries.iter() {


### PR DESCRIPTION
Rename `TotalOrd` and `TotalEq` to `Ord` and `Eq`, following the recent changes in standard library. This version compiles in my copy of `rustc 0.11.0-pre (b981add)`.
