### PR TITLE
Error checking fix for `ClipboardUtil::set_clipboard_text`

### DIFF
--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -33,7 +33,7 @@ impl ClipboardUtil {
             let text = CString::new(text).unwrap();
             let result = sys::SDL_SetClipboardText(text.as_ptr() as *const c_char);
 
-            if result == 0 {
+            if result != 0 {
                 Err(get_error())
             } else {
                 Ok(())


### PR DESCRIPTION
SDL_SetClipboardText returns 0 on success, not failure.  Before this
fix, calling set_clipboard_text successfully would generally return
Err("").