### PR TITLE
Add a sendable EventSender type for pushing events to the event queue

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -111,16 +111,7 @@ impl ::EventSubsystem {
 
     /// Pushes an event to the event queue.
     pub fn push_event(&self, event: Event) -> Result<(), String> {
-        match event.to_ll() {
-            Some(mut raw_event) => {
-                let ok = unsafe { sys::SDL_PushEvent(&mut raw_event) == 1 };
-                if ok { Ok(()) }
-                else { Err(get_error()) }
-            },
-            None => {
-                Err("Cannot push unsupported event type to the queue".to_owned())
-            }
-        }
+        self.event_sender().push_event(event)
     }
 
 
@@ -231,32 +222,17 @@ impl ::EventSubsystem {
     /// ```
     pub fn push_custom_event<T: ::std::any::Any>(&self, event:T)
             -> Result<(), String> {
-        use ::std::any::TypeId;
-        let cet = CUSTOM_EVENT_TYPES.lock().unwrap();
-        let type_id = TypeId::of::<Box<T>>();
+        self.event_sender().push_custom_event(event)
+    }
 
-        let user_event_id = *match cet.type_id_to_sdl_id.get(&type_id) {
-            Some(id) => id,
-            None => {
-                return Err(
-                    "Type is not registered as a custom event type!".to_owned()
-                );
-            }
-        };
-
-        let event_box = Box::new(event);
-        let event = Event::User {
-           timestamp: 0,
-           window_id: 0,
-           type_: user_event_id,
-           code: 0,
-           data1: Box::into_raw(event_box) as *mut c_void,
-           data2: ::std::ptr::null_mut()
-        };
-
-        try!(self.push_event(event));
-
-        Ok(())
+    /// Create an event sender that can be sent to other threads.
+    /// 
+    /// An `EventSender` will not keep the event subsystem alive. If the event subsystem is
+    /// shut down calls to `push_event` and `push_custom_event` will return errors.
+    pub fn event_sender(&self) -> EventSender {
+        EventSender {
+            _priv: (),
+        }
     }
 }
 
@@ -2026,3 +2002,84 @@ mod test {
 
     }
 }
+
+/// A sendible type that can push events to the event queue.
+pub struct EventSender {
+    _priv: (),
+}
+
+impl EventSender {
+    /// Pushes an event to the event queue.
+    pub fn push_event(&self, event: Event) -> Result<(), String> {
+        match event.to_ll() {
+            Some(mut raw_event) => {
+                let ok = unsafe { sys::SDL_PushEvent(&mut raw_event) == 1 };
+                if ok { Ok(()) }
+                else { Err(get_error()) }
+            },
+            None => {
+                Err("Cannot push unsupported event type to the queue".to_owned())
+            }
+        }
+    }
+
+    /// Push a custom event
+    ///
+    /// If the event type ``T`` was not registered using
+    /// [EventSubsystem::register_custom_event]
+    /// (../struct.EventSubsystem.html#method.register_custom_event),
+    /// this method will panic.
+    ///
+    /// # Example: pushing and receiving a custom event
+    /// ```
+    /// struct SomeCustomEvent {
+    ///     a: i32
+    /// }
+    ///
+    /// let sdl = sdl2::init().unwrap();
+    /// let ev = sdl.event().unwrap();
+    /// let mut ep = sdl.event_pump().unwrap();
+    ///
+    /// ev.register_custom_event::<SomeCustomEvent>().unwrap();
+    ///
+    /// let event = SomeCustomEvent { a: 42 };
+    ///
+    /// ev.push_custom_event(event);
+    ///
+    /// let received = ep.poll_event().unwrap(); // or within a for event in ep.poll_iter()
+    /// if received.is_user_event() {
+    ///     let e2 = received.as_user_event_type::<SomeCustomEvent>().unwrap();
+    ///     assert_eq!(e2.a, 42);
+    /// }
+    /// ```
+    pub fn push_custom_event<T: ::std::any::Any>(&self, event:T)
+            -> Result<(), String> {
+        use ::std::any::TypeId;
+        let cet = CUSTOM_EVENT_TYPES.lock().unwrap();
+        let type_id = TypeId::of::<Box<T>>();
+
+        let user_event_id = *match cet.type_id_to_sdl_id.get(&type_id) {
+            Some(id) => id,
+            None => {
+                return Err(
+                    "Type is not registered as a custom event type!".to_owned()
+                );
+            }
+        };
+
+        let event_box = Box::new(event);
+        let event = Event::User {
+           timestamp: 0,
+           window_id: 0,
+           type_: user_event_id,
+           code: 0,
+           data1: Box::into_raw(event_box) as *mut c_void,
+           data2: ::std::ptr::null_mut()
+        };
+
+        try!(self.push_event(event));
+
+        Ok(())
+    }
+}
+

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -81,3 +81,17 @@ fn test4(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
         assert_eq!(e2.a, 42);
     }
 }
+
+#[test]
+fn test_event_sender_no_subsystem() {
+    let sdl = sdl2::init().unwrap();
+    let ev = sdl.event().unwrap();
+    let tx = ev.event_sender();
+
+    assert!(tx.push_event(sdl2::event::Event::AppLowMemory { timestamp: 0 }).is_ok());
+
+    drop(ev);
+
+    // Should return an error now the evet subsystem has been shut down
+    assert!(tx.push_event(sdl2::event::Event::AppLowMemory { timestamp: 0 }).is_err());
+}


### PR DESCRIPTION
`EventSender` does not keep the event subsystem alive and its functions return an error if the event subsystem has been shut down.

Closes #747