### PR TITLE
Fix the mixer demo for sdl2_mixer 2.0.2

### DIFF
--- a/examples/mixer-demo.rs
+++ b/examples/mixer-demo.rs
@@ -26,15 +26,15 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) {
     let sdl = sdl2::init().unwrap();
     let _audio = sdl.audio().unwrap();
     let mut timer = sdl.timer().unwrap();
-    let _mixer_context = sdl2::mixer::init(INIT_MP3 | INIT_FLAC | INIT_MOD | INIT_FLUIDSYNTH |
-                                           INIT_MODPLUG | INIT_OGG)
-            .unwrap();
 
     let frequency = 44_100;
     let format = AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
     let channels = DEFAULT_CHANNELS; // Stereo
     let chunk_size = 1_024;
     sdl2::mixer::open_audio(frequency, format, channels, chunk_size).unwrap();
+    let _mixer_context = sdl2::mixer::init(
+        INIT_MP3 | INIT_FLAC | INIT_MOD | INIT_FLUIDSYNTH | INIT_MODPLUG | INIT_OGG
+    ).unwrap();
 
     // Number of mixing channels available for sound effect `Chunk`s to play
     // simultaneously.


### PR DESCRIPTION
The mixer demo is broken for sdl2_mixer 2.0.2 because Mix_OpenAudio must be called before other functions in the sdl2_mixer library.

https://bugs.archlinux.org/task/56303#comment163521
https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_11.html#SEC11