### PR TITLE
Audio safety fixes

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -60,7 +60,6 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::marker::PhantomData;
 use std::mem;
-use std::mem::transmute;
 use std::ptr;
 
 use AudioSubsystem;
@@ -209,12 +208,16 @@ pub enum AudioStatus {
 impl FromPrimitive for AudioStatus {
     fn from_i64(n: i64) -> Option<AudioStatus> {
         use self::AudioStatus::*;
-        let n = n as u32;
 
-        Some( match unsafe { transmute::<u32, sys::SDL_AudioStatus>(n) } {
-            sys::SDL_AudioStatus::SDL_AUDIO_STOPPED => Stopped,
-            sys::SDL_AudioStatus::SDL_AUDIO_PLAYING => Playing,
-            sys::SDL_AudioStatus::SDL_AUDIO_PAUSED  => Paused,
+        const STOPPED: i64 = sys::SDL_AudioStatus::SDL_AUDIO_STOPPED as i64;
+        const PLAYING: i64 = sys::SDL_AudioStatus::SDL_AUDIO_PLAYING as i64;
+        const PAUSED: i64 = sys::SDL_AudioStatus::SDL_AUDIO_PAUSED as i64;
+
+        Some(match n {
+            STOPPED => Stopped,
+            PLAYING => Playing,
+            PAUSED  => Paused,
+            _ => return None,
         })
     }
 


### PR DESCRIPTION
I had an assert in `get_callback` and noticed when it failed the program segfaulted, this was due to the userdata here https://github.com/Thinkofname/rust-sdl2/commit/0ca64698e97776ef1754da97b4856bc6ef9190ad#diff-93048819a6101989491fb36a4efc59cbL639 being freed with uninitialized memory. This seemed like the safest way to fix it but there could be a better way.

The AudioStatus change is just something I saw when reading through, the use of transmute seemed a bit funny there and could introduce undefined behaviour in safe code.