### PR TITLE
A preview of the don't panic branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bitflags = "0.7"
 libc = "0.2"
 rand = "0.3"
 lazy_static="0.2"
+error-chain = "0.10"
 
 [dependencies.num]
 version = "0.1"

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -346,7 +346,7 @@ impl GameController {
     }
 
     /// Return the joystick id of this controller
-    pub fn instance_id(&self) -> i32 {
+    pub fn instance_id(&self) -> Result<i32, String> {
         let result = unsafe {
           let joystick = ll::SDL_GameControllerGetJoystick(self.raw);
           ::sys::joystick::SDL_JoystickInstanceID(joystick)
@@ -354,9 +354,9 @@ impl GameController {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            bail!(get_error())
         } else {
-            result
+            Ok(result)
         }
     }
 

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -11,6 +11,9 @@ extern crate lazy_static;
 extern crate bitflags;
 pub extern crate sdl2_sys as sys;
 
+#[macro_use]
+extern crate error_chain;
+
 #[cfg(feature = "gfx")]
 extern crate c_vec;
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -350,23 +350,22 @@ impl PixelFormatEnum {
             _ => false
         }
     }
+
+    pub fn try_from(pf: PixelFormat) -> Result<Self, String> {
+        unsafe {
+            let ref sdl_pf = *pf.raw;
+            match PixelFormatEnum::from_u64(sdl_pf.format as u64) {
+                Some(pfe) => Ok(pfe),
+                None => bail!("Unknown pixel format: {:?}", sdl_pf.format)
+            }
+        }
+    }
+
 }
 
 impl Into<ll::SDL_PixelFormatEnum> for PixelFormatEnum {
     fn into(self) -> ll::SDL_PixelFormatEnum {
         self as libc::uint32_t
-    }
-}
-
-impl From<PixelFormat> for PixelFormatEnum {
-    fn from(pf: PixelFormat) -> PixelFormatEnum {
-        unsafe {
-            let ref sdl_pf = *pf.raw;
-            match PixelFormatEnum::from_u64(sdl_pf.format as u64) {
-                Some(pfe) => pfe,
-                None => panic!("Unknown pixel format: {:?}", sdl_pf.format)
-            }
-        }
     }
 }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -26,14 +26,14 @@ impl Palette {
 
             match validate_int(capacity as u32, "capacity") {
                 Ok(len) => len,
-                Err(e) => return Err(format!("{}", e)),
+                Err(e) => bail!("{}", e),
             }
         };
 
         let raw = unsafe { ll::SDL_AllocPalette(ncolors) };
 
         if raw.is_null() {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(Palette {
                 raw: raw,
@@ -59,7 +59,7 @@ impl Palette {
         };
 
         if result < 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(pal)
         }
@@ -240,7 +240,7 @@ impl PixelFormatEnum {
         };
         if result == 0 {
             // SDL_FALSE
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(PixelMasks {
                 bpp: bpp as u8,
@@ -267,10 +267,10 @@ impl PixelFormatEnum {
         }
     }
 
-    pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> usize {
+    pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> Result<usize, String> {
         match *self {
             PixelFormatEnum::RGB332
-                => num_of_pixels,
+                => Ok(num_of_pixels),
             PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
             PixelFormatEnum::BGR555 | PixelFormatEnum::ARGB4444 |
             PixelFormatEnum::RGBA4444 | PixelFormatEnum::ABGR4444 |
@@ -278,36 +278,36 @@ impl PixelFormatEnum {
             PixelFormatEnum::RGBA5551 | PixelFormatEnum::ABGR1555 |
             PixelFormatEnum::BGRA5551 | PixelFormatEnum::RGB565 |
             PixelFormatEnum::BGR565
-                => num_of_pixels * 2,
+                => Ok(num_of_pixels * 2),
             PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24
-                => num_of_pixels * 3,
+                => Ok(num_of_pixels * 3),
             PixelFormatEnum::RGB888 | PixelFormatEnum::RGBX8888 |
             PixelFormatEnum::BGR888 | PixelFormatEnum::BGRX8888 |
             PixelFormatEnum::ARGB8888 | PixelFormatEnum::RGBA8888 |
             PixelFormatEnum::ABGR8888 | PixelFormatEnum::BGRA8888 |
             PixelFormatEnum::ARGB2101010
-                => num_of_pixels * 4,
+                => Ok(num_of_pixels * 4),
             // YUV formats
             // FIXME: rounding error here?
             PixelFormatEnum::YV12 | PixelFormatEnum::IYUV
-                => num_of_pixels / 2 * 3,
+                => Ok(num_of_pixels / 2 * 3),
             PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY |
             PixelFormatEnum::YVYU
-                => num_of_pixels * 2,
+                => Ok(num_of_pixels * 2),
             // Unsupported formats
             PixelFormatEnum::Index8
-                => num_of_pixels,
+                => Ok(num_of_pixels),
             PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
             PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
             PixelFormatEnum::Index4MSB
-                => panic!("not supported format: {:?}", *self),
+                => bail!("not supported format: {:?}", *self),
         }
     }
 
-    pub fn byte_size_per_pixel(&self) -> usize {
+    pub fn byte_size_per_pixel(&self) -> Result<usize, String> {
         match *self {
             PixelFormatEnum::RGB332
-                => 1,
+                => Ok(1),
             PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
             PixelFormatEnum::BGR555 | PixelFormatEnum::ARGB4444 |
             PixelFormatEnum::RGBA4444 | PixelFormatEnum::ABGR4444 |
@@ -315,28 +315,28 @@ impl PixelFormatEnum {
             PixelFormatEnum::RGBA5551 | PixelFormatEnum::ABGR1555 |
             PixelFormatEnum::BGRA5551 | PixelFormatEnum::RGB565 |
             PixelFormatEnum::BGR565
-                => 2,
+                => Ok(2),
             PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24
-                => 3,
+                => Ok(3),
             PixelFormatEnum::RGB888 | PixelFormatEnum::RGBX8888 |
             PixelFormatEnum::BGR888 | PixelFormatEnum::BGRX8888 |
             PixelFormatEnum::ARGB8888 | PixelFormatEnum::RGBA8888 |
             PixelFormatEnum::ABGR8888 | PixelFormatEnum::BGRA8888 |
             PixelFormatEnum::ARGB2101010
-                => 4,
+                => Ok(4),
             // YUV formats
             PixelFormatEnum::YV12 | PixelFormatEnum::IYUV
-                => 2,
+                => Ok(2),
             PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY |
             PixelFormatEnum::YVYU
-                => 2,
+                => Ok(2),
             // Unsupported formats
             PixelFormatEnum::Index8
-                => 1,
+                => Ok(1),
             PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
             PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
             PixelFormatEnum::Index4MSB
-                => panic!("not supported format: {:?}", *self),
+                => bail!("not supported format: {:?}", *self),
         }
     }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -366,11 +366,11 @@ impl<'s> Canvas<Surface<'s>> {
     ///
     /// The target (i.e., `Window`) will not be destroyed and the SDL_Renderer will not be
     /// destroyed if the `TextureCreator` is still in scope.
-    pub fn texture_creator(&self) -> TextureCreator<SurfaceContext<'s>> {
-        TextureCreator {
+    pub fn texture_creator(&self) -> Result<TextureCreator<SurfaceContext<'s>>, String> {
+        Ok(TextureCreator {
             context: self.context.clone(),
-            default_pixel_format: self.surface().pixel_format_enum(),
-        }
+            default_pixel_format: self.surface().pixel_format_enum()?,
+        })
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -229,7 +229,7 @@ impl<T> RendererContext<T> {
         if ll::SDL_SetRenderTarget(self.raw, raw_texture) == 0 {
             Ok(())
         } else {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         }
     }
 
@@ -338,7 +338,7 @@ impl<'s> Canvas<Surface<'s>> {
                    context: context,
                })
         } else {
-            Err(get_error())
+            bail!(get_error())
         }
     }
 
@@ -496,7 +496,7 @@ impl<T: RenderTarget> Canvas<T> {
                 .map_err(|e| TargetRenderError::SdlError(e))?;
             Ok(())
         } else {
-            Err(TargetRenderError::NotSupported)
+            bail!(TargetRenderError::NotSupported)
         }
     }
 
@@ -571,7 +571,7 @@ impl<T: RenderTarget> Canvas<T> {
                 .map_err(|e| TargetRenderError::SdlError(e))?;
             Ok(())
         } else {
-            Err(TargetRenderError::NotSupported)
+            bail!(TargetRenderError::NotSupported)
         }
     }
 }
@@ -627,7 +627,7 @@ impl CanvasBuilder {
         let raw = unsafe { ll::SDL_CreateRenderer(self.window.raw(), index, self.renderer_flags) };
 
         if raw.is_null() {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         } else {
             let context = Rc::new(unsafe { RendererContext::from_ll(raw, self.window.context()) });
             Ok(Canvas {
@@ -746,11 +746,11 @@ impl<T> TextureCreator<T> {
         use self::TextureValueError::*;
         let w = match validate_int(width, "width") {
             Ok(w) => w,
-            Err(_) => return Err(WidthOverflows(width)),
+            Err(_) => bail!(WidthOverflows(width)),
         };
         let h = match validate_int(height, "height") {
             Ok(h) => h,
-            Err(_) => return Err(HeightOverflows(height)),
+            Err(_) => bail!(HeightOverflows(height)),
         };
         let format: PixelFormatEnum = format.into().unwrap_or(self.default_pixel_format);
 
@@ -760,7 +760,7 @@ impl<T> TextureCreator<T> {
             PixelFormatEnum::YV12 |
             PixelFormatEnum::IYUV => {
                 if w % 2 != 0 || h % 2 != 0 {
-                    return Err(WidthMustBeMultipleOfTwoForFormat(width, format));
+                    bail!(WidthMustBeMultipleOfTwoForFormat(width, format));
                 }
             }
             _ => (),
@@ -770,7 +770,7 @@ impl<T> TextureCreator<T> {
             ll::SDL_CreateTexture(self.context.raw, format as uint32_t, access as c_int, w, h)
         };
         if result.is_null() {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         } else {
             unsafe { Ok(self.raw_create_texture(result)) }
         }
@@ -820,7 +820,7 @@ impl<T> TextureCreator<T> {
         let result =
             unsafe { ll::SDL_CreateTextureFromSurface(self.context.raw, surface.as_ref().raw()) };
         if result.is_null() {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         } else {
             unsafe { Ok(self.raw_create_texture(result)) }
         }
@@ -925,7 +925,7 @@ impl<T: RenderTarget> Canvas<T> {
         if result == 0 {
             Ok((width as u32, height as u32))
         } else {
-            Err(get_error())
+            bail!(get_error())
         }
     }
 
@@ -937,7 +937,7 @@ impl<T: RenderTarget> Canvas<T> {
         let result = unsafe { ll::SDL_RenderSetLogicalSize(self.context.raw, width, height) };
         match result {
             0 => Ok(()),
-            _ => Err(SdlError(get_error())),
+            _ => bail!(SdlError(get_error())),
         }
     }
 
@@ -1003,7 +1003,7 @@ impl<T: RenderTarget> Canvas<T> {
     pub fn set_scale(&mut self, scale_x: f32, scale_y: f32) -> Result<(), String> {
         let ret = unsafe { ll::SDL_RenderSetScale(self.context.raw, scale_x, scale_y) };
         // Should only fail on an invalid renderer
-        if ret != 0 { Err(get_error()) } else { Ok(()) }
+        if ret != 0 { bail!(get_error()) } else { Ok(()) }
     }
 
     /// Gets the drawing scale for the current target.
@@ -1020,7 +1020,7 @@ impl<T: RenderTarget> Canvas<T> {
         let point = point.into();
         let result = unsafe { ll::SDL_RenderDrawPoint(self.context.raw, point.x(), point.y()) };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1036,7 +1036,7 @@ impl<T: RenderTarget> Canvas<T> {
                                      points.len() as c_int)
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1054,7 +1054,7 @@ impl<T: RenderTarget> Canvas<T> {
             ll::SDL_RenderDrawLine(self.context.raw, start.x(), start.y(), end.x(), end.y())
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1070,7 +1070,7 @@ impl<T: RenderTarget> Canvas<T> {
                                     points.len() as c_int)
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1081,7 +1081,7 @@ impl<T: RenderTarget> Canvas<T> {
     pub fn draw_rect(&mut self, rect: Rect) -> Result<(), String> {
         let result = unsafe { ll::SDL_RenderDrawRect(self.context.raw, rect.raw()) };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1096,7 +1096,7 @@ impl<T: RenderTarget> Canvas<T> {
                                     rects.len() as c_int)
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1115,7 +1115,7 @@ impl<T: RenderTarget> Canvas<T> {
                                        .unwrap_or(ptr::null()))
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1131,7 +1131,7 @@ impl<T: RenderTarget> Canvas<T> {
                                     rects.len() as c_int)
         };
         if result != 0 {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok(())
         }
@@ -1162,7 +1162,7 @@ impl<T: RenderTarget> Canvas<T> {
                                })
         };
 
-        if ret != 0 { Err(get_error()) } else { Ok(()) }
+        if ret != 0 { bail!(get_error()) } else { Ok(()) }
     }
 
     /// Copies a portion of the texture to the current rendering target,
@@ -1217,7 +1217,7 @@ impl<T: RenderTarget> Canvas<T> {
                                  flip)
         };
 
-        if ret != 0 { Err(get_error()) } else { Ok(()) }
+        if ret != 0 { bail!(get_error()) } else { Ok(()) }
     }
 
     /// Reads pixels from the current rendering target.
@@ -1237,8 +1237,8 @@ impl<T: RenderTarget> Canvas<T> {
                 }
             };
 
-            let pitch = w * format.byte_size_per_pixel(); // calculated pitch
-            let size = format.byte_size_of_pixels(w * h);
+            let pitch = w * format.byte_size_per_pixel()?; // calculated pitch
+            let size = format.byte_size_of_pixels(w * h)?;
             let mut pixels = Vec::with_capacity(size);
             pixels.set_len(size);
 
@@ -1254,7 +1254,7 @@ impl<T: RenderTarget> Canvas<T> {
             if ret == 0 {
                 Ok(pixels)
             } else {
-                Err(get_error())
+                bail!(get_error())
             }
         }
     }
@@ -1546,19 +1546,19 @@ impl<'r> Texture<'r> {
                 match rect {
                     Some(r) => {
                         if r.x() % 2 != 0 {
-                            return Err(XMustBeMultipleOfTwoForFormat(r.x(), format));
+                            bail!(XMustBeMultipleOfTwoForFormat(r.x(), format));
                         } else if r.y() % 2 != 0 {
-                            return Err(YMustBeMultipleOfTwoForFormat(r.y(), format));
+                            bail!(YMustBeMultipleOfTwoForFormat(r.y(), format));
                         } else if r.width() % 2 != 0 {
-                            return Err(WidthMustBeMultipleOfTwoForFormat(r.width(), format));
+                            bail!(WidthMustBeMultipleOfTwoForFormat(r.width(), format));
                         } else if r.height() % 2 != 0 {
-                            return Err(HeightMustBeMultipleOfTwoForFormat(r.height(), format));
+                            bail!(HeightMustBeMultipleOfTwoForFormat(r.height(), format));
                         }
                     }
                     _ => {}
                 };
                 if pitch % 2 != 0 {
-                    return Err(PitchMustBeMultipleOfTwoForFormat(pitch, format));
+                    bail!(PitchMustBeMultipleOfTwoForFormat(pitch, format));
                 }
             }
             _ => {}
@@ -1566,7 +1566,7 @@ impl<'r> Texture<'r> {
 
         let pitch = match validate_int(pitch as u32, "pitch") {
             Ok(p) => p,
-            Err(_) => return Err(PitchOverflows(pitch)),
+            Err(_) => bail!(PitchOverflows(pitch)),
         };
 
         let result = unsafe {
@@ -1577,7 +1577,7 @@ impl<'r> Texture<'r> {
         };
 
         if result != 0 {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         } else {
             Ok(())
         }
@@ -1607,13 +1607,13 @@ impl<'r> Texture<'r> {
         match rect {
             Some(ref r) => {
                 if r.x() % 2 != 0 {
-                    return Err(XMustBeMultipleOfTwoForFormat(r.x()));
+                    bail!(XMustBeMultipleOfTwoForFormat(r.x()));
                 } else if r.y() % 2 != 0 {
-                    return Err(YMustBeMultipleOfTwoForFormat(r.y()));
+                    bail!(YMustBeMultipleOfTwoForFormat(r.y()));
                 } else if r.width() % 2 != 0 {
-                    return Err(WidthMustBeMultipleOfTwoForFormat(r.width()));
+                    bail!(WidthMustBeMultipleOfTwoForFormat(r.width()));
                 } else if r.height() % 2 != 0 {
-                    return Err(HeightMustBeMultipleOfTwoForFormat(r.height()));
+                    bail!(HeightMustBeMultipleOfTwoForFormat(r.height()));
                 }
             }
             _ => {}
@@ -1630,7 +1630,7 @@ impl<'r> Texture<'r> {
             };
             // The destination rectangle cannot lie outside the texture boundaries
             if !inside {
-                return Err(RectNotInsideTexture(r.clone()));
+                bail!(RectNotInsideTexture(r.clone()));
             }
         }
 
@@ -1643,55 +1643,55 @@ impl<'r> Texture<'r> {
 
         //let wrong_length =
         if y_plane.len() != (y_pitch * height) {
-            return Err(InvalidPlaneLength {
-                           plane: "y",
-                           length: y_plane.len(),
-                           pitch: y_pitch,
-                           height: height,
-                       });
+            bail!(InvalidPlaneLength {
+                     plane: "y",
+                     length: y_plane.len(),
+                     pitch: y_pitch,
+                     height: height,
+                  });
         }
         if u_plane.len() != (u_pitch * height / 2) {
-            return Err(InvalidPlaneLength {
-                           plane: "u",
-                           length: u_plane.len(),
-                           pitch: u_pitch,
-                           height: height / 2,
-                       });
+            bail!(InvalidPlaneLength {
+                     plane: "u",
+                     length: u_plane.len(),
+                     pitch: u_pitch,
+                     height: height / 2,
+                  });
         }
         if v_plane.len() != (v_pitch * height / 2) {
-            return Err(InvalidPlaneLength {
-                           plane: "v",
-                           length: v_plane.len(),
-                           pitch: v_pitch,
-                           height: height / 2,
-                       });
+            bail!(InvalidPlaneLength {
+                      plane: "v",
+                      length: v_plane.len(),
+                      pitch: v_pitch,
+                      height: height / 2,
+                  });
         }
 
         let y_pitch = match validate_int(y_pitch as u32, "y_pitch") {
             Ok(p) => p,
             Err(_) => {
-                return Err(PitchOverflows {
+                bail!(PitchOverflows {
                                plane: "y",
                                value: y_pitch,
-                           })
+                      })
             }
         };
         let u_pitch = match validate_int(u_pitch as u32, "u_pitch") {
             Ok(p) => p,
             Err(_) => {
-                return Err(PitchOverflows {
-                               plane: "u",
-                               value: u_pitch,
-                           })
+                bail!(PitchOverflows {
+                          plane: "u",
+                          value: u_pitch,
+                      })
             }
         };
         let v_pitch = match validate_int(v_pitch as u32, "v_pitch") {
             Ok(p) => p,
             Err(_) => {
-                return Err(PitchOverflows {
-                               plane: "v",
-                               value: v_pitch,
-                           })
+                bail!(PitchOverflows {
+                          plane: "v",
+                          value: v_pitch,
+                      })
             }
         };
 
@@ -1706,7 +1706,7 @@ impl<'r> Texture<'r> {
                                      v_pitch)
         };
         if result != 0 {
-            Err(SdlError(get_error()))
+            bail!(SdlError(get_error()))
         } else {
             Ok(())
         }
@@ -1743,7 +1743,7 @@ impl<'r> Texture<'r> {
                     .byte_size_from_pitch_and_height(pitch as usize, height);
                 Ok((::std::slice::from_raw_parts_mut(pixels as *mut u8, size), pitch))
             } else {
-                Err(get_error())
+                bail!(get_error())
             }
         };
 

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -131,13 +131,13 @@ impl<'a> Surface<'a> {
     pub fn from_pixelmasks(width: u32, height: u32, masks: pixels::PixelMasks) -> Result<Surface<'static>, String> {
         unsafe {
             if width >= (1<<31) || height >= (1<<31) {
-                Err("Image is too large.".to_owned())
+                bail!("Image is too large.".to_owned())
             } else {
                 let raw = ll::SDL_CreateRGBSurface(0, width as c_int, height as c_int,
                     masks.bpp as c_int, masks.rmask, masks.gmask, masks.bmask, masks.amask);
 
                 if raw.is_null() {
-                    Err(get_error())
+                    bail!(get_error())
                 } else {
                     Ok(Surface::from_ll(raw))
                 }
@@ -155,16 +155,16 @@ impl<'a> Surface<'a> {
     pub fn from_data_pixelmasks(data: &'a mut [u8], width: u32, height: u32, pitch: u32, masks: pixels::PixelMasks) -> Result<Surface<'a>, String> {
         unsafe {
             if width >= (1<<31) || height >= (1<<31) {
-                Err("Image is too large.".to_owned())
+                bail!("Image is too large.".to_owned())
             } else if pitch >= (1<<31) {
-                Err("Pitch is too large.".to_owned())
+                bail!("Pitch is too large.".to_owned())
             } else {
                 let raw = ll::SDL_CreateRGBSurfaceFrom(
                     data.as_mut_ptr() as *mut _, width as c_int, height as c_int,
                     masks.bpp as c_int, pitch as c_int, masks.rmask, masks.gmask, masks.bmask, masks.amask);
 
                 if raw.is_null() {
-                    Err(get_error())
+                    bail!(get_error())
                 } else {
                     Ok(Surface::from_ll(raw))
                 }
@@ -178,7 +178,7 @@ impl<'a> Surface<'a> {
         };
 
         if raw.is_null() {
-            Err(get_error())
+            bail!(get_error())
         } else {
             Ok( unsafe{ Surface::from_ll(raw) } )
         }
@@ -327,7 +327,7 @@ impl SurfaceRef {
             ll::SDL_SaveBMP_RW(self.raw(), rwops.raw(), 0)
         };
         if ret == 0 { Ok(()) }
-        else { Err(get_error()) }
+        else { bail!(get_error()) }
     }
 
     pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
@@ -340,7 +340,7 @@ impl SurfaceRef {
 
         match result {
             0 => Ok(()),
-            _ => Err(get_error())
+            _ => bail!(get_error())
         }
     }
 
@@ -389,7 +389,7 @@ impl SurfaceRef {
         if result == 0 {
             Ok(pixels::Color::from_u32(&self.pixel_format(), key))
         } else {
-            Err(get_error())
+            bail!(get_error())
         }
     }
 

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -259,30 +259,30 @@ impl SurfaceRef {
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
-    pub fn with_lock<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+    pub fn with_lock<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> Result<R, String> {
         unsafe {
-            if ll::SDL_LockSurface(self.raw()) != 0 { panic!("could not lock surface"); }
+            if ll::SDL_LockSurface(self.raw()) != 0 { bail!("could not lock surface"); }
 
             let raw_pixels = self.raw_ref().pixels as *const _;
             let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
             let pixels = ::std::slice::from_raw_parts(raw_pixels, len);
             let rv = f(pixels);
             ll::SDL_UnlockSurface(self.raw());
-            rv
+            Ok(rv)
         }
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
-    pub fn with_lock_mut<R, F: FnOnce(&mut [u8]) -> R>(&mut self, f: F) -> R {
+    pub fn with_lock_mut<R, F: FnOnce(&mut [u8]) -> R>(&mut self, f: F) -> Result<R, String> {
         unsafe {
-            if ll::SDL_LockSurface(self.raw()) != 0 { panic!("could not lock surface"); }
+            if ll::SDL_LockSurface(self.raw()) != 0 { bail!("could not lock surface"); }
 
             let raw_pixels = self.raw_ref().pixels as *mut _;
             let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
             let pixels = ::std::slice::from_raw_parts_mut(raw_pixels, len);
             let rv = f(pixels);
             ll::SDL_UnlockSurface(self.raw());
-            rv
+            Ok(rv)
         }
     }
 
@@ -345,23 +345,25 @@ impl SurfaceRef {
     }
 
     #[allow(non_snake_case)]
-    pub fn enable_RLE(&mut self) {
+    pub fn enable_RLE(&mut self) -> Result<(), String> {
         let result = unsafe { ll::SDL_SetSurfaceRLE(self.raw(), 1) };
 
         if result != 0 {
             // Should only panic on a null Surface
-            panic!(get_error());
+            bail!(get_error());
         }
+        Ok(())
     }
 
     #[allow(non_snake_case)]
-    pub fn disable_RLE(&mut self) {
+    pub fn disable_RLE(&mut self) -> Result<(), String> {
         let result = unsafe { ll::SDL_SetSurfaceRLE(self.raw(), 0) };
 
         if result != 0 {
             // Should only panic on a null Surface
-            panic!(get_error());
+            bail!(get_error());
         }
+        Ok(())
     }
 
     pub fn set_color_key(&mut self, enable: bool, color: pixels::Color) -> Result<(), String> {
@@ -393,17 +395,18 @@ impl SurfaceRef {
         }
     }
 
-    pub fn set_color_mod(&mut self, color: pixels::Color) {
+    pub fn set_color_mod(&mut self, color: pixels::Color) -> Result<(), String> {
         let (r, g, b) = color.rgb();
         let result = unsafe { ll::SDL_SetSurfaceColorMod(self.raw(), r, g, b) };
 
         if result != 0 {
             // Should only fail on a null Surface
-            panic!(get_error());
+            bail!(get_error());
         }
+        Ok(())
     }
 
-    pub fn color_mod(&self) -> pixels::Color {
+    pub fn color_mod(&self) -> Result<pixels::Color, String> {
         let mut r = 0;
         let mut g = 0;
         let mut b = 0;
@@ -415,10 +418,10 @@ impl SurfaceRef {
         };
 
         if result {
-            pixels::Color::RGB(r, g, b)
+            Ok(pixels::Color::RGB(r, g, b))
         } else {
             // Should only fail on a null Surface
-            panic!(get_error())
+            bail!(get_error())
         }
     }
 
@@ -451,28 +454,29 @@ impl SurfaceRef {
         Ok(())
     }
 
-    pub fn set_alpha_mod(&mut self, alpha: u8) {
+    pub fn set_alpha_mod(&mut self, alpha: u8) -> Result<(), String> {
         let result = unsafe {
             ll::SDL_SetSurfaceAlphaMod(self.raw(), alpha)
         };
 
         if result != 0 {
             // Should only fail on a null Surface
-            panic!(get_error());
+            bail!(get_error());
         }
+        Ok(())
     }
 
-    pub fn alpha_mod(&self) -> u8 {
+    pub fn alpha_mod(&self) -> Result<u8, String> {
         let mut alpha = 0;
         let result = unsafe {
             ll::SDL_GetSurfaceAlphaMod(self.raw(), &mut alpha)
         };
 
-        match result {
+        Ok(match result {
             0 => alpha,
             // Should only fail on a null Surface
-            _ => panic!(get_error())
-        }
+            _ => bail!(get_error())
+        })
     }
 
     /// The function will fail if the blend mode is not supported by SDL.
@@ -487,17 +491,17 @@ impl SurfaceRef {
         }
     }
 
-    pub fn blend_mode(&self) -> BlendMode {
+    pub fn blend_mode(&self) -> Result<BlendMode, String> {
         let mut mode: ::sys::SDL_BlendMode = 0;
         let result = unsafe {
             ll::SDL_GetSurfaceBlendMode(self.raw(), &mut mode)
         };
 
-        match result {
+        Ok(match result {
             0 => FromPrimitive::from_i32(mode as i32).unwrap(),
             // Should only fail on a null Surface
-            _ => panic!(get_error())
-        }
+            _ => bail!(get_error())
+        })
     }
 
     /// Sets the clip rectangle for the surface.

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -254,8 +254,8 @@ impl SurfaceRef {
         }
     }
 
-    pub fn pixel_format_enum(&self) -> pixels::PixelFormatEnum {
-        pixels::PixelFormatEnum::from(self.pixel_format())
+    pub fn pixel_format_enum(&self) -> Result<pixels::PixelFormatEnum, String> {
+        pixels::PixelFormatEnum::try_from(self.pixel_format())
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -134,16 +134,17 @@ macro_rules! attrs {
         #[doc = "**Sets** the attribute: "]
         #[doc = $doc]
         #[inline]
-        pub fn $set_property(&self, value: $t) {
+        pub fn $set_property(&self, value: $t) -> Result<(), String> {
             gl_set_attribute!($attr_name, value.to_gl_value());
+            Ok(())
         }
 
         #[doc = "**Gets** the attribute: "]
         #[doc = $doc]
         #[inline]
-        pub fn $get_property(&self) -> $t {
+        pub fn $get_property(&self) -> Result<$t, String> {
             let value = gl_get_attribute!($attr_name);
-            GLAttrTypeUtil::from_gl_value(value)
+            Ok(GLAttrTypeUtil::from_gl_value(value))
         }
         )*
     );
@@ -207,7 +208,7 @@ pub mod gl_attr {
 
             if result != 0 {
                 // Panic and print the attribute that failed.
-                panic!("couldn't set attribute {}: {}", stringify!($attr), get_error());
+                bail!("couldn't set attribute {}: {}", stringify!($attr), get_error())
             }
         })
     }
@@ -220,7 +221,7 @@ pub mod gl_attr {
             };
             if result != 0 {
                 // Panic and print the attribute that failed.
-                panic!("couldn't get attribute {}: {}", stringify!($attr), get_error());
+                bail!("couldn't get attribute {}: {}", stringify!($attr), get_error());
             }
             value
         })
@@ -297,15 +298,18 @@ pub mod gl_attr {
 
     /// **Sets** the OpenGL context major and minor versions.
     #[inline]
-    pub fn set_context_version(&self, major: u8, minor: u8) {
-        self.set_context_major_version(major);
-        self.set_context_minor_version(minor);
+    pub fn set_context_version(&self, major: u8, minor: u8) -> Result<(), String> {
+        self.set_context_major_version(major)?;
+        self.set_context_minor_version(minor)?;
+        Ok(())
     }
 
     /// **Gets** the OpenGL context major and minor versions as a tuple.
     #[inline]
-    pub fn context_version(&self) -> (u8, u8) {
-        (self.context_major_version(), self.context_minor_version())
+    pub fn context_version(&self) -> Result<(u8, u8), String> {
+        let major = self.context_major_version()?;
+        let minor = self.context_minor_version()?;
+        Ok((major, minor))
     }
 
     }
@@ -319,8 +323,9 @@ pub mod gl_attr {
     impl<'a> ContextFlagsBuilder<'a> {
         /// Finishes the builder and applies the GL context flags to the GL context.
         #[inline]
-        pub fn set(&self) {
+        pub fn set(&self) -> Result<(), String> {
             gl_set_attribute!(SDL_GL_CONTEXT_FLAGS, self.flags);
+            Ok(())
         }
 
         /// Sets the context into "debug" mode.
@@ -403,12 +408,12 @@ pub mod gl_attr {
     ///     println!("Debug mode");
     /// }
     /// ```
-    pub fn context_flags(&self) -> ContextFlags {
+    pub fn context_flags(&self) -> Result<ContextFlags, String> {
         let flags = gl_get_attribute!(SDL_GL_CONTEXT_FLAGS);
 
-        ContextFlags {
+        Ok(ContextFlags {
             flags: flags
-        }
+        })
     }
 
     }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -546,14 +546,14 @@ pub enum SwapInterval {
     LateSwapTearing = -1,
 }
 
-impl From<i32> for SwapInterval {
-    fn from(i: i32) -> Self {
-        match i {
+impl SwapInterval {
+    pub fn try_from(i: i32) -> Result<Self, String> {
+        Ok(match i {
             -1 => SwapInterval::LateSwapTearing,
             0  => SwapInterval::Immediate,
             1  => SwapInterval::VSync,
-            other => panic!("Invalid value for SwapInterval: {}; valid values are -1, 0, 1", other),
-        }
+            other => bail!("Invalid value for SwapInterval: {}; valid values are -1, 0, 1", other),
+        })
     }
 }
 


### PR DESCRIPTION
***Please Do NOT merge this yet!***

I wanted to give you a heads up about some of the changes I want to make. So far I've been pretty aggressive about looking for calls to `panic!` and replacing them with `bail!` from the `error_chain` crate. At the moment that's just sugar for `return Err(...)`. I have yet to start using any real features of the `error_chain` crate. I'm saving that for a later refactor.

After I get rid of the `panic`s, I know I need to look for other forms of panic such as `unwrap()`.

I'm interested in any feedback you have about these changes. Things you want me to change. Changes you don't want me to make, etc.

My reason for being pretty aggressive about getting rid of `panic` is that if the C code could return an error then it would be nice to get a chance to handle that on the Rust side even if it makes the API seem less elegant.

Thanks!