### PR TITLE
Fixed "Private type in exported signature" issue.

### DIFF
--- a/src/codegen/branchify.rs
+++ b/src/codegen/branchify.rs
@@ -5,7 +5,7 @@ use std::io::{File, Writer};
 use std::str::Chars;
 use std::vec::Vec;
 
-struct ParseBranch {
+pub struct ParseBranch {
     matches: Vec<u8>,
     result: Option<String>,
     children: Vec<ParseBranch>,


### PR DESCRIPTION
Building on recent builds of the compiler throws:

```
branchify.rs:25:73: 25:84 error: private type in exported type signature
branchify.rs:25 pub fn branchify(options: &[(&str, &str)], case_sensitive: bool) -> Vec<ParseBranch> {
                                                                                        ^~~~~~~~~~~
branchify.rs:87:21: 87:32 error: private type in exported type signature
branchify.rs:87         branches: &[ParseBranch],
                                    ^~~~~~~~~~~
```

since you can't have private symbols in your public interface any more. This PR makes ParseBranch public in `branchify.rs` to fix this problem. Encapsulation is not lost since the fields are still private.
