### PR TITLE
fix memory leaks on ClipboardUtil::clipboard_text() and filesystem::base_path()

### DIFF
--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -1,4 +1,5 @@
 use std::ffi::{CString, CStr};
+use std::os::raw::c_void;
 use libc::c_char;
 use get_error;
 
@@ -48,7 +49,9 @@ impl ClipboardUtil {
             if buf.is_null() {
                 Err(get_error())
             } else {
-                Ok(CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned())
+                let s = CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned();
+                sys::SDL_free(buf as *mut c_void);
+                Ok(s)
             }
         }
     }

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,6 +1,7 @@
 use std::error;
 use std::ffi::{CStr, CString, NulError};
 use std::fmt;
+use std::os::raw::c_void;
 use get_error;
 use libc::c_char;
 
@@ -9,7 +10,9 @@ use sys;
 pub fn base_path() -> Result<String, String> {
     let result = unsafe {
         let buf = sys::SDL_GetBasePath();
-        CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned()
+        let s = CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned();
+        sys::SDL_free(buf as *mut c_void);
+        s
     };
 
     if result.is_empty() {


### PR DESCRIPTION
Namely SDL_GetBasePath and SDL_GetClipboardText.

For stupid reasons, we have to call SDL_GetClipboardText every frame, and we discovered a pretty bad memory leak if you HAPPENED to have large clipboard content.

There may be other errors of the same pattern, but I haven't looked for them.