### PR TITLE
"Install" Windows dynamic libraries

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -330,7 +330,7 @@ fn main() {
     let host = env::var("HOST").expect("Cargo build scripts always have HOST");
     let target_os = get_os_from_triple(target.as_str()).unwrap();
 
-    let sdl2_compiled_path;
+    let sdl2_compiled_path: PathBuf;
     #[cfg(feature = "bundled")] {
         let sdl2_source_path = download_sdl2();
         sdl2_compiled_path = compile_sdl2(sdl2_source_path.as_path(), target_os);


### PR DESCRIPTION
Windows binaries don't embed library search paths, so tests were
failing for being unable to find sdl2.dll. This commit adds some
logic to copy that DLL into a known-good location.