### PR TITLE
Fix compilation failure on Windows when using 'bundled' and 'use-bindgen' features

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -22,10 +22,10 @@ use std::path::{Path, PathBuf};
 use std::{io, fs, env};
 
 // corresponds to the headers that we have in sdl2-sys/SDL2-{version}
-const SDL2_HEADERS_BUNDLED_VERSION: &str = "2.0.5";
+const SDL2_HEADERS_BUNDLED_VERSION: &str = "2.0.8";
 
 // means the lastest stable version that can be downloaded from SDL2's source
-const LASTEST_SDL2_VERSION: &str = "2.0.5";
+const LASTEST_SDL2_VERSION: &str = "2.0.8";
 
 #[cfg(feature = "bindgen")]
 macro_rules! add_msvc_includes_to_bindings {
@@ -177,10 +177,10 @@ fn patch_sdl2(sdl2_source_path: &Path) {
                 // Skip lines in old_file, and verify that what we expect to
                 // replace is present in the old_file.
                 for expected_line in hunk.source_lines() {
-                let mut actual_line = String::new();
-                old_buf.read_line(&mut actual_line).unwrap();
-                actual_line.pop(); // Remove the trailing newline.
-                    if expected_line.value != actual_line {
+                    let mut actual_line = String::new();
+                    old_buf.read_line(&mut actual_line).unwrap();
+                    actual_line.pop(); // Remove the trailing newline.
+                    if expected_line.value.trim_end() != actual_line {
                         panic!("Can't apply patch; mismatch between expected and actual in hunk {}", i);
                     }
                 }
@@ -677,6 +677,7 @@ fn generate_bindings<S: AsRef<str> + ::std::fmt::Debug>(target: &str, host: &str
         .blacklist_type("FP_SUBNORMAL")
         .blacklist_type("FP_NORMAL")
         .blacklist_type("max_align_t") // Until https://github.com/rust-lang-nursery/rust-bindgen/issues/550 gets fixed
+        .derive_debug(false)
         .generate()
         .expect("Unable to generate bindings!");
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -691,6 +691,7 @@ pub enum Event {
 
     DropFile {
         timestamp: u32,
+        window_id: u32,
         filename: String
     },
 
@@ -1573,6 +1574,7 @@ impl Event {
 
                 Event::DropFile {
                     timestamp: event.timestamp,
+                    window_id: event.windowID,
                     filename: text
                 }
             }

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -65,9 +65,16 @@ fn clamped_mul(a: i32, b: i32) -> i32 {
 /// recommended to use `Option<Rect>`, with `None` representing an empty
 /// rectangle (see, for example, the output of the
 /// [`intersection`](#method.intersection) method).
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Rect {
     raw: sys::SDL_Rect,
+}
+
+impl std::fmt::Debug for Rect {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        return write!(fmt, "Rect {{ x: {}, y: {}, w: {}, h: {} }}",
+            self.raw.x, self.raw.y, self.raw.w, self.raw.h);
+    }
 }
 
 impl PartialEq for Rect {
@@ -653,9 +660,15 @@ impl BitOr<Rect> for Rect {
 }
 
 /// Immutable point type, consisting of x and y.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct Point {
     raw: sys::SDL_Point
+}
+
+impl std::fmt::Debug for Point {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        return write!(fmt, "Point {{ x: {}, y: {} }}", self.raw.x, self.raw.y);
+    }
 }
 
 impl PartialEq for Point {


### PR DESCRIPTION
Currently, compilation fails on Windows when simultaneously using the 'bundled' and 'use-bindgen' feature. This is due to 2 separate problems:

1) The new vulkan support requires minimum of SDL version 2,0.8 but build script is still pulling 2.0.5, resulting in SDL_vulkan.h header not found.
2) Debug is not implemented for arrays whose size are too big - see issue #771. This is because Rust does not automatically provide Debug implementations for arrays whose size are > 32.

This pull request fixes both problems. Note that to fix the second problem, bindgen is configured to not generate #[derive(Debug)]. I'm not sure if this is the right way to fix this, but Debug wasn't really used in the public interface of rust-sdl2 anyway, except for Rect and Point. For this 2 structs, I manually implemented Debug as a substitute.

I only tested this on Windows 10 x64. Please help test this on other platforms.