### PR TITLE
Add SDL_GetWindowBordersSize()

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1161,6 +1161,13 @@ impl Window {
     }
     
     /// Use this function to get the size of a window's borders (decorations) around the client area.
+    ///
+    /// # Remarks
+    /// This function is only supported on X11.
+    ///
+    /// #Notes
+    ///
+    /// If this function fails, (0, 0, 0, 0) will be returned
     pub fn border_size(&self) -> (u16, u16, u16, u16) {
         let mut top: c_int = 0;
         let mut left: c_int = 0;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1167,13 +1167,17 @@ impl Window {
     ///
     /// #Notes
     /// If this function fails, (0, 0, 0, 0) will be returned
-    pub fn border_size(&self) -> (u16, u16, u16, u16) {
+    pub fn border_size(&self) -> Result<(u16, u16, u16, u16), String> {
         let mut top: c_int = 0;
         let mut left: c_int = 0;
         let mut bottom: c_int = 0;
         let mut right: c_int = 0;
-        unsafe { sys::SDL_GetWindowBordersSize(self.context.raw, &mut top, &mut left, &mut bottom, &mut right) };
-        (top as u16, left as u16, bottom as u16, right as u16)
+        let result = unsafe { sys::SDL_GetWindowBordersSize(self.context.raw, &mut top, &mut left, &mut bottom, &mut right) };
+        if result < 0 {
+            Err(get_error())
+        } else {
+            Ok((top as u16, left as u16, bottom as u16, right as u16))
+        }
     }
 
     pub fn set_size(&mut self, width: u32, height: u32)

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1163,10 +1163,7 @@ impl Window {
     /// Use this function to get the size of a window's borders (decorations) around the client area.
     ///
     /// # Remarks
-    /// This function is only supported on X11, otherwise (0, 0, 0, 0) is returned.
-    ///
-    /// #Notes
-    /// If this function fails, (0, 0, 0, 0) will be returned
+    /// This function is only supported on X11, otherwise an error is returned.
     pub fn border_size(&self) -> Result<(u16, u16, u16, u16), String> {
         let mut top: c_int = 0;
         let mut left: c_int = 0;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1159,6 +1159,16 @@ impl Window {
         unsafe { sys::SDL_GetWindowPosition(self.context.raw, &mut x, &mut y) };
         (x as i32, y as i32)
     }
+    
+    /// Use this function to get the size of a window's borders (decorations) around the client area.
+    pub fn border_size(&self) -> (i32, i32, i32, i32) {
+        let mut top: c_int = 0;
+        let mut left: c_int = 0;
+        let mut bottom: c_int = 0;
+        let mut right: c_int = 0;
+        unsafe { sys::SDL_GetWindowBordersSize(self.context.raw, &mut top, &mut left, &mut bottom, &mut right) };
+        (top as i32, left as i32, bottom as i32, right as i32)
+    }
 
     pub fn set_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1161,13 +1161,13 @@ impl Window {
     }
     
     /// Use this function to get the size of a window's borders (decorations) around the client area.
-    pub fn border_size(&self) -> (i32, i32, i32, i32) {
+    pub fn border_size(&self) -> (u16, u16, u16, u16) {
         let mut top: c_int = 0;
         let mut left: c_int = 0;
         let mut bottom: c_int = 0;
         let mut right: c_int = 0;
         unsafe { sys::SDL_GetWindowBordersSize(self.context.raw, &mut top, &mut left, &mut bottom, &mut right) };
-        (top as i32, left as i32, bottom as i32, right as i32)
+        (top as u16, left as u16, bottom as u16, right as u16)
     }
 
     pub fn set_size(&mut self, width: u32, height: u32)

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1163,10 +1163,9 @@ impl Window {
     /// Use this function to get the size of a window's borders (decorations) around the client area.
     ///
     /// # Remarks
-    /// This function is only supported on X11.
+    /// This function is only supported on X11, otherwise (0, 0, 0, 0) is returned.
     ///
     /// #Notes
-    ///
     /// If this function fails, (0, 0, 0, 0) will be returned
     pub fn border_size(&self) -> (u16, u16, u16, u16) {
         let mut top: c_int = 0;


### PR DESCRIPTION
Add SDL_GetWindowBordersSize() as `pub fn border_size(&self) -> (i32, i32, i32, i32)` to `Window`