### PR TITLE
get_ticks returns u32 instead of uint

### DIFF
--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -133,6 +133,6 @@ pub fn clear_error() {
     unsafe { ll::SDL_ClearError(); }
 }
 
-pub fn get_ticks() -> uint {
-    unsafe { ll::SDL_GetTicks() as uint }
+pub fn get_ticks() -> u32 {
+    unsafe { ll::SDL_GetTicks() as u32 }
 }


### PR DESCRIPTION
https://wiki.libsdl.org/SDL_GetTicks
Uint32 SDL_GetTicks(void)

According to the SDL documentation, this function should return u32 instead of simple uint. (The guys at Rust also [debate](https://github.com/rust-lang/rust/issues/9940) about the correct way of using int and uint types)
