### PR TITLE
Remove `Collections` implementation and move `fn len` into `impl RWops`.

### DIFF
--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -73,7 +73,7 @@ impl RWops {
         else { Ok(RWops{raw: raw, close_on_drop: false}) }
     }
 
-    fn len(&self) -> uint {
+    pub fn len(&self) -> uint {
         unsafe {
             ((*self.raw).size)(self.raw) as uint
         }


### PR DESCRIPTION
The `Collection` trait has been removed in accordance with the [std::collections reform](https://github.com/rust-lang/rust/issues/18424) and as far as I can see, there are no traits specifically offering a `fn len` anymore (for example, Vec now [implements it uniquely](http://doc.rust-lang.org/collections/vec/struct.Vec.html#method.len) as well).
