### PR TITLE
Use Unique ptr wrapper where Send ptrs are required

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -226,8 +226,9 @@ impl AudioSpecWAV {
             if ret.is_null() {
                 Err(get_error())
             } else {
-                let v = CVec::new_with_dtor(audio_buf as *mut u8, audio_len as uint, move || {
-                    ll::SDL_FreeWAV(audio_buf)
+                let audio_buf = ptr::Unique(audio_buf);
+                let v = CVec::new_with_dtor(audio_buf.0 as *mut u8, audio_len as uint, move || {
+                    ll::SDL_FreeWAV(audio_buf.0)
                 });
 
                 Ok((AudioSpecWAV {
@@ -552,10 +553,10 @@ impl AudioCVT {
             // convert
             let ret = ll::SDL_ConvertAudio(self.raw);
             // return
-            let p = (*self.raw).buf as *mut c_void; // send to move ||
+            let p = ptr::Unique((*self.raw).buf as *mut c_void); // send to move ||
             if ret == 0 {
-                Ok( CVec::new_with_dtor((*self.raw).buf as *mut u8, (*self.raw).len_cvt as uint,
-                                        move || { libc::free(p) })
+                Ok( CVec::new_with_dtor(p.0 as *mut u8, (*self.raw).len_cvt as uint,
+                                        move || { libc::free(p.0) })
                     )
             } else {
                 Err(get_error())

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -125,7 +125,7 @@ pub mod ll {
         pub fn SDL_RenderFillRects(renderer: *const SDL_Renderer, rects: *const SDL_Rect, count: c_int) -> c_int;
         pub fn SDL_RenderCopy(renderer: *const SDL_Renderer, texture: *const SDL_Texture, srcrect: *const SDL_Rect, dstrect: *const SDL_Rect) -> c_int;
         pub fn SDL_RenderCopyEx(renderer: *const SDL_Renderer, texture: *const SDL_Texture, srcrect: *const SDL_Rect, dstrect: *const SDL_Rect, angle: c_double, center: *const SDL_Point, flip: SDL_RendererFlip) -> c_int;
-        pub fn SDL_RenderReadPixels(renderer: *const SDL_Renderer, rect: *const SDL_Rect, format: uint32_t, pixels: *const c_void, pitch: c_int) -> c_int;
+        pub fn SDL_RenderReadPixels(renderer: *const SDL_Renderer, rect: *const SDL_Rect, format: uint32_t, pixels: *mut c_void, pitch: c_int) -> c_int;
         pub fn SDL_RenderPresent(renderer: *const SDL_Renderer);
         pub fn SDL_DestroyTexture(texture: *const SDL_Texture);
         pub fn SDL_DestroyRenderer(renderer: *const SDL_Renderer);
@@ -575,12 +575,13 @@ impl Renderer {
                 }
             };
             let size = format.byte_size_of_pixels(w * h);
-            let pixels = libc::malloc(size as size_t) as *const u8;
+            let pixels = libc::malloc(size as size_t) as *mut u8;
             let pitch = w * format.byte_size_per_pixel(); // calculated pitch
-            let ret = ll::SDL_RenderReadPixels(self.raw, actual_rect, format as uint32_t, pixels as *const c_void, pitch as c_int);
+            let ret = ll::SDL_RenderReadPixels(self.raw, actual_rect, format as uint32_t, pixels as *mut c_void, pitch as c_int);
             if ret == 0 {
-                Ok(CVec::new_with_dtor(pixels as *mut u8, size, move || {
-                    libc::free(pixels as *mut c_void)
+                let pixels = ptr::Unique(pixels);
+                Ok(CVec::new_with_dtor(pixels.0 as *mut u8, size, move || {
+                    libc::free(pixels.0 as *mut c_void)
                 }))
             } else {
                 Err(get_error())


### PR DESCRIPTION
Send is no longer inferred for raw pointer types. This uses the new ptr::Unique wrapper to make them Send again where necessary.
