### PR TITLE
Added `#[repr(C)]`

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -876,7 +876,7 @@ impl Event {
                                    event.x as int, event.y as int)
             }
             MouseWheelEventType => {
-                let event = *raw.button();
+                let event = *raw.wheel();
 
                 let window = video::Window::from_id(event.windowID);
                 let window = match window {


### PR DESCRIPTION
According to the [FFI guide](http://doc.rust-lang.org/guide-ffi.html#interoperability-with-foreign-code), structs are only guaranteed to be
compatible when annotated with `#[repr(C)]`.

Closes https://github.com/PistonDevelopers/sdl2_game_window/issues/71
