### PR TITLE
Added 'doc/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/sdl2/generated/
 *.swp
 .project
 src/demo/main
+doc/


### PR DESCRIPTION
When using rust-sdl2 git submodule it gets marked dirty when generating
docs in piston-workspace. This prevents new commits.

Ignoring the ‘doc/‘ folder fixes this problem.
