### PR TITLE
Convert old-style collections import to new std::collections

### DIFF
--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -1,4 +1,4 @@
-use collections::hashmap::HashMap;
+use std::collections::HashMap;
 use std::num::FromPrimitive;
 use std::ptr;
 use std::str;


### PR DESCRIPTION
Couldn't build against the latest version of rust:master as they moved collections to a new namespace. Just fixed it real quick. 
