### PR TITLE
SDL_LockTexture returns the pitch of the locked texture, so rust-sdl2 should so

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -355,7 +355,6 @@ impl AudioCVT {
     pub fn convert(&self, src: CVec<u8>) -> SdlResult<CVec<u8>> {
         //! Convert audio data to a desired audio format.
 
-        use std::slice::Slice;
         unsafe {
             if (*self.raw).needed != 1 {
                 return Err("no convertion needed!".into_string())

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -4,7 +4,7 @@
 #![desc = "SDL2 bindings"]
 #![license = "MIT"]
 
-#![feature(default_type_params, globs, macro_rules, unsafe_destructor)]
+#![feature(default_type_params, globs, macro_rules, slicing_syntax, unsafe_destructor)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
In my application I need the pitch of the texture after I locked it, so this (or some similar) modification is required to be compatible with the original SDL 2 API. 

The second commit contains a little bit cleaner implementation, because it does not expose the ugly tuple type, and, what is more important, it makes impossible to forget unlocking the locked texture.
