### PR TITLE
Add a #[must_use] directive to add_timer()

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -13,6 +13,7 @@ impl TimerSubsystem {
     ///
     /// * when the timer is dropped
     /// * or when the callback returns a non-positive continuation interval
+    #[must_use = "if unused the Timer will be dropped immediately"]
     pub fn add_timer<'b, 'c>(&'b self, delay: u32, callback: TimerCallback<'c>) -> Timer<'b, 'c> {
         unsafe {
             let callback = Box::new(callback);


### PR DESCRIPTION
If the result of add_timer is unused, the timer will be dropped immediately and the callback won't fire. A small gotcha, and this change can save some debugging time.