### PR TITLE
Add Arch Linux example to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Ubuntu example:
 Fedora example:
 > sudo dnf install SDL2-devel
 
+Arch example:  
+(Arch doesn't have separate regular and development packages, everything goes together.)  
+> sudo pacman -S sdl2
+
 You might also need a C compiler (`gcc`).
 
 ### Mac OS X


### PR DESCRIPTION
There were examples of getting SDL2 development libraries on Ubuntu and Fedora. I've added an Arch Linux example with an explanation of why there's no sdl2-dev or similar package.