### PR TITLE
Make getting-started example copy-paste friendly

### DIFF
--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -1,6 +1,8 @@
 //! # Getting started
 //!
 //! ```rust,no_run
+//! extern crate sdl2; 
+//!
 //! use sdl2::pixels::Color;
 //! use sdl2::event::Event;
 //! use sdl2::keyboard::Keycode;


### PR DESCRIPTION
Make getting-started example copy-paste friendly by adding "extern crate sdl2;" line.

When I was starting to read the docs, the first thing I did was copy-paste this example into a file to play with it but without this line, it doesn't compile (easy enough to fix, but wanted to fix it at the source).

From reading the contributing guidelines, this appears to be small enough/documentation only, so I didn't think it required a changelog update.