### PR TITLE
Expose Joystick power level

### DIFF
--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -27,9 +27,13 @@ fn main() {
         }
     }
 
-    if joystick.is_none() {
-        panic!("Couldn't open any joystick");
-    };
+    // Print the joystick's power level, if a joystick was found.
+    match joystick {
+        Some(j) => {
+            println!("\"{}\" power level: {:?}", j.name(), j.power_level().unwrap());
+        },
+        None => panic!("Couldn't open any joystick"),
+    }
 
     for event in sdl_context.event_pump().unwrap().wait_iter() {
         use sdl2::event::Event;


### PR DESCRIPTION
This PR adds a `power_level` method to the `Joystick` type. The method’s signature looks like this:

```rust
pub fn power_level(&self) -> Result<PowerLevel, IntegerOrSdlError>
```

At this stage, due to limitations in SDL2 itself, this method only returns a useful value for XInput devices on Windows, but hopefully SDL2 will improve that in the future! On unsupported platforms, this will currently consistently return `Ok` wrapping `sdl2::joystick::PowerLevel::Unknown` with no error.

On a supported platform, it will return `Ok` wrapping one of `sdl2::joystick::PowerLevel::{Unknown, Empty, Low, Medium, Full, Wired}`, depending on the type and status of the controller. These values mirror those in the underlying SDL2 enum, discarding the “MAX” value which is not used (this appeared to be the norm on other Rust versions of SDL enums)

It should not be possible for this method to return an `IntegerOrSdlError`, as the only case in which the underlying SDL2 method should emit an error is if it is called on a joystick object which is not yet open (the check governing this is that the object passed through to the underlying `SDL_PrivateJoystickValid` function is `NULL`), which should be impossible using the Rust API, however, for consistency with other methods like this, I have implemented it this way. If it would be preferred to discard the error states altogether given they should be impossible using the safe API, I’d be up for making the change.

I’ve also added a power level reading to the joystick example. It prints once when a valid joystick has been found.

Of note is that this method is suitable for use on `GameController` objects via `SDL_GameControllerGetJoystick`, but given the rest of the `Joystick` API is not mirrored in `GameController` I have held off on doing something so rash until discussion in #758 :)

Looking forward to your feedback! :)