### PR TITLE
Add missing examples & required features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,13 @@ use_mac_framework = ["sdl2-sys/use_mac_framework"]
 name = "animation"
 
 [[example]]
+name = "audio-capture-and-replay"
+
+[[example]]
 name = "audio-queue-squarewave"
+
+[[example]]
+name = "audio-squarewave"
 
 [[example]]
 name = "audio-wav"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ name = "renderer-texture"
 name = "renderer-yuv"
 
 [[example]]
+required-features = ["ttf", "image"]
 name = "resource-manager"
 
 [[example]]


### PR DESCRIPTION
I was trying to run all examples and hit some issues:

- a couple of them were not defined on `Cargo.toml`
- another was missing `required-features` which resulted in not being able to be built