### PR TITLE
Make mixer::Channel and mixer::Group fields public

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,10 @@ in `Texture`s in the `render` module.
 * Adds the `Music::from_static_bytes` function, which creates a Music instance with the
 static lifetime from a buffer that also has a static lifetime.
 
+[PR #708](https://github.com/Rust-SDL2/rust-sdl2/pull/708)
+
+* Makes the fields of the `sdl2::mixer::Channel(i32)` and `sdl::mixer::Group(i32)` structs
+
 ### v0.30
 
 Re-exported sdl2\_sys as sdl2::sys

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ static lifetime from a buffer that also has a static lifetime.
 [PR #708](https://github.com/Rust-SDL2/rust-sdl2/pull/708)
 
 * Makes the fields of the `sdl2::mixer::Channel(i32)` and `sdl::mixer::Group(i32)` structs
+public so they can be instantiated directly, and deprecates `sdl2::mixer::channel(i32)`.
 
 ### v0.30
 

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -336,9 +336,10 @@ pub enum Fading {
 
 /// Sound effect channel.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Channel(i32);
+pub struct Channel(pub i32);
 
 /// Return a channel object.
+#[deprecated(since = "0.31.0", note = "use `Channel(i32)` instead")]
 pub fn channel(chan: i32) -> Channel {
     Channel(chan)
 }
@@ -629,7 +630,7 @@ pub fn reserve_channels(num: i32) -> i32 {
 
 /// Sound effect channel grouping.
 #[derive(Copy, Clone)]
-pub struct Group(i32);
+pub struct Group(pub i32);
 
 impl default::Default for Group {
     fn default() -> Group {


### PR DESCRIPTION
Also deprecate the now-unnecessary channel(i32) function.