### PR TITLE
Remove rust version output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ install:
     - cd SDL2-2.0.3
     - ./configure && make && sudo make install
     - cd -
-before_script:
-    - rustc -v
-    - cargo -V
 script:
     - cargo build -v
     - cargo test -v


### PR DESCRIPTION
The cli options have been renamed, and Travis also prints the versions.

Travis will still fail because of the runtime removal unfortunately.
