### PR TITLE
Fixed macros for new rust nightly.

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -556,8 +556,8 @@ pub struct AudioCVT {
     owned: bool,
 }
 
-impl_raw_accessors!(AudioCVT, *mut ll::SDL_AudioCVT)
-impl_owned_accessors!(AudioCVT, owned)
+impl_raw_accessors!(AudioCVT, *mut ll::SDL_AudioCVT);
+impl_owned_accessors!(AudioCVT, owned);
 
 impl Drop for AudioCVT {
     fn drop(&mut self) {

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -9,7 +9,7 @@ macro_rules! impl_raw_accessors(
         }
         )+
     )
-)
+);
 
 macro_rules! impl_owned_accessors(
     ($($t:ty, $owned:ident);+) => (
@@ -20,7 +20,7 @@ macro_rules! impl_owned_accessors(
         }
         )+
     )
-)
+);
 
 macro_rules! impl_raw_constructor(
     ($($t:ty -> $te:ident ($($r:ident:$rt:ty),+));+) => (
@@ -33,4 +33,4 @@ macro_rules! impl_raw_constructor(
         }
         )+
     )
-)
+);

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -97,7 +97,7 @@ pub struct Palette {
     raw: *const ll::SDL_Palette
 }
 
-impl_raw_accessors!(Palette, *const ll::SDL_Palette)
+impl_raw_accessors!(Palette, *const ll::SDL_Palette);
 
 #[deriving(PartialEq, Clone, Copy)]
 pub enum Color {
@@ -149,8 +149,8 @@ pub struct PixelFormat {
     raw: *const ll::SDL_PixelFormat
 }
 
-impl_raw_accessors!(PixelFormat, *const ll::SDL_PixelFormat)
-impl_raw_constructor!(PixelFormat -> PixelFormat (raw: *const ll::SDL_PixelFormat))
+impl_raw_accessors!(PixelFormat, *const ll::SDL_PixelFormat);
+impl_raw_constructor!(PixelFormat -> PixelFormat (raw: *const ll::SDL_PixelFormat));
 
 #[deriving(Copy, Clone, PartialEq, Show, FromPrimitive)]
 pub enum PixelFormatFlag {

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -52,8 +52,8 @@ pub struct RWops {
     close_on_drop: bool
 }
 
-impl_raw_accessors!(RWops, *const ll::SDL_RWops)
-impl_owned_accessors!(RWops, close_on_drop)
+impl_raw_accessors!(RWops, *const ll::SDL_RWops);
+impl_owned_accessors!(RWops, close_on_drop);
 
 /// A structure that provides an abstract interface to stream I/O.
 impl RWops {

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -108,9 +108,9 @@ impl Drop for Surface {
     }
 }
 
-impl_raw_accessors!(Surface, *const ll::SDL_Surface)
-impl_owned_accessors!(Surface, owned)
-impl_raw_constructor!(Surface -> Surface (raw: *const ll::SDL_Surface, owned: bool))
+impl_raw_accessors!(Surface, *const ll::SDL_Surface);
+impl_owned_accessors!(Surface, owned);
+impl_raw_constructor!(Surface -> Surface (raw: *const ll::SDL_Surface, owned: bool));
 
 impl Surface {
     pub fn new(surface_flags: SurfaceFlag, width: int, height: int, bpp: int,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -343,16 +343,16 @@ pub struct Window {
 impl_raw_accessors!(
     GLContext, ll::SDL_GLContext;
     Window, *const ll::SDL_Window
-)
+);
 
 impl_owned_accessors!(
     GLContext, owned;
     Window, owned
-)
+);
 
 impl_raw_constructor!(
     Window -> Window (raw: *const ll::SDL_Window, owned: bool)
-)
+);
 
 impl Drop for Window {
     fn drop(&mut self) {


### PR DESCRIPTION
Added semicolons to macros in order to fix this error coming from Rust's nightly builds:
`macros that expand to items must either be surrounded with braces or followed by a semicolon`
