### PR TITLE
Fix floating-point literal used in pattern in example

### DIFF
--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -16,7 +16,7 @@ impl AudioCallback for SquareWave {
         // Generate a square wave
         for x in out.iter_mut() {
             *x = match self.phase {
-                0.0...0.5 => self.volume,
+                phase if phase < 0.5 => self.volume,
                 _ => -self.volume
             };
             self.phase = (self.phase + self.phase_inc) % 1.0;

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -15,10 +15,7 @@ impl AudioCallback for SquareWave {
     fn callback(&mut self, out: &mut [f32]) {
         // Generate a square wave
         for x in out.iter_mut() {
-            *x = match self.phase {
-                phase if phase < 0.5 => self.volume,
-                _ => -self.volume
-            };
+            *x = if self.phase < 0.5 { self.volume } else { -self.volume };
             self.phase = (self.phase + self.phase_inc) % 1.0;
         }
     }


### PR DESCRIPTION
This PR preemptively fixes the audio-squarewave.rs example from an eventual error when [the rust-lang issue on matching floating point literals](https://github.com/rust-lang/rust/issues/41620) is completed.