### PR TITLE
Keep slicing syntax compiling after nightly update

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -355,7 +355,6 @@ impl AudioCVT {
     pub fn convert(&self, src: CVec<u8>) -> SdlResult<CVec<u8>> {
         //! Convert audio data to a desired audio format.
 
-        use std::slice::Slice;
         unsafe {
             if (*self.raw).needed != 1 {
                 return Err("no convertion needed!".into_string())

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -4,7 +4,7 @@
 #![desc = "SDL2 bindings"]
 #![license = "MIT"]
 
-#![feature(default_type_params, globs, macro_rules, unsafe_destructor)]
+#![feature(default_type_params, globs, macro_rules, slicing_syntax, unsafe_destructor)]
 
 extern crate libc;
 extern crate collections;


### PR DESCRIPTION
Some very minor fixes were necessary after updating to the latest rustc nightly.
- Enables the feature-gate for slicing
- Removes `use std::slice::Slice` since it is included in the prelude.

`cargo build && cargo test` work on `rustc 0.12.0-dev (683e40f35 2014-10-07 14:32:09 +0000)`
