### PR TITLE
bumped bitflags to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name       = "sdl2"
 path       = "src/sdl2/lib.rs"
 
 [dependencies]
-bitflags = "0.7"
+bitflags = "1.0"
 libc = "0.2"
 rand = "0.3"
 lazy_static="0.2"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 use std::env;
 use std::path::Path;
 use sdl2::event::Event;
-use sdl2::image::{LoadSurface, INIT_PNG, INIT_JPG};
+use sdl2::image::{LoadSurface, InitFlag};
 use sdl2::keyboard::Keycode;
 use sdl2::mouse::Cursor;
 use sdl2::pixels::Color;
@@ -14,7 +14,7 @@ pub fn run(png: &Path) {
 
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
-    let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG).unwrap();
+    let _image_context = sdl2::image::init(InitFlag::INIT_PNG | InitFlag::INIT_JPG).unwrap();
     let window = video_subsystem.window("rust-sdl2 demo: Cursor", 800, 600)
       .position_centered()
       .build()

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -2,7 +2,7 @@ extern crate sdl2;
 
 use std::env;
 use std::path::Path;
-use sdl2::image::{LoadTexture, INIT_PNG, INIT_JPG};
+use sdl2::image::{LoadTexture, InitFlag};
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
@@ -10,7 +10,7 @@ pub fn run(png: &Path) {
 
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
-    let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG).unwrap();
+    let _image_context = sdl2::image::init(InitFlag::INIT_PNG | InitFlag::INIT_JPG).unwrap();
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
       .position_centered()
       .build()

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -27,7 +27,7 @@ pub fn main() {
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
                     let res =
-                        show_simple_message_box(MESSAGEBOX_ERROR,
+                        show_simple_message_box(MessageBoxFlag::MESSAGEBOX_ERROR,
                                                 "Some title",
                                                 "Some information inside the window",
                                                 canvas.window());
@@ -47,22 +47,22 @@ pub fn main() {
     }
     let buttons : Vec<_> = vec![
         ButtonData {
-            flags:MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT,
+            flags:MessageBoxButtonFlag::MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT,
             button_id:1,
             text:"Ok"
         },
         ButtonData {
-            flags:MESSAGEBOX_BUTTON_NOTHING,
+            flags:MessageBoxButtonFlag::MESSAGEBOX_BUTTON_NOTHING,
             button_id:2,
             text:"No"
         },
         ButtonData {
-            flags:MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT,
+            flags:MessageBoxButtonFlag::MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT,
             button_id:3,
             text:"Cancel"
         },
     ];
-    let res = show_message_box(MESSAGEBOX_WARNING,
+    let res = show_message_box(MessageBoxFlag::MESSAGEBOX_WARNING,
                                buttons.as_slice(),
                                "Some warning",
                                "You forget to do something, do it anyway ?",

--- a/examples/resource-manager.rs
+++ b/examples/resource-manager.rs
@@ -1,7 +1,7 @@
 extern crate sdl2;
 
 use sdl2::event::Event;
-use sdl2::image::{LoadTexture, INIT_PNG, INIT_JPG};
+use sdl2::image::{LoadTexture, InitFlag};
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::render::{TextureCreator, Texture};
@@ -25,7 +25,7 @@ fn main() {
         let sdl_context = sdl2::init().unwrap();
         let video_subsystem = sdl_context.video().unwrap();
         let font_context = sdl2::ttf::init().unwrap();
-        let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG).unwrap();
+        let _image_context = sdl2::image::init(InitFlag::INIT_PNG | InitFlag::INIT_JPG).unwrap();
         let window = video_subsystem
             .window("rust-sdl2 resource-manager demo", 800, 600)
             .position_centered()

--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -60,7 +60,7 @@ fn run(font_path: &Path) {
     // Load a font
     let mut font = ttf_context.load_font(font_path, 128).unwrap();
     font.set_style(sdl2::ttf::STYLE_BOLD);
-    
+
     // render a surface, and convert it to a texture bound to the canvas
     let surface = font.render("Hello Rust!")
         .blended(Color::RGBA(255, 0, 0, 255)).unwrap();

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -54,27 +54,27 @@ mod ffi;
 /// InitFlags are passed to init() to control which subsystem
 /// functionality to load.
 bitflags! {
-    pub flags InitFlag : u32 {
-        const INIT_JPG  = ffi::IMG_INIT_JPG as u32,
-        const INIT_PNG  = ffi::IMG_INIT_PNG as u32,
-        const INIT_TIF  = ffi::IMG_INIT_TIF as u32,
-        const INIT_WEBP = ffi::IMG_INIT_WEBP as u32
+    pub struct InitFlag : u32 {
+        const INIT_JPG  = ffi::IMG_INIT_JPG as u32;
+        const INIT_PNG  = ffi::IMG_INIT_PNG as u32;
+        const INIT_TIF  = ffi::IMG_INIT_TIF as u32;
+        const INIT_WEBP = ffi::IMG_INIT_WEBP as u32;
     }
 }
 
 // This is used for error message for init
 impl ::std::fmt::Display for InitFlag {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        if self.contains(INIT_JPG) {
+        if self.contains(InitFlag::INIT_JPG) {
             try!(f.write_str("INIT_JPG "));
         }
-        if self.contains(INIT_PNG) {
+        if self.contains(InitFlag::INIT_PNG) {
             try!(f.write_str("INIT_PNG "));
         }
-        if self.contains(INIT_TIF) {
+        if self.contains(InitFlag::INIT_TIF) {
             try!(f.write_str("INIT_TIF "));
         }
-        if self.contains(INIT_WEBP) {
+        if self.contains(InitFlag::INIT_WEBP) {
             try!(f.write_str("INIT_WEBP "));
         }
         Ok(())

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -11,20 +11,20 @@ pub use self::keycode::Keycode;
 pub use self::scancode::Scancode;
 
 bitflags! {
-    pub flags Mod: u16 {
-        const NOMOD = 0x0000,
-        const LSHIFTMOD = 0x0001,
-        const RSHIFTMOD = 0x0002,
-        const LCTRLMOD = 0x0040,
-        const RCTRLMOD = 0x0080,
-        const LALTMOD = 0x0100,
-        const RALTMOD = 0x0200,
-        const LGUIMOD = 0x0400,
-        const RGUIMOD = 0x0800,
-        const NUMMOD = 0x1000,
-        const CAPSMOD = 0x2000,
-        const MODEMOD = 0x4000,
-        const RESERVEDMOD = 0x8000
+    pub struct Mod: u16 {
+        const NOMOD = 0x0000;
+        const LSHIFTMOD = 0x0001;
+        const RSHIFTMOD = 0x0002;
+        const LCTRLMOD = 0x0040;
+        const RCTRLMOD = 0x0080;
+        const LALTMOD = 0x0100;
+        const RALTMOD = 0x0200;
+        const LGUIMOD = 0x0400;
+        const RGUIMOD = 0x0800;
+        const NUMMOD = 0x1000;
+        const CAPSMOD = 0x2000;
+        const MODEMOD = 0x4000;
+        const RESERVEDMOD = 0x8000;
     }
 }
 

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -10,23 +10,23 @@ use get_error;
 use sys;
 
 bitflags! {
-    pub flags MessageBoxFlag: u32 {
+    pub struct MessageBoxFlag: u32 {
         const MESSAGEBOX_ERROR =
-            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_ERROR as u32,
+            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_ERROR as u32;
         const MESSAGEBOX_WARNING =
-            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_WARNING as u32,
+            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_WARNING as u32;
         const MESSAGEBOX_INFORMATION =
-            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_INFORMATION as u32
+            sys::SDL_MessageBoxFlags::SDL_MESSAGEBOX_INFORMATION as u32;
     }
 }
 
 bitflags! {
-    pub flags MessageBoxButtonFlag: u32 {
+    pub struct MessageBoxButtonFlag: u32 {
         const MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT =
-            sys::SDL_MessageBoxButtonFlags::SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT as u32,
+            sys::SDL_MessageBoxButtonFlags::SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT as u32;
         const MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT =
-            sys::SDL_MessageBoxButtonFlags::SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT as u32,
-        const MESSAGEBOX_BUTTON_NOTHING = 0
+            sys::SDL_MessageBoxButtonFlags::SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT as u32;
+        const MESSAGEBOX_BUTTON_NOTHING = 0;
     }
 }
 

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -16,12 +16,12 @@ use super::ffi;
 // Absolute paths are a workaround for https://github.com/rust-lang-nursery/bitflags/issues/39 .
 bitflags! {
     /// The styling of a font.
-    pub flags FontStyle: i32 {
-        const STYLE_NORMAL        = ffi::TTF_STYLE_NORMAL as i32,
-        const STYLE_BOLD          = ffi::TTF_STYLE_BOLD as i32,
-        const STYLE_ITALIC        = ffi::TTF_STYLE_ITALIC as i32,
-        const STYLE_UNDERLINE     = ffi::TTF_STYLE_UNDERLINE as i32,
-        const STYLE_STRIKETHROUGH = ffi::TTF_STYLE_STRIKETHROUGH as i32,
+    pub struct FontStyle: i32 {
+        const STYLE_NORMAL        = ffi::TTF_STYLE_NORMAL as i32;
+        const STYLE_BOLD          = ffi::TTF_STYLE_BOLD as i32;
+        const STYLE_ITALIC        = ffi::TTF_STYLE_ITALIC as i32;
+        const STYLE_UNDERLINE     = ffi::TTF_STYLE_UNDERLINE as i32;
+        const STYLE_STRIKETHROUGH = ffi::TTF_STYLE_STRIKETHROUGH as i32;
     }
 }
 

--- a/src/sdl2/ttf/mod.rs
+++ b/src/sdl2/ttf/mod.rs
@@ -1,7 +1,7 @@
 //!
 //! A binding for the library `SDL2_ttf`
 //!
-//! 
+//!
 //! Note that you need to build with the
 //! feature `ttf` for this module to be enabled,
 //! like so:
@@ -48,5 +48,5 @@ pub use self::context::{
 };
 pub use self::font::{
     Font, FontStyle, Hinting, GlyphMetrics, PartialRendering, FontError,
-    FontResult, STYLE_NORMAL, STYLE_BOLD, STYLE_ITALIC, STYLE_UNDERLINE, STYLE_STRIKETHROUGH
+    FontResult
 };


### PR DESCRIPTION
Breaking change of bitflags from 0.7 to 1.0:

> since 0.9.0
> [breaking change] Use struct keyword instead of flags to define bitflag types
> [breaking change] Terminate const items with semicolons instead of commas
> 
> since 1.0.0
> [breaking change] Macro now generates associated constants
> [breaking change] Minimum supported version is Rust 1.20, due to usage of associated constants

The major changes to rust-sdl2 is `bitflags now generates associated constants`, codes should be change from:

    use sdl2::image::{LoadTexture, INIT_PNG, INIT_JPG};
    let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG).unwrap();

to:

    use sdl2::image::{LoadTexture, InitFlag};
    let _image_context = sdl2::image::init(InitFlag::INIT_PNG | InitFlag::INIT_JPG).unwrap();

Flags affected in sdl2-rust listed here:

- `sdl2::image::InitFlag`
- `sdl2::keyboard::Mod`
- `sdl2::messagebox::MessageBoxFlag`
- `sdl2::messagebox::MessageBoxButtonFlag`
- `sdl2::ttf::FontStyle`
