### PR TITLE
Timer needed unsafe_destructor annotation

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -70,6 +70,7 @@ impl<'a> Timer<'a> {
     }
 }
 
+#[unsafe_destructor]
 impl<'a> Drop for Timer<'a> {
     fn drop(&mut self) {
         if self.remove_on_drop {


### PR DESCRIPTION
rust-sdl2 did not compile with current version of rust because the destructor of Timer needed this #[unsafe_destructor] annotation, but that should be alright because it is unsafe anyways.
