### PR TITLE
Build examples on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
 script:
 - |
   travis-cargo build -- --features "gfx image ttf mixer" &&
+  travis-cargo build -- --examples --features "gfx image ttf mixer" &&
   travis-cargo test -- --features "gfx image ttf mixer" &&
   travis-cargo --only stable doc -- --features "gfx image ttf mixer"
 after_success:

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -9,13 +9,6 @@ use sdl2::gfx::primitives::DrawRenderer;
 const SCREEN_WIDTH: u32 = 800;
 const SCREEN_HEIGHT: u32 = 600;
 
-// hadle the annoying Rect i32
-macro_rules! rect(
-    ($x:expr, $y:expr, $w:expr, $h:expr) => (
-        sdl2::rect::Rect::new($x as i32, $y as i32, $w as i32, $h as i32)
-    )
-);
-
 fn main() {
     let sdl_context = sdl2::init().unwrap();
     let video_subsys = sdl_context.video().unwrap();


### PR DESCRIPTION
Resolves https://github.com/Rust-SDL2/rust-sdl2/issues/722

While testing this I noticed there's an unused macro (Rust's warning) and removed that.

## Tips for QA

- Introduce a bug in an example
- Run `cargo build --examples --features "gfx image ttf mixer"`
  - Note: `--examples` option was added on [cargo PR3901](https://github.com/rust-lang/cargo/pull/3901)
- Revert the bug
- Run it again