### PR TITLE
Derive or ignore Copy for types that can implement it

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -45,6 +45,7 @@ pub mod ll {
         ::std::option::Option<extern "C" fn
                                   (arg1: *const c_void, arg2: *const uint8_t,
                                    arg3: c_int)>;
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_AudioSpec {
         pub freq: c_int,
@@ -61,7 +62,7 @@ pub mod ll {
         ::std::option::Option<extern "C" fn
                                   (arg1: *const SDL_AudioCVT,
                                    arg2: SDL_AudioFormat)>;
-    #[allow(dead_code)]
+    #[allow(dead_code, missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_AudioCVT {
         pub needed: c_int,
@@ -146,7 +147,7 @@ pub const AUDIOS32SYS : AudioFormat = ll::AUDIO_S32SYS;
 pub const AUDIOF32SYS : AudioFormat = ll::AUDIO_F32SYS;
 
 #[repr(C)]
-#[deriving(Clone, PartialEq, Hash, Show, FromPrimitive)]
+#[deriving(Copy, Clone, PartialEq, Hash, Show, FromPrimitive)]
 pub enum AudioStatus {
     Stopped = ll::SDL_AUDIO_STOPPED as int,
     Playing = ll::SDL_AUDIO_PLAYING as int,
@@ -197,7 +198,7 @@ pub fn get_current_audio_driver() -> String {
     }
 }
 
-#[deriving(Clone, Show)]
+#[deriving(Copy, Clone, Show)]
 pub struct AudioSpecWAV {
     pub freq: i32,
     // TODO: Showing format should be prettier
@@ -431,7 +432,8 @@ impl<T: AudioFormatNum<T>, CB: AudioCallback<T>> AudioSpecDesired<T, CB> {
     }
 }
 
-#[deriving(Clone, Show)]
+#[allow(missing_copy_implementations)]
+#[deriving(Show)]
 pub struct AudioSpec {
     pub freq: i32,
     // TODO: Showing format should be prettier

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -16,6 +16,7 @@ pub mod ll {
     pub const SDL_CONTROLLER_BINDTYPE_HAT: SDL_GameControllerBindType = 3;
 
     #[allow(dead_code, non_snake_case)]
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_GameControllerButtonBind {
         bindType: SDL_GameControllerBindType,
@@ -23,12 +24,14 @@ pub mod ll {
     }
 
     #[allow(dead_code)]
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_GameControllerButtonBindData {
         data: [c_uchar, ..8u],
     }
 
     #[allow(dead_code)]
+    #[deriving(Copy, Clone)]
     pub struct SDL_GameControllerButtonBindDataHat {
         hat: c_int,
         hat_mask: c_int,
@@ -126,7 +129,7 @@ pub mod ll {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 #[repr(i32)]
 pub enum ControllerAxis {
     Invalid      = ll::SDL_CONTROLLER_AXIS_INVALID,
@@ -150,7 +153,7 @@ pub fn wrap_controller_axis(bitflags: u8) -> ControllerAxis {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 #[repr(i32)]
 pub enum ControllerButton {
     Invalid       = ll::SDL_CONTROLLER_BUTTON_INVALID,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -85,12 +85,14 @@ pub mod ll {
     pub const SDL_USEREVENT: SDL_EventType = 32768;
     pub const SDL_LASTEVENT: SDL_EventType = 65535;
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_CommonEvent {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_WindowEvent {
         pub _type: uint32_t,
@@ -104,6 +106,7 @@ pub mod ll {
         pub data2: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_KeyboardEvent {
         pub _type: uint32_t,
@@ -116,6 +119,7 @@ pub mod ll {
         pub keysym: SDL_Keysym,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_TextEditingEvent {
         pub _type: uint32_t,
@@ -126,6 +130,7 @@ pub mod ll {
         pub length: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_TextInputEvent {
         pub _type: uint32_t,
@@ -134,6 +139,7 @@ pub mod ll {
         pub text: [c_char, ..32u],
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_MouseMotionEvent {
         pub _type: uint32_t,
@@ -147,6 +153,7 @@ pub mod ll {
         pub yrel: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_MouseButtonEvent {
         pub _type: uint32_t,
@@ -161,6 +168,7 @@ pub mod ll {
         pub y: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_MouseWheelEvent {
         pub _type: uint32_t,
@@ -171,6 +179,7 @@ pub mod ll {
         pub y: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoyAxisEvent {
         pub _type: uint32_t,
@@ -184,6 +193,7 @@ pub mod ll {
         pub padding4: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoyBallEvent {
         pub _type: uint32_t,
@@ -197,6 +207,7 @@ pub mod ll {
         pub yrel: int16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoyHatEvent {
         pub _type: uint32_t,
@@ -208,6 +219,7 @@ pub mod ll {
         pub padding2: uint8_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoyButtonEvent {
         pub _type: uint32_t,
@@ -219,6 +231,7 @@ pub mod ll {
         pub padding2: uint8_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoyDeviceEvent {
         pub _type: uint32_t,
@@ -226,6 +239,7 @@ pub mod ll {
         pub which: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_ControllerAxisEvent {
         pub _type: uint32_t,
@@ -239,6 +253,7 @@ pub mod ll {
         pub padding4: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_ControllerButtonEvent {
         pub _type: uint32_t,
@@ -250,6 +265,7 @@ pub mod ll {
         pub padding2: uint8_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_ControllerDeviceEvent {
         pub _type: uint32_t,
@@ -257,6 +273,7 @@ pub mod ll {
         pub which: int32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_TouchFingerEvent {
         pub _type: uint32_t,
@@ -270,6 +287,7 @@ pub mod ll {
         pub pressure: c_float,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_MultiGestureEvent {
         pub _type: uint32_t,
@@ -283,6 +301,7 @@ pub mod ll {
         pub padding: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_DollarGestureEvent {
         pub _type: uint32_t,
@@ -295,6 +314,7 @@ pub mod ll {
         pub y: c_float,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_DropEvent {
         pub _type: uint32_t,
@@ -302,18 +322,21 @@ pub mod ll {
         pub file: *const c_char,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_QuitEvent {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_OSEvent {
         pub _type: uint32_t,
         pub timestamp: uint32_t,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_UserEvent {
         pub _type: uint32_t,
@@ -324,6 +347,7 @@ pub mod ll {
         pub data2: *const c_void,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_SysWMEvent {
         pub _type: uint32_t,
@@ -331,6 +355,7 @@ pub mod ll {
         pub msg: *const SDL_SysWMmsg,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Event {
         pub data: [uint8_t, ..56u],
@@ -470,7 +495,7 @@ pub mod ll {
 }
 
 /// Types of events that can be delivered.
-#[deriving(FromPrimitive)]
+#[deriving(Copy, Clone, FromPrimitive)]
 #[repr(u32)]
 pub enum EventType {
     First = ll::SDL_FIRSTEVENT,
@@ -525,7 +550,7 @@ pub enum EventType {
     Last = ll::SDL_LASTEVENT,
 }
 
-#[deriving(Show)]
+#[deriving(Copy, Clone, Show)]
 /// An enum of window events.
 pub enum WindowEventId {
     None,

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -24,12 +24,14 @@ pub mod ll {
 
     pub type SDL_Haptic = c_void;
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticDirection {
         pub _type: uint8_t,
         pub dir: [int32_t, ..3],
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticConstant {
         pub _type: uint16_t,
@@ -45,6 +47,7 @@ pub mod ll {
         pub fade_level: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticPeriodic {
         pub _type: uint16_t,
@@ -63,6 +66,7 @@ pub mod ll {
         pub fade_level: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticCondition {
         pub _type: uint16_t,
@@ -79,6 +83,7 @@ pub mod ll {
         pub center: [int16_t, ..3],
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticRamp {
         pub _type: uint16_t,
@@ -94,6 +99,7 @@ pub mod ll {
         pub fade_level: uint16_t,
     }
 
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_HapticLeftRight {
         pub _type: uint16_t,
@@ -102,6 +108,7 @@ pub mod ll {
         pub small_magnitude: uint16_t,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_HapticCustom {
         pub _type: uint16_t,
@@ -120,6 +127,7 @@ pub mod ll {
         pub fade_level: uint16_t,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_HapticEffect {
         pub data: [uint8_t, ..72u],

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -7,6 +7,7 @@ pub mod ll {
     pub type SDL_Joystick = c_void;
 
     #[allow(dead_code)]
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_JoystickGUID {
         data: [uint8_t, ..16u],
@@ -46,6 +47,7 @@ pub mod ll {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags HatState: u8 {
         const CENTEREDHATSTATE = 0,
         const UPHATSTATE = 0x01,

--- a/src/sdl2/keyboard.rs
+++ b/src/sdl2/keyboard.rs
@@ -21,6 +21,7 @@ pub mod ll {
     pub type SDL_Scancode = c_uint;
 
     // SDL_keyboard.h
+    #[deriving(Copy, Clone)]
     pub struct SDL_Keysym {
         pub scancode: SDL_Scancode,
         pub sym: SDL_Keycode,
@@ -49,6 +50,7 @@ pub mod ll {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags Mod: u32 {
         const NOMOD = 0x0000,
         const LSHIFTMOD = 0x0001,

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -20,6 +20,7 @@ pub mod ll {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags MessageBoxFlag: u32 {
         const MESSAGEBOX_ERROR = ll::SDL_MESSAGEBOX_ERROR,
         const MESSAGEBOX_WARNING = ll::SDL_MESSAGEBOX_WARNING,

--- a/src/sdl2/mouse.rs
+++ b/src/sdl2/mouse.rs
@@ -55,7 +55,7 @@ pub mod ll {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 #[repr(u32)]
 pub enum SystemCursor {
     Arrow = ll::SDL_SYSTEM_CURSOR_ARROW,
@@ -135,7 +135,7 @@ impl Cursor {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum Mouse {
     Left,
     Middle,
@@ -146,6 +146,7 @@ pub enum Mouse {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags MouseState: u32 {
         const LEFTMOUSESTATE = 0x01,
         const MIDDLEMOUSESTATE = 0x02,

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -5,6 +5,7 @@ pub mod ll {
     use libc::{c_int, uint8_t, uint32_t};
 
     //SDL_pixels.h
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_Color {
         pub r: uint8_t,
@@ -13,6 +14,7 @@ pub mod ll {
         pub a: uint8_t,
     }
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Palette {
         pub ncolors: c_int,
@@ -21,7 +23,7 @@ pub mod ll {
         pub refcount: c_int
     }
 
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_PixelFormat {
         pub format: SDL_PixelFormatFlag,
@@ -90,7 +92,7 @@ pub mod ll {
         pub fn SDL_MapRGBA(format: *const SDL_PixelFormat, r: uint8_t, g: uint8_t, b: uint8_t, a: uint8_t) -> uint32_t;
     }
 }
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[deriving(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct Palette {
     raw: *const ll::SDL_Palette
 }
@@ -142,7 +144,7 @@ impl rand::Rand for Color {
     }
 }
 
-#[deriving(PartialEq)] #[allow(raw_pointer_deriving)]
+#[deriving(PartialEq)] #[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct PixelFormat {
     raw: *const ll::SDL_PixelFormat
 }
@@ -150,7 +152,7 @@ pub struct PixelFormat {
 impl_raw_accessors!(PixelFormat, *const ll::SDL_PixelFormat)
 impl_raw_constructor!(PixelFormat -> PixelFormat (raw: *const ll::SDL_PixelFormat))
 
-#[deriving(PartialEq, Show, FromPrimitive)]
+#[deriving(Copy, Clone, PartialEq, Show, FromPrimitive)]
 pub enum PixelFormatFlag {
     Unknown = ll::SDL_PIXELFORMAT_UNKNOWN as int,
     Index1LSB = ll::SDL_PIXELFORMAT_INDEX1LSB as int,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -36,6 +36,7 @@ pub mod ll {
     pub const SDL_RENDERER_PRESENTVSYNC : SDL_RendererFlags = 0x00000004;
     pub const SDL_RENDERER_TARGETTEXTURE : SDL_RendererFlags = 0x00000008;
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_RendererInfo
     {
@@ -62,8 +63,10 @@ pub mod ll {
     pub const SDL_FLIP_HORIZONTAL : SDL_RendererFlip = 0x00000001;
     pub const SDL_FLIP_VERTICAL : SDL_RendererFlip = 0x00000002;
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Renderer;
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Texture;
 
@@ -130,12 +133,13 @@ pub mod ll {
     }
 }
 
+#[deriving(Copy, Clone)]
 pub enum RenderDriverIndex {
     Auto,
     Index(int)
 }
 
-#[deriving(PartialEq, FromPrimitive)]
+#[deriving(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum TextureAccess {
     Static = ll::SDL_TEXTUREACCESS_STATIC as int,
     Streaming = ll::SDL_TEXTUREACCESS_STREAMING as int,
@@ -143,6 +147,7 @@ pub enum TextureAccess {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags RendererFlags: u32 {
         const SOFTWARE = ll::SDL_RENDERER_SOFTWARE as u32,
         const ACCELERATED = ll::SDL_RENDERER_ACCELERATED as u32,
@@ -160,7 +165,7 @@ pub struct RendererInfo {
     pub max_texture_height: int
 }
 
-#[deriving(PartialEq, FromPrimitive)]
+#[deriving(Copy, Clone, PartialEq, FromPrimitive)]
 pub enum BlendMode {
     None = ll::SDL_BLENDMODE_NONE as int,
     Blend = ll::SDL_BLENDMODE_BLEND as int,
@@ -168,7 +173,7 @@ pub enum BlendMode {
     Mod = ll::SDL_BLENDMODE_MOD as int
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum RendererFlip {
     None = ll::SDL_FLIP_NONE as int,
     Horizontal = ll::SDL_FLIP_HORIZONTAL as int,
@@ -584,6 +589,8 @@ impl Renderer {
     }
 }
 
+
+#[deriving(Copy, Clone)]
 pub struct TextureQuery {
     pub format: pixels::PixelFormatFlag,
     pub access: TextureAccess,

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -61,6 +61,7 @@ pub mod ll {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags InitFlag: u32 {
         const INIT_TIMER = ll::SDL_INIT_TIMER,
         const INIT_AUDIO = ll::SDL_INIT_AUDIO,
@@ -74,7 +75,7 @@ bitflags! {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum Error {
     NoMemError = ll::SDL_ENOMEM as int,
     ReadError = ll::SDL_EFREAD as int,

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -28,9 +28,11 @@ pub mod ll {
     pub const SDL_DONTFREE: SDL_SurfaceFlag = 0x00000004;
 
     //SDL_surface.h
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_BlitMap;
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Surface {
         pub flags: uint32_t,
@@ -81,6 +83,7 @@ pub mod ll {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags SurfaceFlag: u32 {
         const SWSURFACE = ll::SDL_SWSURFACE as u32,
         const PREALLOC = ll::SDL_PREALLOC as u32,
@@ -90,7 +93,7 @@ bitflags! {
 }
 
 #[deriving(PartialEq)]
-#[allow(raw_pointer_deriving)]
+#[allow(raw_pointer_deriving, missing_copy_implementations)]
 pub struct Surface {
     raw: *const ll::SDL_Surface,
     owned: bool

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -9,6 +9,7 @@ use std::c_str::CString;
 #[allow(non_camel_case_types)]
 pub mod ll {
     use libc::{uint8_t, c_char, c_int};
+    #[deriving(Copy, Clone)]
     #[repr(C)]
     pub struct SDL_version {
         pub major: uint8_t,
@@ -23,7 +24,7 @@ pub mod ll {
 }
 
 /// A structure that contains information about the version of SDL in use.
-#[deriving(PartialEq, Clone)]
+#[deriving(PartialEq, Copy, Clone)]
 pub struct Version {
     /// major version
     pub major: int,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -21,9 +21,11 @@ pub mod ll {
     pub type SDL_bool = c_int;
 
     //SDL_video.h
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_Window;
 
+    #[allow(missing_copy_implementations)]
     #[repr(C)]
     pub struct SDL_DisplayMode {
         pub format: uint32_t,
@@ -37,6 +39,7 @@ pub mod ll {
     pub const SDL_WINDOWPOS_CENTERED: SDL_WindowPos = 0x2FFF0000;
     pub const SDL_WINDOWPOS_UNDEFINED: SDL_WindowPos = 0x1FFF0000;
 
+    #[deriving(Copy, Clone)]
     pub enum SDL_WindowFlags {
         SDL_WINDOW_FULLSCREEN = 0x00000001,
         SDL_WINDOW_OPENGL = 0x00000002,
@@ -54,6 +57,7 @@ pub mod ll {
         SDL_WINDOW_ALLOW_HIGHDPI = 0x00002000
     }
 
+    #[deriving(Copy, Clone)]
     pub enum SDL_WindowEventID {
         SDL_WINDOWEVENT_NONE,
         SDL_WINDOWEVENT_SHOWN,
@@ -74,7 +78,7 @@ pub mod ll {
 
     pub type SDL_GLContext = *const c_void;
 
-    #[deriving(FromPrimitive)]
+    #[deriving(Copy, Clone, FromPrimitive)]
     #[repr(C)]
     pub enum SDL_GLattr {
         SDL_GL_RED_SIZE = 0,
@@ -103,6 +107,7 @@ pub mod ll {
         SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = 23
     }
 
+    #[deriving(Copy, Clone)]
     pub enum SDL_GLprofile {
         SDL_GL_CONTEXT_PROFILE_CORE = 0x0001,
         SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = 0x0002,
@@ -185,7 +190,7 @@ pub mod ll {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum GLAttr {
     GLRedSize = ll::SDL_GLattr::SDL_GL_RED_SIZE as int,
     GLGreenSize = ll::SDL_GLattr::SDL_GL_GREEN_SIZE as int,
@@ -213,7 +218,7 @@ pub enum GLAttr {
     GLFramebufferSRGBCapable = ll::SDL_GLattr::SDL_GL_FRAMEBUFFER_SRGB_CAPABLE as int
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum GLProfile {
   GLCoreProfile = ll::SDL_GLprofile::SDL_GL_CONTEXT_PROFILE_CORE as int,
   GLCompatibilityProfile = ll::SDL_GLprofile::SDL_GL_CONTEXT_PROFILE_COMPATIBILITY as int,
@@ -231,7 +236,8 @@ fn empty_sdl_display_mode() -> ll::SDL_DisplayMode {
     }
 }
 
-#[deriving(PartialEq)]
+#[allow(missing_copy_implementations)]
+#[deriving(Clone, PartialEq)]
 pub struct DisplayMode {
     pub format: u32,
     pub w: int,
@@ -271,6 +277,7 @@ impl DisplayMode {
 }
 
 bitflags! {
+    #[deriving(Copy)]
     flags WindowFlags: u32 {
         const FULLSCREEN = ll::SDL_WindowFlags::SDL_WINDOW_FULLSCREEN as u32,
         const OPENGL = ll::SDL_WindowFlags::SDL_WINDOW_OPENGL as u32,
@@ -289,7 +296,7 @@ bitflags! {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(Copy, Clone, PartialEq)]
 pub enum FullscreenType {
     FTOff = 0,
     FTTrue = ll::SDL_WindowFlags::SDL_WINDOW_FULLSCREEN as int,


### PR DESCRIPTION
This goes through all types that previously would have inferred Copy and either derives it or allows its absence. For many types the choice is obvious, but for some it's a bit of a judgment call. The general rule I used is that if the struct transitively contains a raw pointer then it ignores copy, otherwise it derives it.
