### PR TITLE
Changed target_os from "win32" to "windows"

### DIFF
--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -12,7 +12,7 @@ mod mac {
     extern {}
 }
 
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 #[cfg(target_os="linux")]
 #[cfg(target_os="freebsd")]
 mod others {


### PR DESCRIPTION
As of rust pull request 16435 (https://github.com/rust-lang/rust/pull/16435), cfg attributes now use "windows" instead of "win32" for the target_os parameter.

This caused linking against rust-sdl2 on Windows to fail since the #[link(name="SDL2")] attribute was ignored due to the mismatching cfg above it.
