### PR TITLE
Allow for more versions of c_vec to be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "sdl2-sys"
 version = "0.30.0"
 
 [dependencies.c_vec]
-version = "1.0.*"
+version = ">= 1.0, <= 1.3"
 optional = true
 
 [features]


### PR DESCRIPTION
The reason I'm asking for this change is simply that it makes it easier for a user to use a package which requires `c_vec` version 1.2 (like cairo-rs) and sdl.

otherwise, when using `Cargo`, the user will be faced with the following issue:

```
error: failed to select a version for `c_vec` (required by `sdl2`):
all possible versions conflict with previously selected versions of `c_vec`
  version 1.2.0 in use by c_vec v1.2.0
  possible versions to select: 1.0.12, 1.0.11, 1.0.10, 1.0.9, 1.0.8, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2, 1.0.1, 1.0.0
```

Looking at the history of c_vec, it looks to me that they keep backward compatibility from 1.0.x to 1.3. However, I'm not very familiar with rust to be 100% sure of that.