### PR TITLE
Upgraded to latest Rust-Empty

### DIFF
--- a/rust-empty.mk
+++ b/rust-empty.mk
@@ -72,16 +72,16 @@ TARGET = $(shell rustc --version 2> /dev/null | awk "/host:/ { print \$$2 }")
 # TARGET = x86_64-unknown-linux-gnu
 # TARGET = x86_64-apple-darwin
 
-TARGET_LIB_DIR = target/$(TARGET)/lib/
+TARGET_LIB_DIR = target/deps/
 
 # Ask 'rustc' the file name of the library and use a dummy name if the source has not been created yet.
 # The dummy file name is used to trigger the creation of the source first time.
 # Next time 'rustc' will return the right file name.
 RLIB_FILE = $(shell (rustc --crate-type=rlib --crate-file-name "$(LIB_ENTRY_FILE)" 2> /dev/null) || (echo "dummy.rlib"))
 # You can't have quotes around paths because 'make' doesn't see it exists.
-RLIB = target/$(TARGET)/lib/$(RLIB_FILE)
+RLIB = target/$(RLIB_FILE)
 DYLIB_FILE = $(shell (rustc --crate-type=dylib --crate-file-name "$(LIB_ENTRY_FILE)" 2> /dev/null) || (echo "dummy.dylib"))
-DYLIB = target/$(TARGET)/lib/$(DYLIB_FILE)
+DYLIB = target/$(DYLIB_FILE)
 
 # Use 'VERBOSE=1' to echo all commands, for example 'make help VERBOSE=1'.
 ifdef VERBOSE
@@ -93,7 +93,7 @@ endif
 all: $(DEFAULT)
 
 help:
-	$(Q)echo "--- rust-empty (0.5 006)"
+	$(Q)echo "--- rust-empty (0.5 008)"
 	$(Q)echo "make run               - Runs executable"
 	$(Q)echo "make exe               - Builds main executable"
 	$(Q)echo "make lib               - Both static and dynamic library"
@@ -122,7 +122,7 @@ help:
 	$(Q)echo "make clean             - Deletes binaries and documentation."
 	$(Q)echo "make clear-project     - WARNING: Deletes project files except 'Makefile'"
 	$(Q)echo "make clear-git         - WARNING: Deletes Git setup"
-	$(Q)echo "make symlink-build     - Creates a script for building dependencies
+	$(Q)echo "make symlink-build     - Creates a script for building dependencies"
 	$(Q)echo "make symlink-info      - Symlinked libraries dependency info"
 	$(Q)echo "make target-dir        - Creates directory for current target"
 
@@ -211,7 +211,7 @@ cargo-exe: $(EXE_ENTRY_FILE)
 	( \
 		name=$${PWD##/*/} ; \
 		readme=$$((test -e README.md && echo -e "readme = \"README.md\"") || ("")) ; \
-		echo -e "[package]\n\nname = \"$$name\"\nversion = \"0.0\"\n$$readme\nauthors = [\"Your Name <your@email.com>\"]\ntags = []\n\n[[bin]]\n\nname = \"$$name\"\npath = \"$(EXE_ENTRY_FILE)\"\n" > Cargo.toml \
+		echo -e "[package]\n\nname = \"$$name\"\nversion = \"0.0.0\"\n$$readme\nauthors = [\"Your Name <your@email.com>\"]\ntags = []\n\n[[bin]]\n\nname = \"$$name\"\npath = \"$(EXE_ENTRY_FILE)\"\n" > Cargo.toml \
 		&& echo "--- Created 'Cargo.toml' for executable" \
 		&& cat Cargo.toml \
 	)
@@ -225,7 +225,7 @@ cargo-lib: $(EXE_ENTRY_FILE)
 	( \
 		name=$${PWD##/*/} ; \
 		readme=$$((test -e README.md && echo -e "readme = \"README.md\"") || ("")) ; \
-		echo -e "[package]\n\nname = \"$$name\"\nversion = \"0.0\"\n$$readme\nauthors = [\"Your Name <your@email.com>\"]\ntags = []\n\n[[lib]]\n\nname = \"$$name\"\npath = \"$(LIB_ENTRY_FILE)\"\n" > Cargo.toml \
+		echo -e "[package]\n\nname = \"$$name\"\nversion = \"0.0.0\"\n$$readme\nauthors = [\"Your Name <your@email.com>\"]\ntags = []\n\n[[lib]]\n\nname = \"$$name\"\npath = \"$(LIB_ENTRY_FILE)\"\n" > Cargo.toml \
 		&& echo "--- Created 'Cargo.toml' for executable" \
 		&& cat Cargo.toml \
 	)
@@ -255,7 +255,7 @@ rust-ci-exe: $(EXE_ENTRY_FILE)
 	)
 
 doc: $(SOURCE_FILES) | src/
-	$(Q)$(RUSTDOC) $(LIB_ENTRY_FILE) -L "target/$(TARGET)/lib" \
+	$(Q)$(RUSTDOC) $(LIB_ENTRY_FILE) -L "$(TARGET_LIB_DIR)" \
 	&& echo "--- Built documentation"
 
 run: exe
@@ -267,7 +267,7 @@ target-dir: $(TARGET_LIB_DIR)
 exe: bin/main | $(TARGET_LIB_DIR)
 
 bin/main: $(SOURCE_FILES) | bin/ $(EXE_ENTRY_FILE)
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) $(EXE_ENTRY_FILE) -o bin/main -L "target/$(TARGET)/lib" \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) $(EXE_ENTRY_FILE) -o bin/main -L "$(TARGET_LIB_DIR)" -L "target" \
 	&& echo "--- Built executable" \
 	&& echo "--- Type 'make run' to run executable"
 
@@ -280,7 +280,7 @@ test-external: bin/test-external
 	&& ./test-external
 
 bin/test-external: $(SOURCE_FILES) | rlib bin/ src/test.rs
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --test src/test.rs -o bin/test-external -L "target/$(TARGET)/lib" \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --test src/test.rs -o bin/test-external -L "$(TARGET_LIB_DIR)" -L "target" \
 	&& echo "--- Built external test runner"
 
 test-internal: bin/test-internal
@@ -288,7 +288,7 @@ test-internal: bin/test-internal
 	&& ./test-internal
 
 bin/test-internal: $(SOURCE_FILES) | rlib src/ bin/
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --test $(LIB_ENTRY_FILE) -o bin/test-internal -L "target/$(TARGET)/lib" \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --test $(LIB_ENTRY_FILE) -o bin/test-internal -L "$(TARGET_LIB_DIR)" -L "target" \
 	&& echo "--- Built internal test runner"
 
 bench: bench-internal bench-external
@@ -305,13 +305,13 @@ lib: rlib dylib
 rlib: $(RLIB)
 
 $(RLIB): $(SOURCE_FILES) | $(LIB_ENTRY_FILE) $(TARGET_LIB_DIR)
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --crate-type=rlib $(LIB_ENTRY_FILE) -L "target/$(TARGET)/lib" --out-dir "target/$(TARGET)/lib/" \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --crate-type=rlib $(LIB_ENTRY_FILE) -L "$(TARGET_LIB_DIR)" --out-dir "target" \
 	&& echo "--- Built rlib"
 
 dylib: $(DYLIB)
 
 $(DYLIB): $(SOURCE_FILES) | $(LIB_ENTRY_FILE) $(TARGET_LIB_DIR)
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --crate-type=dylib $(LIB_ENTRY_FILE) -L "target/$(TARGET)/lib" --out-dir "target/$(TARGET)/lib/" \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) --crate-type=dylib $(LIB_ENTRY_FILE) -L "$(TARGET_LIB_DIR)" --out-dir "target/" \
 	&& echo "--- Built dylib"
 
 bin/:
@@ -350,7 +350,7 @@ git-ignore:
 examples: $(EXAMPLE_FILES)
 
 $(EXAMPLE_FILES): lib examples-dir
-	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) $@ -L "target/$(TARGET)/lib" --out-dir examples/ \
+	$(Q)$(COMPILER) --target "$(TARGET)" $(COMPILER_FLAGS) $@ -L "$(TARGET_LIB_DIR)" -L "target" --out-dir examples/ \
 	&& echo "--- Built '$@' (make $@)"
 
 $(EXE_ENTRY_FILE): | src/
@@ -416,7 +416,7 @@ while true; do
   echo -n "> "
   read line
   TMP="`mktemp r.XXXXXX`"
-  $(COMPILER) - -o $$TMP -L "target/$(TARGET)/lib/" <<EOF
+  $(COMPILER) - -o $$TMP -L "$(TARGET_LIB_DIR)" <<EOF
   #![feature(globs, macro_rules, phase, struct_variant)]
   extern crate arena;
   extern crate collections;
@@ -585,7 +585,7 @@ function contains() {
 i=0
 function build_deps {
     local current=$$(pwd)
-    for symlib in $$(find target/*/lib -type l) ; do
+    for symlib in $$(find $(TARGET_LIB_DIR) -type l) ; do
         cd $$current
         echo $$symlib
         local original_file=$$(readlink $$symlib)
@@ -675,7 +675,7 @@ loc:
 # prints the commit hash with remote branches containing that commit.
 symlink-info:
 	$(Q)	current=$$(pwd) ; \
-	for symlib in $$(find target/*/lib -type l) ; do \
+	for symlib in $$(find $(TARGET_LIB_DIR) -type l) ; do \
 		cd $$current ; \
 		echo $$symlib ; \
 		original_file=$$(readlink $$symlib) ; \


### PR DESCRIPTION
This version supports same structure as Cargo.

To compile, type `make gen-lib && make -f rust-empty.mk`
