### PR TITLE
Fix proposal: safe unwrap of keyboard::Mod

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -1262,12 +1262,13 @@ impl Event {
 
             EventType::KeyDown => {
                 let event = raw.key;
+
                 Event::KeyDown {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
                     keycode: Keycode::from_i32(event.keysym.sym as i32),
                     scancode: Scancode::from_i32(event.keysym.scancode as i32),
-                    keymod: keyboard::Mod::from_bits(event.keysym.mod_).unwrap(),
+                    keymod: Event::unwrap_keymod(keyboard::Mod::from_bits(event.keysym.mod_)),
                     repeat: event.repeat != 0
                 }
             }
@@ -1605,6 +1606,13 @@ impl Event {
                 }
             }
         }}                      // close unsafe & match
+    }
+
+    pub fn unwrap_keymod(keymod_option: Option<keyboard::Mod>) -> keyboard::Mod {
+        match keymod_option {
+            None => keyboard::Mod::empty(),
+            Some(x) => x,
+        }
     }
 
     pub fn is_user_event(&self) -> bool {


### PR DESCRIPTION
I had some trouble with panics caused by the unwrap of the keymod on the KeyDown event and changed the code to default to keyboard::Mod::empty().

To me that makes sense and solved the issue, but I am aware that in general this behavior might not be wanted.