### PR TITLE
Fix `use-bindgen` feature on non-windows platforms

### DIFF
--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config.h
@@ -19,239 +19,37 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_windows_h_
-#define SDL_config_windows_h_
+#ifndef SDL_config_h_
 #define SDL_config_h_
 
 #include "SDL_platform.h"
 
-/* This is a set of defines to configure the SDL features */
+/**
+ *  \file SDL_config.h
+ */
 
-#if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
-#if defined(__GNUC__) || defined(__DMC__) || defined(__WATCOMC__)
-#define HAVE_STDINT_H   1
-#elif defined(_MSC_VER)
-typedef signed __int8 int8_t;
-typedef unsigned __int8 uint8_t;
-typedef signed __int16 int16_t;
-typedef unsigned __int16 uint16_t;
-typedef signed __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef signed __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#ifndef _UINTPTR_T_DEFINED
-#ifdef  _WIN64
-typedef unsigned __int64 uintptr_t;
+/* Add any platform that doesn't build using the configure system. */
+#if defined(__WIN32__)
+#include "SDL_config_windows.h"
+#elif defined(__WINRT__)
+#include "SDL_config_winrt.h"
+#elif defined(__MACOSX__)
+#include "SDL_config_macosx.h"
+#elif defined(__IPHONEOS__)
+#include "SDL_config_iphoneos.h"
+#elif defined(__ANDROID__)
+#include "SDL_config_android.h"
+#elif defined(__PSP__)
+#include "SDL_config_psp.h"
+#elif defined(__OS2__)
+#include "SDL_config_os2.h"
 #else
-typedef unsigned int uintptr_t;
-#endif
-#define _UINTPTR_T_DEFINED
-#endif
-/* Older Visual C++ headers don't have the Win64-compatible typedefs... */
-#if ((_MSC_VER <= 1200) && (!defined(DWORD_PTR)))
-#define DWORD_PTR DWORD
-#endif
-#if ((_MSC_VER <= 1200) && (!defined(LONG_PTR)))
-#define LONG_PTR LONG
-#endif
-#else /* !__GNUC__ && !_MSC_VER */
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int16_t;
-typedef unsigned short uint16_t;
-typedef signed int int32_t;
-typedef unsigned int uint32_t;
-typedef signed long long int64_t;
-typedef unsigned long long uint64_t;
-#ifndef _SIZE_T_DEFINED_
-#define _SIZE_T_DEFINED_
-typedef unsigned int size_t;
-#endif
-typedef unsigned int uintptr_t;
-#endif /* __GNUC__ || _MSC_VER */
-#endif /* !_STDINT_H_ && !HAVE_STDINT_H */
+/* This is a minimal configuration just to get SDL running on new platforms. */
+#include "SDL_config_minimal.h"
+#endif /* platform config */
 
-#ifdef _WIN64
-# define SIZEOF_VOIDP 8
-#else
-# define SIZEOF_VOIDP 4
+#ifdef USING_GENERATED_CONFIG_H
+#error Wrong SDL_config.h, check your include path?
 #endif
 
-#define HAVE_DDRAW_H 1
-#define HAVE_DINPUT_H 1
-#define HAVE_DSOUND_H 1
-#define HAVE_DXGI_H 1
-#define HAVE_XINPUT_H 1
-#define HAVE_MMDEVICEAPI_H 1
-#define HAVE_AUDIOCLIENT_H 1
-#define HAVE_ENDPOINTVOLUME_H 1
-
-/* This is disabled by default to avoid C runtime dependencies and manifest requirements */
-#ifdef HAVE_LIBC
-/* Useful headers */
-#define STDC_HEADERS 1
-#define HAVE_CTYPE_H 1
-#define HAVE_FLOAT_H 1
-#define HAVE_LIMITS_H 1
-#define HAVE_MATH_H 1
-#define HAVE_SIGNAL_H 1
-#define HAVE_STDIO_H 1
-#define HAVE_STRING_H 1
-
-/* C library functions */
-#define HAVE_MALLOC 1
-#define HAVE_CALLOC 1
-#define HAVE_REALLOC 1
-#define HAVE_FREE 1
-#define HAVE_ALLOCA 1
-#define HAVE_QSORT 1
-#define HAVE_ABS 1
-#define HAVE_MEMSET 1
-#define HAVE_MEMCPY 1
-#define HAVE_MEMMOVE 1
-#define HAVE_MEMCMP 1
-#define HAVE_STRLEN 1
-#define HAVE__STRREV 1
-/* These functions have security warnings, so we won't use them */
-/* #undef HAVE__STRUPR */
-/* #undef HAVE__STRLWR */
-#define HAVE_STRCHR 1
-#define HAVE_STRRCHR 1
-#define HAVE_STRSTR 1
-/* These functions have security warnings, so we won't use them */
-/* #undef HAVE__LTOA */
-/* #undef HAVE__ULTOA */
-#define HAVE_STRTOL 1
-#define HAVE_STRTOUL 1
-#define HAVE_STRTOD 1
-#define HAVE_ATOI 1
-#define HAVE_ATOF 1
-#define HAVE_STRCMP 1
-#define HAVE_STRNCMP 1
-#define HAVE__STRICMP 1
-#define HAVE__STRNICMP 1
-#define HAVE_ACOS   1
-#define HAVE_ACOSF  1
-#define HAVE_ASIN   1
-#define HAVE_ASINF  1
-#define HAVE_ATAN   1
-#define HAVE_ATANF  1
-#define HAVE_ATAN2  1
-#define HAVE_ATAN2F 1
-#define HAVE_CEILF  1
-#define HAVE__COPYSIGN  1
-#define HAVE_COS    1
-#define HAVE_COSF   1
-#define HAVE_EXP    1
-#define HAVE_EXPF   1
-#define HAVE_FABS   1
-#define HAVE_FABSF  1
-#define HAVE_FLOOR  1
-#define HAVE_FLOORF 1
-#define HAVE_FMOD   1
-#define HAVE_FMODF  1
-#define HAVE_LOG    1
-#define HAVE_LOGF   1
-#define HAVE_LOG10  1
-#define HAVE_LOG10F 1
-#define HAVE_POW    1
-#define HAVE_POWF   1
-#define HAVE_SIN    1
-#define HAVE_SINF   1
-#define HAVE_SQRT   1
-#define HAVE_SQRTF  1
-#define HAVE_TAN    1
-#define HAVE_TANF   1
-#if defined(_MSC_VER)
-/* These functions were added with the VC++ 2013 C runtime library */
-#if _MSC_VER >= 1800
-#define HAVE_STRTOLL 1
-#define HAVE_VSSCANF 1
-#define HAVE_SCALBN 1
-#define HAVE_SCALBNF    1
-#endif
-/* This function is available with at least the VC++ 2008 C runtime library */
-#if _MSC_VER >= 1400
-#define HAVE__FSEEKI64 1
-#endif
-#endif
-#if !defined(_MSC_VER) || defined(_USE_MATH_DEFINES)
-#define HAVE_M_PI 1
-#endif
-#else
-#define HAVE_STDARG_H   1
-#define HAVE_STDDEF_H   1
-#endif
-
-/* Enable various audio drivers */
-#define SDL_AUDIO_DRIVER_WASAPI 1
-#define SDL_AUDIO_DRIVER_DSOUND 1
-#define SDL_AUDIO_DRIVER_WINMM  1
-#define SDL_AUDIO_DRIVER_DISK   1
-#define SDL_AUDIO_DRIVER_DUMMY  1
-
-/* Enable various input drivers */
-#define SDL_JOYSTICK_DINPUT 1
-#define SDL_JOYSTICK_XINPUT 1
-#define SDL_JOYSTICK_HIDAPI 1
-#define SDL_HAPTIC_DINPUT   1
-#define SDL_HAPTIC_XINPUT   1
-
-/* Enable the dummy sensor driver */
-#define SDL_SENSOR_DUMMY  1
-
-/* Enable various shared object loading systems */
-#define SDL_LOADSO_WINDOWS  1
-
-/* Enable various threading systems */
-#define SDL_THREAD_WINDOWS  1
-
-/* Enable various timer systems */
-#define SDL_TIMER_WINDOWS   1
-
-/* Enable various video drivers */
-#define SDL_VIDEO_DRIVER_DUMMY  1
-#define SDL_VIDEO_DRIVER_WINDOWS    1
-
-#ifndef SDL_VIDEO_RENDER_D3D
-#define SDL_VIDEO_RENDER_D3D    1
-#endif
-#ifndef SDL_VIDEO_RENDER_D3D11
-#define SDL_VIDEO_RENDER_D3D11  0
-#endif
-
-/* Enable OpenGL support */
-#ifndef SDL_VIDEO_OPENGL
-#define SDL_VIDEO_OPENGL    1
-#endif
-#ifndef SDL_VIDEO_OPENGL_WGL
-#define SDL_VIDEO_OPENGL_WGL    1
-#endif
-#ifndef SDL_VIDEO_RENDER_OGL
-#define SDL_VIDEO_RENDER_OGL    1
-#endif
-#ifndef SDL_VIDEO_RENDER_OGL_ES2
-#define SDL_VIDEO_RENDER_OGL_ES2    1
-#endif
-#ifndef SDL_VIDEO_OPENGL_ES2
-#define SDL_VIDEO_OPENGL_ES2    1
-#endif
-#ifndef SDL_VIDEO_OPENGL_EGL
-#define SDL_VIDEO_OPENGL_EGL    1
-#endif
-
-/* Enable Vulkan support */
-#define SDL_VIDEO_VULKAN 1
-
-/* Enable system power support */
-#define SDL_POWER_WINDOWS 1
-
-/* Enable filesystem support */
-#define SDL_FILESYSTEM_WINDOWS  1
-
-/* Enable assembly routines (Win64 doesn't have inline asm) */
-#ifndef _WIN64
-#define SDL_ASSEMBLY_ROUTINES   1
-#endif
-
-#endif /* SDL_config_windows_h_ */
+#endif /* SDL_config_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config.h.cmake
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config.h.cmake
@@ -1,0 +1,476 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_h_
+#define SDL_config_h_
+
+/**
+ *  \file SDL_config.h.in
+ *
+ *  This is a set of defines to configure the SDL features
+ */
+
+/* General platform specific identifiers */
+#include "SDL_platform.h"
+
+/* C language features */
+#cmakedefine const @HAVE_CONST@
+#cmakedefine inline @HAVE_INLINE@
+#cmakedefine volatile @HAVE_VOLATILE@
+
+/* C datatypes */
+/* Define SIZEOF_VOIDP for 64/32 architectures */
+#ifdef __LP64__
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+
+#cmakedefine HAVE_GCC_ATOMICS @HAVE_GCC_ATOMICS@
+#cmakedefine HAVE_GCC_SYNC_LOCK_TEST_AND_SET @HAVE_GCC_SYNC_LOCK_TEST_AND_SET@
+
+/* Comment this if you want to build without any C library requirements */
+#cmakedefine HAVE_LIBC 1
+#if HAVE_LIBC
+
+/* Useful headers */
+#cmakedefine STDC_HEADERS 1
+#cmakedefine HAVE_ALLOCA_H 1
+#cmakedefine HAVE_CTYPE_H 1
+#cmakedefine HAVE_FLOAT_H 1
+#cmakedefine HAVE_ICONV_H 1
+#cmakedefine HAVE_INTTYPES_H 1
+#cmakedefine HAVE_LIMITS_H 1
+#cmakedefine HAVE_MALLOC_H 1
+#cmakedefine HAVE_MATH_H 1
+#cmakedefine HAVE_MEMORY_H 1
+#cmakedefine HAVE_SIGNAL_H 1
+#cmakedefine HAVE_STDARG_H 1
+#cmakedefine HAVE_STDINT_H 1
+#cmakedefine HAVE_STDIO_H 1
+#cmakedefine HAVE_STDLIB_H 1
+#cmakedefine HAVE_STRINGS_H 1
+#cmakedefine HAVE_STRING_H 1
+#cmakedefine HAVE_SYS_TYPES_H 1
+#cmakedefine HAVE_WCHAR_H 1
+#cmakedefine HAVE_PTHREAD_NP_H 1
+#cmakedefine HAVE_LIBUNWIND_H 1
+
+/* C library functions */
+#cmakedefine HAVE_MALLOC 1
+#cmakedefine HAVE_CALLOC 1
+#cmakedefine HAVE_REALLOC 1
+#cmakedefine HAVE_FREE 1
+#cmakedefine HAVE_ALLOCA 1
+#ifndef __WIN32__ /* Don't use C runtime versions of these on Windows */
+#cmakedefine HAVE_GETENV 1
+#cmakedefine HAVE_SETENV 1
+#cmakedefine HAVE_PUTENV 1
+#cmakedefine HAVE_UNSETENV 1
+#endif
+#cmakedefine HAVE_QSORT 1
+#cmakedefine HAVE_ABS 1
+#cmakedefine HAVE_BCOPY 1
+#cmakedefine HAVE_MEMSET 1
+#cmakedefine HAVE_MEMCPY 1
+#cmakedefine HAVE_MEMMOVE 1
+#cmakedefine HAVE_MEMCMP 1
+#cmakedefine HAVE_WCSLEN 1
+#cmakedefine HAVE_WCSLCPY 1
+#cmakedefine HAVE_WCSLCAT 1
+#cmakedefine HAVE_WCSCMP 1
+#cmakedefine HAVE_STRLEN 1
+#cmakedefine HAVE_STRLCPY 1
+#cmakedefine HAVE_STRLCAT 1
+#cmakedefine HAVE__STRREV 1
+#cmakedefine HAVE__STRUPR 1
+#cmakedefine HAVE__STRLWR 1
+#cmakedefine HAVE_INDEX 1
+#cmakedefine HAVE_RINDEX 1
+#cmakedefine HAVE_STRCHR 1
+#cmakedefine HAVE_STRRCHR 1
+#cmakedefine HAVE_STRSTR 1
+#cmakedefine HAVE_ITOA 1
+#cmakedefine HAVE__LTOA 1
+#cmakedefine HAVE__UITOA 1
+#cmakedefine HAVE__ULTOA 1
+#cmakedefine HAVE_STRTOL 1
+#cmakedefine HAVE_STRTOUL 1
+#cmakedefine HAVE__I64TOA 1
+#cmakedefine HAVE__UI64TOA 1
+#cmakedefine HAVE_STRTOLL 1
+#cmakedefine HAVE_STRTOULL 1
+#cmakedefine HAVE_STRTOD 1
+#cmakedefine HAVE_ATOI 1
+#cmakedefine HAVE_ATOF 1
+#cmakedefine HAVE_STRCMP 1
+#cmakedefine HAVE_STRNCMP 1
+#cmakedefine HAVE__STRICMP 1
+#cmakedefine HAVE_STRCASECMP 1
+#cmakedefine HAVE__STRNICMP 1
+#cmakedefine HAVE_STRNCASECMP 1
+#cmakedefine HAVE_VSSCANF 1
+#cmakedefine HAVE_VSNPRINTF 1
+#cmakedefine HAVE_M_PI 1
+#cmakedefine HAVE_ACOS 1
+#cmakedefine HAVE_ACOSF 1
+#cmakedefine HAVE_ASIN 1
+#cmakedefine HAVE_ASINF 1
+#cmakedefine HAVE_ATAN 1
+#cmakedefine HAVE_ATANF 1
+#cmakedefine HAVE_ATAN2 1
+#cmakedefine HAVE_ATAN2F 1
+#cmakedefine HAVE_CEIL 1
+#cmakedefine HAVE_CEILF 1
+#cmakedefine HAVE_COPYSIGN 1
+#cmakedefine HAVE_COPYSIGNF 1
+#cmakedefine HAVE_COS 1
+#cmakedefine HAVE_COSF 1
+#cmakedefine HAVE_EXP 1
+#cmakedefine HAVE_EXPF 1
+#cmakedefine HAVE_FABS 1
+#cmakedefine HAVE_FABSF 1
+#cmakedefine HAVE_FLOOR 1
+#cmakedefine HAVE_FLOORF 1
+#cmakedefine HAVE_FMOD 1
+#cmakedefine HAVE_FMODF 1
+#cmakedefine HAVE_LOG 1
+#cmakedefine HAVE_LOGF 1
+#cmakedefine HAVE_LOG10 1
+#cmakedefine HAVE_LOG10F 1
+#cmakedefine HAVE_POW 1
+#cmakedefine HAVE_POWF 1
+#cmakedefine HAVE_SCALBN 1
+#cmakedefine HAVE_SCALBNF 1
+#cmakedefine HAVE_SIN 1
+#cmakedefine HAVE_SINF 1
+#cmakedefine HAVE_SQRT 1
+#cmakedefine HAVE_SQRTF 1
+#cmakedefine HAVE_TAN 1
+#cmakedefine HAVE_TANF 1
+#cmakedefine HAVE_FOPEN64 1
+#cmakedefine HAVE_FSEEKO 1
+#cmakedefine HAVE_FSEEKO64 1
+#cmakedefine HAVE_SIGACTION 1
+#cmakedefine HAVE_SA_SIGACTION 1
+#cmakedefine HAVE_SETJMP 1
+#cmakedefine HAVE_NANOSLEEP 1
+#cmakedefine HAVE_SYSCONF 1
+#cmakedefine HAVE_SYSCTLBYNAME 1
+#cmakedefine HAVE_CLOCK_GETTIME 1
+#cmakedefine HAVE_GETPAGESIZE 1
+#cmakedefine HAVE_MPROTECT 1
+#cmakedefine HAVE_ICONV 1
+#cmakedefine HAVE_PTHREAD_SETNAME_NP 1
+#cmakedefine HAVE_PTHREAD_SET_NAME_NP 1
+#cmakedefine HAVE_SEM_TIMEDWAIT 1
+#cmakedefine HAVE_GETAUXVAL 1
+#cmakedefine HAVE_POLL 1
+
+#elif __WIN32__
+#cmakedefine HAVE_STDARG_H 1
+#cmakedefine HAVE_STDDEF_H 1
+#cmakedefine HAVE_FLOAT_H 1
+#else
+/* We may need some replacement for stdarg.h here */
+#include <stdarg.h>
+#endif /* HAVE_LIBC */
+
+#cmakedefine HAVE_ALTIVEC_H 1
+#cmakedefine HAVE_DBUS_DBUS_H 1
+#cmakedefine HAVE_FCITX_FRONTEND_H 1
+#cmakedefine HAVE_IBUS_IBUS_H 1
+#cmakedefine HAVE_IMMINTRIN_H 1
+#cmakedefine HAVE_LIBSAMPLERATE_H 1
+#cmakedefine HAVE_LIBUDEV_H 1
+
+#cmakedefine HAVE_D3D_H @HAVE_D3D_H@
+#cmakedefine HAVE_D3D11_H @HAVE_D3D11_H@
+#cmakedefine HAVE_DDRAW_H @HAVE_DDRAW_H@
+#cmakedefine HAVE_DSOUND_H @HAVE_DSOUND_H@
+#cmakedefine HAVE_DINPUT_H @HAVE_DINPUT_H@
+#cmakedefine HAVE_XINPUT_H @HAVE_XINPUT_H@
+#cmakedefine HAVE_DXGI_H @HAVE_DXGI_H@
+
+#cmakedefine HAVE_ENDPOINTVOLUME_H @HAVE_ENDPOINTVOLUME_H@
+#cmakedefine HAVE_MMDEVICEAPI_H @HAVE_MMDEVICEAPI_H@
+#cmakedefine HAVE_AUDIOCLIENT_H @HAVE_AUDIOCLIENT_H@
+
+#cmakedefine HAVE_XINPUT_GAMEPAD_EX @HAVE_XINPUT_GAMEPAD_EX@
+#cmakedefine HAVE_XINPUT_STATE_EX @HAVE_XINPUT_STATE_EX@
+
+/* SDL internal assertion support */
+#cmakedefine SDL_DEFAULT_ASSERT_LEVEL @SDL_DEFAULT_ASSERT_LEVEL@
+
+/* Allow disabling of core subsystems */
+#cmakedefine SDL_ATOMIC_DISABLED @SDL_ATOMIC_DISABLED@
+#cmakedefine SDL_AUDIO_DISABLED @SDL_AUDIO_DISABLED@
+#cmakedefine SDL_CPUINFO_DISABLED @SDL_CPUINFO_DISABLED@
+#cmakedefine SDL_EVENTS_DISABLED @SDL_EVENTS_DISABLED@
+#cmakedefine SDL_FILE_DISABLED @SDL_FILE_DISABLED@
+#cmakedefine SDL_JOYSTICK_DISABLED @SDL_JOYSTICK_DISABLED@
+#cmakedefine SDL_HAPTIC_DISABLED @SDL_HAPTIC_DISABLED@
+#cmakedefine SDL_SENSOR_DISABLED @SDL_SENSOR_DISABLED@
+#cmakedefine SDL_LOADSO_DISABLED @SDL_LOADSO_DISABLED@
+#cmakedefine SDL_RENDER_DISABLED @SDL_RENDER_DISABLED@
+#cmakedefine SDL_THREADS_DISABLED @SDL_THREADS_DISABLED@
+#cmakedefine SDL_TIMERS_DISABLED @SDL_TIMERS_DISABLED@
+#cmakedefine SDL_VIDEO_DISABLED @SDL_VIDEO_DISABLED@
+#cmakedefine SDL_POWER_DISABLED @SDL_POWER_DISABLED@
+#cmakedefine SDL_FILESYSTEM_DISABLED @SDL_FILESYSTEM_DISABLED@
+
+/* Enable various audio drivers */
+#cmakedefine SDL_AUDIO_DRIVER_ALSA @SDL_AUDIO_DRIVER_ALSA@
+#cmakedefine SDL_AUDIO_DRIVER_ALSA_DYNAMIC @SDL_AUDIO_DRIVER_ALSA_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_ANDROID @SDL_AUDIO_DRIVER_ANDROID@
+#cmakedefine SDL_AUDIO_DRIVER_ARTS @SDL_AUDIO_DRIVER_ARTS@
+#cmakedefine SDL_AUDIO_DRIVER_ARTS_DYNAMIC @SDL_AUDIO_DRIVER_ARTS_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_COREAUDIO @SDL_AUDIO_DRIVER_COREAUDIO@
+#cmakedefine SDL_AUDIO_DRIVER_DISK @SDL_AUDIO_DRIVER_DISK@
+#cmakedefine SDL_AUDIO_DRIVER_DSOUND @SDL_AUDIO_DRIVER_DSOUND@
+#cmakedefine SDL_AUDIO_DRIVER_DUMMY @SDL_AUDIO_DRIVER_DUMMY@
+#cmakedefine SDL_AUDIO_DRIVER_EMSCRIPTEN @SDL_AUDIO_DRIVER_EMSCRIPTEN@
+#cmakedefine SDL_AUDIO_DRIVER_ESD @SDL_AUDIO_DRIVER_ESD@
+#cmakedefine SDL_AUDIO_DRIVER_ESD_DYNAMIC @SDL_AUDIO_DRIVER_ESD_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_FUSIONSOUND @SDL_AUDIO_DRIVER_FUSIONSOUND@
+#cmakedefine SDL_AUDIO_DRIVER_FUSIONSOUND_DYNAMIC @SDL_AUDIO_DRIVER_FUSIONSOUND_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_HAIKU @SDL_AUDIO_DRIVER_HAIKU@
+#cmakedefine SDL_AUDIO_DRIVER_JACK @SDL_AUDIO_DRIVER_JACK@
+#cmakedefine SDL_AUDIO_DRIVER_JACK_DYNAMIC @SDL_AUDIO_DRIVER_JACK_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_NAS @SDL_AUDIO_DRIVER_NAS@
+#cmakedefine SDL_AUDIO_DRIVER_NAS_DYNAMIC @SDL_AUDIO_DRIVER_NAS_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_NETBSD @SDL_AUDIO_DRIVER_NETBSD@
+#cmakedefine SDL_AUDIO_DRIVER_OSS @SDL_AUDIO_DRIVER_OSS@
+#cmakedefine SDL_AUDIO_DRIVER_OSS_SOUNDCARD_H @SDL_AUDIO_DRIVER_OSS_SOUNDCARD_H@
+#cmakedefine SDL_AUDIO_DRIVER_PAUDIO @SDL_AUDIO_DRIVER_PAUDIO@
+#cmakedefine SDL_AUDIO_DRIVER_PULSEAUDIO @SDL_AUDIO_DRIVER_PULSEAUDIO@
+#cmakedefine SDL_AUDIO_DRIVER_PULSEAUDIO_DYNAMIC @SDL_AUDIO_DRIVER_PULSEAUDIO_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_QSA @SDL_AUDIO_DRIVER_QSA@
+#cmakedefine SDL_AUDIO_DRIVER_SNDIO @SDL_AUDIO_DRIVER_SNDIO@
+#cmakedefine SDL_AUDIO_DRIVER_SNDIO_DYNAMIC @SDL_AUDIO_DRIVER_SNDIO_DYNAMIC@
+#cmakedefine SDL_AUDIO_DRIVER_SUNAUDIO @SDL_AUDIO_DRIVER_SUNAUDIO@
+#cmakedefine SDL_AUDIO_DRIVER_WASAPI @SDL_AUDIO_DRIVER_WASAPI@
+#cmakedefine SDL_AUDIO_DRIVER_WINMM @SDL_AUDIO_DRIVER_WINMM@
+
+/* Enable various input drivers */
+#cmakedefine SDL_INPUT_LINUXEV @SDL_INPUT_LINUXEV@
+#cmakedefine SDL_INPUT_LINUXKD @SDL_INPUT_LINUXKD@
+#cmakedefine SDL_INPUT_TSLIB @SDL_INPUT_TSLIB@
+#cmakedefine SDL_JOYSTICK_ANDROID @SDL_JOYSTICK_ANDROID@
+#cmakedefine SDL_JOYSTICK_HAIKU @SDL_JOYSTICK_HAIKU@
+#cmakedefine SDL_JOYSTICK_DINPUT @SDL_JOYSTICK_DINPUT@
+#cmakedefine SDL_JOYSTICK_XINPUT @SDL_JOYSTICK_XINPUT@
+#cmakedefine SDL_JOYSTICK_DUMMY @SDL_JOYSTICK_DUMMY@
+#cmakedefine SDL_JOYSTICK_IOKIT @SDL_JOYSTICK_IOKIT@
+#cmakedefine SDL_JOYSTICK_MFI @SDL_JOYSTICK_MFI@
+#cmakedefine SDL_JOYSTICK_LINUX @SDL_JOYSTICK_LINUX@
+#cmakedefine SDL_JOYSTICK_WINMM @SDL_JOYSTICK_WINMM@
+#cmakedefine SDL_JOYSTICK_USBHID @SDL_JOYSTICK_USBHID@
+#cmakedefine SDL_JOYSTICK_USBHID_MACHINE_JOYSTICK_H @SDL_JOYSTICK_USBHID_MACHINE_JOYSTICK_H@
+#cmakedefine SDL_JOYSTICK_EMSCRIPTEN @SDL_JOYSTICK_EMSCRIPTEN@
+#cmakedefine SDL_HAPTIC_DUMMY @SDL_HAPTIC_DUMMY@
+#cmakedefine SDL_HAPTIC_LINUX @SDL_HAPTIC_LINUX@
+#cmakedefine SDL_HAPTIC_IOKIT @SDL_HAPTIC_IOKIT@
+#cmakedefine SDL_HAPTIC_DINPUT @SDL_HAPTIC_DINPUT@
+#cmakedefine SDL_HAPTIC_XINPUT @SDL_HAPTIC_XINPUT@
+#cmakedefine SDL_HAPTIC_ANDROID @SDL_HAPTIC_ANDROID@
+
+/* Enable various sensor drivers */
+#cmakedefine SDL_SENSOR_ANDROID @SDL_SENSOR_ANDROID@
+#cmakedefine SDL_SENSOR_DUMMY @SDL_SENSOR_DUMMY@
+
+/* Enable various shared object loading systems */
+#cmakedefine SDL_LOADSO_DLOPEN @SDL_LOADSO_DLOPEN@
+#cmakedefine SDL_LOADSO_DUMMY @SDL_LOADSO_DUMMY@
+#cmakedefine SDL_LOADSO_LDG @SDL_LOADSO_LDG@
+#cmakedefine SDL_LOADSO_WINDOWS @SDL_LOADSO_WINDOWS@
+
+/* Enable various threading systems */
+#cmakedefine SDL_THREAD_PTHREAD @SDL_THREAD_PTHREAD@
+#cmakedefine SDL_THREAD_PTHREAD_RECURSIVE_MUTEX @SDL_THREAD_PTHREAD_RECURSIVE_MUTEX@
+#cmakedefine SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP @SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP@
+#cmakedefine SDL_THREAD_WINDOWS @SDL_THREAD_WINDOWS@
+
+/* Enable various timer systems */
+#cmakedefine SDL_TIMER_HAIKU @SDL_TIMER_HAIKU@
+#cmakedefine SDL_TIMER_DUMMY @SDL_TIMER_DUMMY@
+#cmakedefine SDL_TIMER_UNIX @SDL_TIMER_UNIX@
+#cmakedefine SDL_TIMER_WINDOWS @SDL_TIMER_WINDOWS@
+#cmakedefine SDL_TIMER_WINCE @SDL_TIMER_WINCE@
+
+/* Enable various video drivers */
+#cmakedefine SDL_VIDEO_DRIVER_ANDROID @SDL_VIDEO_DRIVER_ANDROID@
+#cmakedefine SDL_VIDEO_DRIVER_HAIKU @SDL_VIDEO_DRIVER_HAIKU@
+#cmakedefine SDL_VIDEO_DRIVER_COCOA @SDL_VIDEO_DRIVER_COCOA@
+#cmakedefine SDL_VIDEO_DRIVER_DIRECTFB @SDL_VIDEO_DRIVER_DIRECTFB@
+#cmakedefine SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC @SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC@
+#cmakedefine SDL_VIDEO_DRIVER_DUMMY @SDL_VIDEO_DRIVER_DUMMY@
+#cmakedefine SDL_VIDEO_DRIVER_WINDOWS @SDL_VIDEO_DRIVER_WINDOWS@
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND @SDL_VIDEO_DRIVER_WAYLAND@
+#cmakedefine SDL_VIDEO_DRIVER_RPI @SDL_VIDEO_DRIVER_RPI@
+#cmakedefine SDL_VIDEO_DRIVER_VIVANTE @SDL_VIDEO_DRIVER_VIVANTE@
+#cmakedefine SDL_VIDEO_DRIVER_VIVANTE_VDK @SDL_VIDEO_DRIVER_VIVANTE_VDK@
+
+#cmakedefine SDL_VIDEO_DRIVER_KMSDRM @SDL_VIDEO_DRIVER_KMSDRM@
+#cmakedefine SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC @SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC@
+#cmakedefine SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC_GBM @SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC_GBM@
+
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH @SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH@
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC @SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC@
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL @SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL@
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR @SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR@
+#cmakedefine SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON @SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON@
+
+#cmakedefine SDL_VIDEO_DRIVER_MIR @SDL_VIDEO_DRIVER_MIR@
+#cmakedefine SDL_VIDEO_DRIVER_MIR_DYNAMIC @SDL_VIDEO_DRIVER_MIR_DYNAMIC@
+#cmakedefine SDL_VIDEO_DRIVER_MIR_DYNAMIC_XKBCOMMON @SDL_VIDEO_DRIVER_MIR_DYNAMIC_XKBCOMMON@
+#cmakedefine SDL_VIDEO_DRIVER_EMSCRIPTEN @SDL_VIDEO_DRIVER_EMSCRIPTEN@
+#cmakedefine SDL_VIDEO_DRIVER_X11 @SDL_VIDEO_DRIVER_X11@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC @SDL_VIDEO_DRIVER_X11_DYNAMIC@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT @SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XCURSOR @SDL_VIDEO_DRIVER_X11_DYNAMIC_XCURSOR@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA @SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2 @SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR @SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS @SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS@
+#cmakedefine SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE @SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XCURSOR @SDL_VIDEO_DRIVER_X11_XCURSOR@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XDBE @SDL_VIDEO_DRIVER_X11_XDBE@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XINERAMA @SDL_VIDEO_DRIVER_X11_XINERAMA@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XINPUT2 @SDL_VIDEO_DRIVER_X11_XINPUT2@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH @SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XRANDR @SDL_VIDEO_DRIVER_X11_XRANDR@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XSCRNSAVER @SDL_VIDEO_DRIVER_X11_XSCRNSAVER@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XSHAPE @SDL_VIDEO_DRIVER_X11_XSHAPE@
+#cmakedefine SDL_VIDEO_DRIVER_X11_XVIDMODE @SDL_VIDEO_DRIVER_X11_XVIDMODE@
+#cmakedefine SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS @SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS@
+#cmakedefine SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY @SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY@
+#cmakedefine SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM @SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM@
+
+#cmakedefine SDL_VIDEO_RENDER_D3D @SDL_VIDEO_RENDER_D3D@
+#cmakedefine SDL_VIDEO_RENDER_D3D11 @SDL_VIDEO_RENDER_D3D11@
+#cmakedefine SDL_VIDEO_RENDER_OGL @SDL_VIDEO_RENDER_OGL@
+#cmakedefine SDL_VIDEO_RENDER_OGL_ES @SDL_VIDEO_RENDER_OGL_ES@
+#cmakedefine SDL_VIDEO_RENDER_OGL_ES2 @SDL_VIDEO_RENDER_OGL_ES2@
+#cmakedefine SDL_VIDEO_RENDER_DIRECTFB @SDL_VIDEO_RENDER_DIRECTFB@
+#cmakedefine SDL_VIDEO_RENDER_METAL @SDL_VIDEO_RENDER_METAL@
+
+/* Enable OpenGL support */
+#cmakedefine SDL_VIDEO_OPENGL @SDL_VIDEO_OPENGL@
+#cmakedefine SDL_VIDEO_OPENGL_ES @SDL_VIDEO_OPENGL_ES@
+#cmakedefine SDL_VIDEO_OPENGL_ES2 @SDL_VIDEO_OPENGL_ES2@
+#cmakedefine SDL_VIDEO_OPENGL_BGL @SDL_VIDEO_OPENGL_BGL@
+#cmakedefine SDL_VIDEO_OPENGL_CGL @SDL_VIDEO_OPENGL_CGL@
+#cmakedefine SDL_VIDEO_OPENGL_GLX @SDL_VIDEO_OPENGL_GLX@
+#cmakedefine SDL_VIDEO_OPENGL_WGL @SDL_VIDEO_OPENGL_WGL@
+#cmakedefine SDL_VIDEO_OPENGL_EGL @SDL_VIDEO_OPENGL_EGL@
+#cmakedefine SDL_VIDEO_OPENGL_OSMESA @SDL_VIDEO_OPENGL_OSMESA@
+#cmakedefine SDL_VIDEO_OPENGL_OSMESA_DYNAMIC @SDL_VIDEO_OPENGL_OSMESA_DYNAMIC@
+
+/* Enable Vulkan support */
+#cmakedefine SDL_VIDEO_VULKAN @SDL_VIDEO_VULKAN@
+
+/* Enable system power support */
+#cmakedefine SDL_POWER_ANDROID @SDL_POWER_ANDROID@
+#cmakedefine SDL_POWER_LINUX @SDL_POWER_LINUX@
+#cmakedefine SDL_POWER_WINDOWS @SDL_POWER_WINDOWS@
+#cmakedefine SDL_POWER_MACOSX @SDL_POWER_MACOSX@
+#cmakedefine SDL_POWER_HAIKU @SDL_POWER_HAIKU@
+#cmakedefine SDL_POWER_EMSCRIPTEN @SDL_POWER_EMSCRIPTEN@
+#cmakedefine SDL_POWER_HARDWIRED @SDL_POWER_HARDWIRED@
+
+/* Enable system filesystem support */
+#cmakedefine SDL_FILESYSTEM_ANDROID @SDL_FILESYSTEM_ANDROID@
+#cmakedefine SDL_FILESYSTEM_HAIKU @SDL_FILESYSTEM_HAIKU@
+#cmakedefine SDL_FILESYSTEM_COCOA @SDL_FILESYSTEM_COCOA@
+#cmakedefine SDL_FILESYSTEM_DUMMY @SDL_FILESYSTEM_DUMMY@
+#cmakedefine SDL_FILESYSTEM_UNIX @SDL_FILESYSTEM_UNIX@
+#cmakedefine SDL_FILESYSTEM_WINDOWS @SDL_FILESYSTEM_WINDOWS@
+#cmakedefine SDL_FILESYSTEM_EMSCRIPTEN @SDL_FILESYSTEM_EMSCRIPTEN@
+
+/* Enable assembly routines */
+#cmakedefine SDL_ASSEMBLY_ROUTINES @SDL_ASSEMBLY_ROUTINES@
+#cmakedefine SDL_ALTIVEC_BLITTERS @SDL_ALTIVEC_BLITTERS@
+
+/* Enable dynamic libsamplerate support */
+#cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@
+
+/* Platform specific definitions */
+#if !defined(__WIN32__)
+#  if !defined(_STDINT_H_) && !defined(_STDINT_H) && !defined(HAVE_STDINT_H) && !defined(_HAVE_STDINT_H)
+typedef unsigned int size_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long uintptr_t;
+#  endif /* if (stdint.h isn't available) */
+#else /* __WIN32__ */
+#  if !defined(_STDINT_H_) && !defined(HAVE_STDINT_H) && !defined(_HAVE_STDINT_H)
+#    if defined(__GNUC__) || defined(__DMC__) || defined(__WATCOMC__)
+#define HAVE_STDINT_H	1
+#    elif defined(_MSC_VER)
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#      ifndef _UINTPTR_T_DEFINED
+#        ifdef  _WIN64
+typedef unsigned __int64 uintptr_t;
+#          else
+typedef unsigned int uintptr_t;
+#        endif
+#define _UINTPTR_T_DEFINED
+#      endif
+/* Older Visual C++ headers don't have the Win64-compatible typedefs... */
+#      if ((_MSC_VER <= 1200) && (!defined(DWORD_PTR)))
+#define DWORD_PTR DWORD
+#      endif
+#      if ((_MSC_VER <= 1200) && (!defined(LONG_PTR)))
+#define LONG_PTR LONG
+#      endif
+#    else /* !__GNUC__ && !_MSC_VER */
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+#      ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef unsigned int size_t;
+#      endif
+typedef unsigned int uintptr_t;
+#    endif /* __GNUC__ || _MSC_VER */
+#  endif /* !_STDINT_H_ && !HAVE_STDINT_H */
+#endif /* __WIN32__ */
+
+#endif /* SDL_config_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config.h.in
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config.h.in
@@ -1,0 +1,420 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_h_
+#define SDL_config_h_
+
+/**
+ *  \file SDL_config.h.in
+ *
+ *  This is a set of defines to configure the SDL features
+ */
+
+/* General platform specific identifiers */
+#include "SDL_platform.h"
+
+/* Make sure that this isn't included by Visual C++ */
+#ifdef _MSC_VER
+#error You should run hg revert SDL_config.h 
+#endif
+
+/* C language features */
+#undef const
+#undef inline
+#undef volatile
+
+/* C datatypes */
+#ifdef __LP64__
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+#undef HAVE_GCC_ATOMICS
+#undef HAVE_GCC_SYNC_LOCK_TEST_AND_SET
+
+/* Comment this if you want to build without any C library requirements */
+#undef HAVE_LIBC
+#if HAVE_LIBC
+
+/* Useful headers */
+#undef STDC_HEADERS
+#undef HAVE_ALLOCA_H
+#undef HAVE_CTYPE_H
+#undef HAVE_FLOAT_H
+#undef HAVE_ICONV_H
+#undef HAVE_INTTYPES_H
+#undef HAVE_LIMITS_H
+#undef HAVE_MALLOC_H
+#undef HAVE_MATH_H
+#undef HAVE_MEMORY_H
+#undef HAVE_SIGNAL_H
+#undef HAVE_STDARG_H
+#undef HAVE_STDINT_H
+#undef HAVE_STDIO_H
+#undef HAVE_STDLIB_H
+#undef HAVE_STRINGS_H
+#undef HAVE_STRING_H
+#undef HAVE_SYS_TYPES_H
+#undef HAVE_WCHAR_H
+#undef HAVE_PTHREAD_NP_H
+#undef HAVE_LIBUNWIND_H
+
+/* C library functions */
+#undef HAVE_MALLOC
+#undef HAVE_CALLOC
+#undef HAVE_REALLOC
+#undef HAVE_FREE
+#undef HAVE_ALLOCA
+#ifndef __WIN32__ /* Don't use C runtime versions of these on Windows */
+#undef HAVE_GETENV
+#undef HAVE_SETENV
+#undef HAVE_PUTENV
+#undef HAVE_UNSETENV
+#endif
+#undef HAVE_QSORT
+#undef HAVE_ABS
+#undef HAVE_BCOPY
+#undef HAVE_MEMSET
+#undef HAVE_MEMCPY
+#undef HAVE_MEMMOVE
+#undef HAVE_MEMCMP
+#undef HAVE_WCSLEN
+#undef HAVE_WCSLCPY
+#undef HAVE_WCSLCAT
+#undef HAVE_WCSCMP
+#undef HAVE_STRLEN
+#undef HAVE_STRLCPY
+#undef HAVE_STRLCAT
+#undef HAVE__STRREV
+#undef HAVE__STRUPR
+#undef HAVE__STRLWR
+#undef HAVE_INDEX
+#undef HAVE_RINDEX
+#undef HAVE_STRCHR
+#undef HAVE_STRRCHR
+#undef HAVE_STRSTR
+#undef HAVE_ITOA
+#undef HAVE__LTOA
+#undef HAVE__UITOA
+#undef HAVE__ULTOA
+#undef HAVE_STRTOL
+#undef HAVE_STRTOUL
+#undef HAVE__I64TOA
+#undef HAVE__UI64TOA
+#undef HAVE_STRTOLL
+#undef HAVE_STRTOULL
+#undef HAVE_STRTOD
+#undef HAVE_ATOI
+#undef HAVE_ATOF
+#undef HAVE_STRCMP
+#undef HAVE_STRNCMP
+#undef HAVE__STRICMP
+#undef HAVE_STRCASECMP
+#undef HAVE__STRNICMP
+#undef HAVE_STRNCASECMP
+#undef HAVE_SSCANF
+#undef HAVE_VSSCANF
+#undef HAVE_SNPRINTF
+#undef HAVE_VSNPRINTF
+#undef HAVE_M_PI
+#undef HAVE_ACOS
+#undef HAVE_ACOSF
+#undef HAVE_ASIN
+#undef HAVE_ASINF
+#undef HAVE_ATAN
+#undef HAVE_ATANF
+#undef HAVE_ATAN2
+#undef HAVE_ATAN2F
+#undef HAVE_CEIL
+#undef HAVE_CEILF
+#undef HAVE_COPYSIGN
+#undef HAVE_COPYSIGNF
+#undef HAVE_COS
+#undef HAVE_COSF
+#undef HAVE_EXP
+#undef HAVE_EXPF
+#undef HAVE_FABS
+#undef HAVE_FABSF
+#undef HAVE_FLOOR
+#undef HAVE_FLOORF
+#undef HAVE_FMOD
+#undef HAVE_FMODF
+#undef HAVE_LOG
+#undef HAVE_LOGF
+#undef HAVE_LOG10
+#undef HAVE_LOG10F
+#undef HAVE_POW
+#undef HAVE_POWF
+#undef HAVE_SCALBN
+#undef HAVE_SCALBNF
+#undef HAVE_SIN
+#undef HAVE_SINF
+#undef HAVE_SQRT
+#undef HAVE_SQRTF
+#undef HAVE_TAN
+#undef HAVE_TANF
+#undef HAVE_FOPEN64
+#undef HAVE_FSEEKO
+#undef HAVE_FSEEKO64
+#undef HAVE_SIGACTION
+#undef HAVE_SA_SIGACTION
+#undef HAVE_SETJMP
+#undef HAVE_NANOSLEEP
+#undef HAVE_SYSCONF
+#undef HAVE_SYSCTLBYNAME
+#undef HAVE_CLOCK_GETTIME
+#undef HAVE_GETPAGESIZE
+#undef HAVE_MPROTECT
+#undef HAVE_ICONV
+#undef HAVE_PTHREAD_SETNAME_NP
+#undef HAVE_PTHREAD_SET_NAME_NP
+#undef HAVE_SEM_TIMEDWAIT
+#undef HAVE_GETAUXVAL
+#undef HAVE_POLL
+
+#else
+#define HAVE_STDARG_H   1
+#define HAVE_STDDEF_H   1
+#define HAVE_STDINT_H   1
+#endif /* HAVE_LIBC */
+
+#undef HAVE_ALTIVEC_H
+#undef HAVE_DBUS_DBUS_H
+#undef HAVE_FCITX_FRONTEND_H
+#undef HAVE_IBUS_IBUS_H
+#undef HAVE_IMMINTRIN_H
+#undef HAVE_LIBSAMPLERATE_H
+#undef HAVE_LIBUDEV_H
+
+#undef HAVE_DDRAW_H
+#undef HAVE_DINPUT_H
+#undef HAVE_DSOUND_H
+#undef HAVE_DXGI_H
+#undef HAVE_XINPUT_H
+#undef HAVE_ENDPOINTVOLUME_H
+#undef HAVE_MMDEVICEAPI_H
+#undef HAVE_AUDIOCLIENT_H
+#undef HAVE_XINPUT_GAMEPAD_EX
+#undef HAVE_XINPUT_STATE_EX
+
+/* SDL internal assertion support */
+#undef SDL_DEFAULT_ASSERT_LEVEL
+
+/* Allow disabling of core subsystems */
+#undef SDL_ATOMIC_DISABLED
+#undef SDL_AUDIO_DISABLED
+#undef SDL_CPUINFO_DISABLED
+#undef SDL_EVENTS_DISABLED
+#undef SDL_FILE_DISABLED
+#undef SDL_JOYSTICK_DISABLED
+#undef SDL_HAPTIC_DISABLED
+#undef SDL_SENSOR_DISABLED
+#undef SDL_LOADSO_DISABLED
+#undef SDL_RENDER_DISABLED
+#undef SDL_THREADS_DISABLED
+#undef SDL_TIMERS_DISABLED
+#undef SDL_VIDEO_DISABLED
+#undef SDL_POWER_DISABLED
+#undef SDL_FILESYSTEM_DISABLED
+
+/* Enable various audio drivers */
+#undef SDL_AUDIO_DRIVER_ALSA
+#undef SDL_AUDIO_DRIVER_ALSA_DYNAMIC
+#undef SDL_AUDIO_DRIVER_ANDROID
+#undef SDL_AUDIO_DRIVER_ARTS
+#undef SDL_AUDIO_DRIVER_ARTS_DYNAMIC
+#undef SDL_AUDIO_DRIVER_COREAUDIO
+#undef SDL_AUDIO_DRIVER_DISK
+#undef SDL_AUDIO_DRIVER_DSOUND
+#undef SDL_AUDIO_DRIVER_DUMMY
+#undef SDL_AUDIO_DRIVER_EMSCRIPTEN
+#undef SDL_AUDIO_DRIVER_ESD
+#undef SDL_AUDIO_DRIVER_ESD_DYNAMIC
+#undef SDL_AUDIO_DRIVER_FUSIONSOUND
+#undef SDL_AUDIO_DRIVER_FUSIONSOUND_DYNAMIC
+#undef SDL_AUDIO_DRIVER_HAIKU
+#undef SDL_AUDIO_DRIVER_JACK
+#undef SDL_AUDIO_DRIVER_JACK_DYNAMIC
+#undef SDL_AUDIO_DRIVER_NACL
+#undef SDL_AUDIO_DRIVER_NAS
+#undef SDL_AUDIO_DRIVER_NAS_DYNAMIC
+#undef SDL_AUDIO_DRIVER_NETBSD
+#undef SDL_AUDIO_DRIVER_OSS
+#undef SDL_AUDIO_DRIVER_OSS_SOUNDCARD_H
+#undef SDL_AUDIO_DRIVER_PAUDIO
+#undef SDL_AUDIO_DRIVER_PULSEAUDIO
+#undef SDL_AUDIO_DRIVER_PULSEAUDIO_DYNAMIC
+#undef SDL_AUDIO_DRIVER_QSA
+#undef SDL_AUDIO_DRIVER_SNDIO
+#undef SDL_AUDIO_DRIVER_SNDIO_DYNAMIC
+#undef SDL_AUDIO_DRIVER_SUNAUDIO
+#undef SDL_AUDIO_DRIVER_WASAPI
+#undef SDL_AUDIO_DRIVER_WINMM
+
+/* Enable various input drivers */
+#undef SDL_INPUT_LINUXEV
+#undef SDL_INPUT_LINUXKD
+#undef SDL_INPUT_TSLIB
+#undef SDL_JOYSTICK_HAIKU
+#undef SDL_JOYSTICK_DINPUT
+#undef SDL_JOYSTICK_XINPUT
+#undef SDL_JOYSTICK_DUMMY
+#undef SDL_JOYSTICK_IOKIT
+#undef SDL_JOYSTICK_LINUX
+#undef SDL_JOYSTICK_ANDROID
+#undef SDL_JOYSTICK_WINMM
+#undef SDL_JOYSTICK_USBHID
+#undef SDL_JOYSTICK_USBHID_MACHINE_JOYSTICK_H
+#undef SDL_JOYSTICK_HIDAPI
+#undef SDL_JOYSTICK_EMSCRIPTEN
+#undef SDL_HAPTIC_DUMMY
+#undef SDL_HAPTIC_ANDROID
+#undef SDL_HAPTIC_LINUX
+#undef SDL_HAPTIC_IOKIT
+#undef SDL_HAPTIC_DINPUT
+#undef SDL_HAPTIC_XINPUT
+
+/* Enable various sensor drivers */
+#undef SDL_SENSOR_ANDROID
+#undef SDL_SENSOR_DUMMY
+
+/* Enable various shared object loading systems */
+#undef SDL_LOADSO_DLOPEN
+#undef SDL_LOADSO_DUMMY
+#undef SDL_LOADSO_LDG
+#undef SDL_LOADSO_WINDOWS
+
+/* Enable various threading systems */
+#undef SDL_THREAD_PTHREAD
+#undef SDL_THREAD_PTHREAD_RECURSIVE_MUTEX
+#undef SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP
+#undef SDL_THREAD_WINDOWS
+
+/* Enable various timer systems */
+#undef SDL_TIMER_HAIKU
+#undef SDL_TIMER_DUMMY
+#undef SDL_TIMER_UNIX
+#undef SDL_TIMER_WINDOWS
+
+/* Enable various video drivers */
+#undef SDL_VIDEO_DRIVER_HAIKU
+#undef SDL_VIDEO_DRIVER_COCOA
+#undef SDL_VIDEO_DRIVER_DIRECTFB
+#undef SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC
+#undef SDL_VIDEO_DRIVER_DUMMY
+#undef SDL_VIDEO_DRIVER_WINDOWS
+#undef SDL_VIDEO_DRIVER_WAYLAND
+#undef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
+#undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC
+#undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL
+#undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR
+#undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON
+#undef SDL_VIDEO_DRIVER_MIR
+#undef SDL_VIDEO_DRIVER_MIR_DYNAMIC
+#undef SDL_VIDEO_DRIVER_MIR_DYNAMIC_XKBCOMMON
+#undef SDL_VIDEO_DRIVER_X11
+#undef SDL_VIDEO_DRIVER_RPI
+#undef SDL_VIDEO_DRIVER_KMSDRM
+#undef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC
+#undef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC_GBM
+#undef SDL_VIDEO_DRIVER_ANDROID
+#undef SDL_VIDEO_DRIVER_EMSCRIPTEN
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XCURSOR
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS
+#undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE
+#undef SDL_VIDEO_DRIVER_X11_XCURSOR
+#undef SDL_VIDEO_DRIVER_X11_XDBE
+#undef SDL_VIDEO_DRIVER_X11_XINERAMA
+#undef SDL_VIDEO_DRIVER_X11_XINPUT2
+#undef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
+#undef SDL_VIDEO_DRIVER_X11_XRANDR
+#undef SDL_VIDEO_DRIVER_X11_XSCRNSAVER
+#undef SDL_VIDEO_DRIVER_X11_XSHAPE
+#undef SDL_VIDEO_DRIVER_X11_XVIDMODE
+#undef SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS
+#undef SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY
+#undef SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM
+#undef SDL_VIDEO_DRIVER_NACL
+#undef SDL_VIDEO_DRIVER_VIVANTE
+#undef SDL_VIDEO_DRIVER_VIVANTE_VDK
+#undef SDL_VIDEO_DRIVER_QNX
+
+#undef SDL_VIDEO_RENDER_D3D
+#undef SDL_VIDEO_RENDER_D3D11
+#undef SDL_VIDEO_RENDER_OGL
+#undef SDL_VIDEO_RENDER_OGL_ES
+#undef SDL_VIDEO_RENDER_OGL_ES2
+#undef SDL_VIDEO_RENDER_DIRECTFB
+#undef SDL_VIDEO_RENDER_METAL
+
+/* Enable OpenGL support */
+#undef SDL_VIDEO_OPENGL
+#undef SDL_VIDEO_OPENGL_ES
+#undef SDL_VIDEO_OPENGL_ES2
+#undef SDL_VIDEO_OPENGL_BGL
+#undef SDL_VIDEO_OPENGL_CGL
+#undef SDL_VIDEO_OPENGL_EGL
+#undef SDL_VIDEO_OPENGL_GLX
+#undef SDL_VIDEO_OPENGL_WGL
+#undef SDL_VIDEO_OPENGL_OSMESA
+#undef SDL_VIDEO_OPENGL_OSMESA_DYNAMIC
+
+/* Enable Vulkan support */
+#undef SDL_VIDEO_VULKAN
+
+/* Enable system power support */
+#undef SDL_POWER_LINUX
+#undef SDL_POWER_WINDOWS
+#undef SDL_POWER_MACOSX
+#undef SDL_POWER_HAIKU
+#undef SDL_POWER_ANDROID
+#undef SDL_POWER_EMSCRIPTEN
+#undef SDL_POWER_HARDWIRED
+
+/* Enable system filesystem support */
+#undef SDL_FILESYSTEM_HAIKU
+#undef SDL_FILESYSTEM_COCOA
+#undef SDL_FILESYSTEM_DUMMY
+#undef SDL_FILESYSTEM_UNIX
+#undef SDL_FILESYSTEM_WINDOWS
+#undef SDL_FILESYSTEM_NACL
+#undef SDL_FILESYSTEM_ANDROID
+#undef SDL_FILESYSTEM_EMSCRIPTEN
+
+/* Enable assembly routines */
+#undef SDL_ASSEMBLY_ROUTINES
+#undef SDL_ALTIVEC_BLITTERS
+
+/* Enable ime support */
+#undef SDL_USE_IME
+
+/* Enable dynamic udev support */
+#undef SDL_UDEV_DYNAMIC
+
+/* Enable dynamic libsamplerate support */
+#undef SDL_LIBSAMPLERATE_DYNAMIC
+
+#endif /* SDL_config_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_android.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_android.h
@@ -1,0 +1,177 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_android_h_
+#define SDL_config_android_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+/**
+ *  \file SDL_config_android.h
+ *
+ *  This is a configuration that can be used to build SDL for Android
+ */
+
+#include <stdarg.h>
+
+#define HAVE_GCC_ATOMICS    1
+
+#define STDC_HEADERS    1
+#define HAVE_ALLOCA_H       1
+#define HAVE_CTYPE_H    1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H   1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDINT_H   1
+#define HAVE_STDIO_H    1
+#define HAVE_STRING_H   1
+#define HAVE_SYS_TYPES_H    1
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC    1
+#define HAVE_FREE   1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_SETENV 1
+#define HAVE_UNSETENV   1
+#define HAVE_QSORT  1
+#define HAVE_ABS    1
+#define HAVE_BCOPY  1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE    1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY    1
+#define HAVE_STRLCAT    1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR    1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL    1
+#define HAVE_STRTOLL    1
+#define HAVE_STRTOULL   1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI   1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP    1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF  1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE_COPYSIGN   1
+#define HAVE_COPYSIGNF  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE_SIGACTION 1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP  1
+#define HAVE_SYSCONF    1
+#define HAVE_CLOCK_GETTIME  1
+
+#define SIZEOF_VOIDP 4
+
+/* Enable various audio drivers */
+#define SDL_AUDIO_DRIVER_ANDROID    1
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable various input drivers */
+#define SDL_JOYSTICK_ANDROID    1
+#define SDL_JOYSTICK_HIDAPI    1
+#define SDL_HAPTIC_ANDROID    1
+
+/* Enable sensor driver */
+#define SDL_SENSOR_ANDROID  1
+
+/* Enable various shared object loading systems */
+#define SDL_LOADSO_DLOPEN   1
+
+/* Enable various threading systems */
+#define SDL_THREAD_PTHREAD  1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX  1
+
+/* Enable various timer systems */
+#define SDL_TIMER_UNIX  1
+
+/* Enable various video drivers */
+#define SDL_VIDEO_DRIVER_ANDROID 1
+
+/* Enable OpenGL ES */
+#define SDL_VIDEO_OPENGL_ES 1
+#define SDL_VIDEO_OPENGL_ES2 1
+#define SDL_VIDEO_OPENGL_EGL 1
+#define SDL_VIDEO_RENDER_OGL_ES 1
+#define SDL_VIDEO_RENDER_OGL_ES2    1
+
+/* Enable Vulkan support */
+/* Android does not support Vulkan in native code using the "armeabi" ABI. */
+#if defined(__ARM_ARCH) && __ARM_ARCH < 7
+#define SDL_VIDEO_VULKAN 0
+#else
+#define SDL_VIDEO_VULKAN 1
+#endif
+
+/* Enable system power support */
+#define SDL_POWER_ANDROID 1
+
+/* Enable the filesystem driver */
+#define SDL_FILESYSTEM_ANDROID   1
+
+#endif /* SDL_config_android_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_iphoneos.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_iphoneos.h
@@ -1,0 +1,201 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_iphoneos_h_
+#define SDL_config_iphoneos_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+#ifdef __LP64__
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+
+#define HAVE_GCC_ATOMICS    1
+
+#define STDC_HEADERS    1
+#define HAVE_ALLOCA_H       1
+#define HAVE_CTYPE_H    1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H   1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H   1
+#define HAVE_STDINT_H   1
+#define HAVE_STDIO_H    1
+#define HAVE_STRING_H   1
+#define HAVE_SYS_TYPES_H    1
+/* The libunwind functions are only available on x86 */
+/* #undef HAVE_LIBUNWIND_H */
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC    1
+#define HAVE_FREE   1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_SETENV 1
+#define HAVE_UNSETENV   1
+#define HAVE_QSORT  1
+#define HAVE_ABS    1
+#define HAVE_BCOPY  1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE    1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY    1
+#define HAVE_STRLCAT    1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR    1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL    1
+#define HAVE_STRTOLL    1
+#define HAVE_STRTOULL   1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI   1
+#define HAVE_ATOF   1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP    1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF  1
+#define HAVE_M_PI   1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE_COPYSIGN   1
+#define HAVE_COPYSIGNF  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE_SIGACTION  1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP  1
+#define HAVE_SYSCONF    1
+#define HAVE_SYSCTLBYNAME 1
+
+/* enable iPhone version of Core Audio driver */
+#define SDL_AUDIO_DRIVER_COREAUDIO 1
+/* Enable the dummy audio driver (src/audio/dummy/\*.c) */
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable the stub haptic driver (src/haptic/dummy/\*.c) */
+#define SDL_HAPTIC_DUMMY 1
+
+/* Enable MFi joystick support */
+#define SDL_JOYSTICK_MFI 1
+/*#define SDL_JOYSTICK_HIDAPI 1*/
+
+#ifdef __TVOS__
+#define SDL_SENSOR_DUMMY    1
+#else
+/* Enable the CoreMotion sensor driver */
+#define SDL_SENSOR_COREMOTION   1
+#endif
+
+/* Enable Unix style SO loading */
+#define SDL_LOADSO_DLOPEN 1
+
+/* Enable various threading systems */
+#define SDL_THREAD_PTHREAD  1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX  1
+
+/* Enable various timer systems */
+#define SDL_TIMER_UNIX  1
+
+/* Supported video drivers */
+#define SDL_VIDEO_DRIVER_UIKIT  1
+#define SDL_VIDEO_DRIVER_DUMMY  1
+
+/* Enable OpenGL ES */
+#define SDL_VIDEO_OPENGL_ES2 1
+#define SDL_VIDEO_OPENGL_ES 1
+#define SDL_VIDEO_RENDER_OGL_ES 1
+#define SDL_VIDEO_RENDER_OGL_ES2    1
+
+/* Metal supported on 64-bit devices running iOS 8.0 and tvOS 9.0 and newer */
+#if !TARGET_OS_SIMULATOR && !TARGET_CPU_ARM && ((__IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (__TV_OS_VERSION_MIN_REQUIRED >= 90000))
+#define SDL_PLATFORM_SUPPORTS_METAL	1
+#else
+#define SDL_PLATFORM_SUPPORTS_METAL	0
+#endif
+
+#if SDL_PLATFORM_SUPPORTS_METAL
+#define SDL_VIDEO_RENDER_METAL  1
+#endif
+
+#if SDL_PLATFORM_SUPPORTS_METAL
+#define SDL_VIDEO_VULKAN 1
+#endif
+
+/* Enable system power support */
+#define SDL_POWER_UIKIT 1
+
+/* enable iPhone keyboard support */
+#define SDL_IPHONE_KEYBOARD 1
+
+/* enable iOS extended launch screen */
+#define SDL_IPHONE_LAUNCHSCREEN 1
+
+/* Set max recognized G-force from accelerometer
+   See src/joystick/uikit/SDL_sysjoystick.m for notes on why this is needed
+ */
+#define SDL_IPHONE_MAX_GFORCE 5.0
+
+/* enable filesystem support */
+#define SDL_FILESYSTEM_COCOA   1
+
+#endif /* SDL_config_iphoneos_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_macosx.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_macosx.h
@@ -1,0 +1,240 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_macosx_h_
+#define SDL_config_macosx_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+/* This gets us MAC_OS_X_VERSION_MIN_REQUIRED... */
+#include <AvailabilityMacros.h>
+
+/* This is a set of defines to configure the SDL features */
+
+#ifdef __LP64__
+    #define SIZEOF_VOIDP 8
+#else
+    #define SIZEOF_VOIDP 4
+#endif
+
+/* Useful headers */
+#define STDC_HEADERS    1
+#define HAVE_ALLOCA_H       1
+#define HAVE_CTYPE_H    1
+#define HAVE_FLOAT_H    1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H   1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H   1
+#define HAVE_STDINT_H   1
+#define HAVE_STDIO_H    1
+#define HAVE_STRING_H   1
+#define HAVE_SYS_TYPES_H    1
+#define HAVE_LIBUNWIND_H    1
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC    1
+#define HAVE_FREE   1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_UNSETENV   1
+#define HAVE_QSORT  1
+#define HAVE_ABS    1
+#define HAVE_BCOPY  1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE    1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY    1
+#define HAVE_STRLCAT    1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR    1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL    1
+#define HAVE_STRTOLL    1
+#define HAVE_STRTOULL   1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI   1
+#define HAVE_ATOF   1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP    1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF  1
+#define HAVE_M_PI   1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE_COPYSIGN   1
+#define HAVE_COPYSIGNF  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE_SIGACTION  1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP  1
+#define HAVE_SYSCONF    1
+#define HAVE_SYSCTLBYNAME 1
+
+/* Enable various audio drivers */
+#define SDL_AUDIO_DRIVER_COREAUDIO  1
+#define SDL_AUDIO_DRIVER_DISK   1
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable various input drivers */
+#define SDL_JOYSTICK_IOKIT  1
+#define SDL_JOYSTICK_HIDAPI  1
+#define SDL_HAPTIC_IOKIT    1
+
+/* Enable the dummy sensor driver */
+#define SDL_SENSOR_DUMMY  1
+
+/* Enable various shared object loading systems */
+#define SDL_LOADSO_DLOPEN   1
+
+/* Enable various threading systems */
+#define SDL_THREAD_PTHREAD  1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX  1
+
+/* Enable various timer systems */
+#define SDL_TIMER_UNIX  1
+
+/* Enable various video drivers */
+#define SDL_VIDEO_DRIVER_COCOA  1
+#define SDL_VIDEO_DRIVER_DUMMY  1
+#undef SDL_VIDEO_DRIVER_X11
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC "/usr/X11R6/lib/libX11.6.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT "/usr/X11R6/lib/libXext.6.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA "/usr/X11R6/lib/libXinerama.1.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2 "/usr/X11R6/lib/libXi.6.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR "/usr/X11R6/lib/libXrandr.2.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS "/usr/X11R6/lib/libXss.1.dylib"
+#define SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE "/usr/X11R6/lib/libXxf86vm.1.dylib"
+#define SDL_VIDEO_DRIVER_X11_XDBE 1
+#define SDL_VIDEO_DRIVER_X11_XINERAMA 1
+#define SDL_VIDEO_DRIVER_X11_XRANDR 1
+#define SDL_VIDEO_DRIVER_X11_XSCRNSAVER 1
+#define SDL_VIDEO_DRIVER_X11_XSHAPE 1
+#define SDL_VIDEO_DRIVER_X11_XVIDMODE 1
+#define SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM 1
+
+#ifdef MAC_OS_X_VERSION_10_8
+/*
+ * No matter the versions targeted, this is the 10.8 or later SDK, so you have
+ *  to use the external Xquartz, which is a more modern Xlib. Previous SDKs
+ *  used an older Xlib.
+ */
+#define SDL_VIDEO_DRIVER_X11_XINPUT2 1
+#define SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS 1
+#define SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY 1
+#endif
+
+#ifndef SDL_VIDEO_RENDER_OGL
+#define SDL_VIDEO_RENDER_OGL    1
+#endif
+
+#ifndef SDL_VIDEO_RENDER_OGL_ES2
+#define SDL_VIDEO_RENDER_OGL_ES2 1
+#endif
+
+#ifndef SDL_VIDEO_RENDER_METAL
+/* Metal only supported on 64-bit architectures with 10.11+ */
+#if TARGET_CPU_X86_64 && (MAC_OS_X_VERSION_MAX_ALLOWED >= 101100)
+#define SDL_VIDEO_RENDER_METAL    1
+#else
+#define SDL_VIDEO_RENDER_METAL    0
+#endif
+#endif
+
+/* Enable OpenGL support */
+#ifndef SDL_VIDEO_OPENGL
+#define SDL_VIDEO_OPENGL    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_ES2
+#define SDL_VIDEO_OPENGL_ES2    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_EGL
+#define SDL_VIDEO_OPENGL_EGL    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_CGL
+#define SDL_VIDEO_OPENGL_CGL    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_GLX
+#define SDL_VIDEO_OPENGL_GLX    1
+#endif
+
+/* Enable Vulkan support */
+/* Metal/MoltenVK/Vulkan only supported on 64-bit architectures with 10.11+ */
+#if TARGET_CPU_X86_64 && (MAC_OS_X_VERSION_MAX_ALLOWED >= 101100)
+#define SDL_VIDEO_VULKAN 1
+#else
+#define SDL_VIDEO_VULKAN 0
+#endif
+
+/* Enable system power support */
+#define SDL_POWER_MACOSX 1
+
+/* enable filesystem support */
+#define SDL_FILESYSTEM_COCOA   1
+
+/* Enable assembly routines */
+#define SDL_ASSEMBLY_ROUTINES   1
+#ifdef __ppc__
+#define SDL_ALTIVEC_BLITTERS    1
+#endif
+
+#endif /* SDL_config_macosx_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_minimal.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_minimal.h
@@ -1,0 +1,85 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_minimal_h_
+#define SDL_config_minimal_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+/**
+ *  \file SDL_config_minimal.h
+ *
+ *  This is the minimal configuration that can be used to build SDL.
+ */
+
+#define HAVE_STDARG_H   1
+#define HAVE_STDDEF_H   1
+
+/* Most everything except Visual Studio 2008 and earlier has stdint.h now */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+/* Here are some reasonable defaults */
+typedef unsigned int size_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long uintptr_t;
+#else
+#define HAVE_STDINT_H 1
+#endif /* Visual Studio 2008 */
+
+#ifdef __GNUC__
+#define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
+#endif
+
+/* Enable the dummy audio driver (src/audio/dummy/\*.c) */
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable the stub joystick driver (src/joystick/dummy/\*.c) */
+#define SDL_JOYSTICK_DISABLED   1
+
+/* Enable the stub haptic driver (src/haptic/dummy/\*.c) */
+#define SDL_HAPTIC_DISABLED 1
+
+/* Enable the stub sensor driver (src/sensor/dummy/\*.c) */
+#define SDL_SENSOR_DISABLED 1
+
+/* Enable the stub shared object loader (src/loadso/dummy/\*.c) */
+#define SDL_LOADSO_DISABLED 1
+
+/* Enable the stub thread support (src/thread/generic/\*.c) */
+#define SDL_THREADS_DISABLED    1
+
+/* Enable the stub timer support (src/timer/dummy/\*.c) */
+#define SDL_TIMERS_DISABLED 1
+
+/* Enable the dummy video driver (src/video/dummy/\*.c) */
+#define SDL_VIDEO_DRIVER_DUMMY  1
+
+/* Enable the dummy filesystem driver (src/filesystem/dummy/\*.c) */
+#define SDL_FILESYSTEM_DUMMY  1
+
+#endif /* SDL_config_minimal_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_os2.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_os2.h
@@ -1,0 +1,170 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_os2_h_
+#define SDL_config_os2_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+#define SDL_AUDIO_DRIVER_DUMMY 1
+#define SDL_AUDIO_DRIVER_DISK 1
+
+#define SDL_POWER_DISABLED  1
+#define SDL_JOYSTICK_DISABLED 1
+#define SDL_HAPTIC_DISABLED 1
+/*#undef SDL_JOYSTICK_HIDAPI */
+
+#define SDL_SENSOR_DUMMY 1
+#define SDL_VIDEO_DRIVER_DUMMY 1
+
+/* Enable OpenGL support */
+/* #undef SDL_VIDEO_OPENGL */
+
+/* Enable Vulkan support */
+/* #undef SDL_VIDEO_VULKAN */
+
+#define SDL_LOADSO_DISABLED 1
+#define SDL_THREADS_DISABLED 1
+#define SDL_TIMERS_DISABLED 1
+#define SDL_FILESYSTEM_DUMMY 1
+
+/* Enable assembly routines */
+#define SDL_ASSEMBLY_ROUTINES 1
+
+/* #undef HAVE_LIBSAMPLERATE_H */
+
+/* Enable dynamic libsamplerate support */
+/* #undef SDL_LIBSAMPLERATE_DYNAMIC */
+
+#define HAVE_LIBC 1
+
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_STDIO_H 1
+#define STDC_HEADERS 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_WCHAR_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_MATH_H 1
+#define HAVE_FLOAT_H 1
+#define HAVE_SIGNAL_H 1
+
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#if defined(__WATCOMC__)
+#define HAVE__FSEEKI64 1
+#define HAVE__FTELLI64 1
+#endif
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_BCOPY 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMCMP 1
+#define HAVE_WCSLEN 1
+#define HAVE_WCSLCPY 1
+#define HAVE_WCSLCAT 1
+#define HAVE_WCSCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY 1
+#define HAVE_STRLCAT 1
+#define HAVE__STRREV 1
+#define HAVE__STRUPR 1
+#define HAVE__STRLWR 1
+#define HAVE_INDEX 1
+#define HAVE_RINDEX 1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+#define HAVE_ITOA 1
+#define HAVE__LTOA 1
+#define HAVE__ULTOA 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+#define HAVE__I64TOA 1
+#define HAVE__UI64TOA 1
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#define HAVE_STRICMP 1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_SSCANF 1
+#define HAVE_SNPRINTF 1
+#define HAVE_VSNPRINTF 1
+#define HAVE_SETJMP 1
+#define HAVE_ACOS 1
+/* #undef HAVE_ACOSF */
+#define HAVE_ASIN 1
+/* #undef HAVE_ASINF */
+#define HAVE_ATAN 1
+#define HAVE_ATAN2 1
+/* #undef HAVE_ATAN2F */
+#define HAVE_CEIL 1
+/* #undef HAVE_CEILF */
+/* #undef HAVE_COPYSIGN */
+/* #undef HAVE_COPYSIGNF */
+#define HAVE_COS 1
+/* #undef HAVE_COSF */
+#define HAVE_EXP 1
+/* #undef HAVE_EXPF */
+#define HAVE_FABS 1
+/* #undef HAVE_FABSF */
+#define HAVE_FLOOR 1
+/* #undef HAVE_FLOORF */
+#define HAVE_FMOD 1
+/* #undef HAVE_FMODF */
+#define HAVE_LOG 1
+/* #undef HAVE_LOGF */
+#define HAVE_LOG10 1
+/* #undef HAVE_LOG10F */
+#define HAVE_POW 1
+/* #undef HAVE_POWF */
+#define HAVE_SIN 1
+/* #undef HAVE_SINF */
+/* #undef HAVE_SCALBN */
+/* #undef HAVE_SCALBNF */
+#define HAVE_SQRT 1
+/* #undef HAVE_SQRTF */
+#define HAVE_TAN 1
+/* #undef HAVE_TANF */
+
+#endif /* SDL_config_os2_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_pandora.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_pandora.h
@@ -1,0 +1,133 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_pandora_h_
+#define SDL_config_pandora_h_
+#define SDL_config_h_
+
+/* This is a set of defines to configure the SDL features */
+
+/* General platform specific identifiers */
+#include "SDL_platform.h"
+
+#ifdef __LP64__
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+
+#define SDL_BYTEORDER 1234
+
+#define STDC_HEADERS 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_ICONV_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MATH_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_UNSETENV 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_BCOPY 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_STRLEN 1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF 1
+#define HAVE_M_PI 1
+#define HAVE_CEIL 1
+#define HAVE_COPYSIGN 1
+#define HAVE_COS 1
+#define HAVE_COSF 1
+#define HAVE_EXP 1
+#define HAVE_FABS 1
+#define HAVE_FLOOR 1
+#define HAVE_LOG 1
+#define HAVE_LOG10 1
+#define HAVE_SCALBN 1
+#define HAVE_SIN 1
+#define HAVE_SINF 1
+#define HAVE_SQRT 1
+#define HAVE_SQRTF 1
+#define HAVE_TAN 1
+#define HAVE_TANF 1
+#define HAVE_SIGACTION 1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP 1
+
+#define SDL_AUDIO_DRIVER_DUMMY 1
+#define SDL_AUDIO_DRIVER_OSS 1
+
+#define SDL_INPUT_LINUXEV 1
+#define SDL_INPUT_TSLIB 1
+#define SDL_JOYSTICK_LINUX 1
+#define SDL_HAPTIC_LINUX 1
+
+#define SDL_SENSOR_DUMMY 1
+
+#define SDL_LOADSO_DLOPEN 1
+
+#define SDL_THREAD_PTHREAD 1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP 1
+
+#define SDL_TIMER_UNIX 1
+#define SDL_FILESYSTEM_UNIX 1
+
+#define SDL_VIDEO_DRIVER_DUMMY 1
+#define SDL_VIDEO_DRIVER_X11 1
+#define SDL_VIDEO_DRIVER_PANDORA 1
+#define SDL_VIDEO_RENDER_OGL_ES 1
+#define SDL_VIDEO_OPENGL_ES 1
+
+#endif /* SDL_config_pandora_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_psp.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_psp.h
@@ -1,0 +1,164 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_psp_h_
+#define SDL_config_psp_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+
+
+#ifdef __GNUC__
+#define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
+#endif
+
+#define HAVE_GCC_ATOMICS    1
+
+#define STDC_HEADERS    1
+#define HAVE_ALLOCA_H       1
+#define HAVE_CTYPE_H    1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H   1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H   1
+#define HAVE_STDINT_H   1
+#define HAVE_STDIO_H    1
+#define HAVE_STRING_H   1
+#define HAVE_SYS_TYPES_H    1
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC    1
+#define HAVE_FREE   1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_SETENV 1
+#define HAVE_UNSETENV   1
+#define HAVE_QSORT  1
+#define HAVE_ABS    1
+#define HAVE_BCOPY  1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE    1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY    1
+#define HAVE_STRLCAT    1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR    1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL    1
+#define HAVE_STRTOLL    1
+#define HAVE_STRTOULL   1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI   1
+#define HAVE_ATOF   1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP    1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF  1
+#define HAVE_M_PI   1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE_COPYSIGN   1
+#define HAVE_COPYSIGNF  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP  1
+/* #define HAVE_SYSCONF  1 */
+/* #define HAVE_SIGACTION    1 */
+
+
+/* PSP isn't that sophisticated */
+#define LACKS_SYS_MMAN_H 1
+
+/* Enable the PSP thread support (src/thread/psp/\*.c) */
+#define SDL_THREAD_PSP  1
+
+/* Enable the PSP timer support (src/timer/psp/\*.c) */
+#define SDL_TIMERS_PSP  1
+
+/* Enable the PSP joystick driver (src/joystick/psp/\*.c) */
+#define SDL_JOYSTICK_PSP        1
+
+/* Enable the dummy sensor driver */
+#define SDL_SENSOR_DUMMY  1
+
+/* Enable the PSP audio driver (src/audio/psp/\*.c) */
+#define SDL_AUDIO_DRIVER_PSP    1
+
+/* PSP video driver */
+#define SDL_VIDEO_DRIVER_PSP   1
+
+/* PSP render driver */
+#define SDL_VIDEO_RENDER_PSP   1
+
+#define SDL_POWER_PSP          1
+
+/* !!! FIXME: what does PSP do for filesystem stuff? */
+#define SDL_FILESYSTEM_DUMMY   1
+
+/* PSP doesn't have haptic device (src/haptic/dummy/\*.c) */
+#define SDL_HAPTIC_DISABLED    1
+
+/* PSP can't load shared object (src/loadso/dummy/\*.c) */
+#define SDL_LOADSO_DISABLED    1
+
+
+#endif /* SDL_config_psp_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_windows.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_windows.h
@@ -1,0 +1,257 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_windows_h_
+#define SDL_config_windows_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+/* This is a set of defines to configure the SDL features */
+
+#if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
+#if defined(__GNUC__) || defined(__DMC__) || defined(__WATCOMC__)
+#define HAVE_STDINT_H   1
+#elif defined(_MSC_VER)
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#ifndef _UINTPTR_T_DEFINED
+#ifdef  _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned int uintptr_t;
+#endif
+#define _UINTPTR_T_DEFINED
+#endif
+/* Older Visual C++ headers don't have the Win64-compatible typedefs... */
+#if ((_MSC_VER <= 1200) && (!defined(DWORD_PTR)))
+#define DWORD_PTR DWORD
+#endif
+#if ((_MSC_VER <= 1200) && (!defined(LONG_PTR)))
+#define LONG_PTR LONG
+#endif
+#else /* !__GNUC__ && !_MSC_VER */
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef unsigned int size_t;
+#endif
+typedef unsigned int uintptr_t;
+#endif /* __GNUC__ || _MSC_VER */
+#endif /* !_STDINT_H_ && !HAVE_STDINT_H */
+
+#ifdef _WIN64
+# define SIZEOF_VOIDP 8
+#else
+# define SIZEOF_VOIDP 4
+#endif
+
+#define HAVE_DDRAW_H 1
+#define HAVE_DINPUT_H 1
+#define HAVE_DSOUND_H 1
+#define HAVE_DXGI_H 1
+#define HAVE_XINPUT_H 1
+#define HAVE_MMDEVICEAPI_H 1
+#define HAVE_AUDIOCLIENT_H 1
+#define HAVE_ENDPOINTVOLUME_H 1
+
+/* This is disabled by default to avoid C runtime dependencies and manifest requirements */
+#ifdef HAVE_LIBC
+/* Useful headers */
+#define STDC_HEADERS 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STRING_H 1
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#define HAVE_ALLOCA 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE__STRREV 1
+/* These functions have security warnings, so we won't use them */
+/* #undef HAVE__STRUPR */
+/* #undef HAVE__STRLWR */
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+/* These functions have security warnings, so we won't use them */
+/* #undef HAVE__LTOA */
+/* #undef HAVE__ULTOA */
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#define HAVE__STRICMP 1
+#define HAVE__STRNICMP 1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEILF  1
+#define HAVE__COPYSIGN  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#if defined(_MSC_VER)
+/* These functions were added with the VC++ 2013 C runtime library */
+#if _MSC_VER >= 1800
+#define HAVE_STRTOLL 1
+#define HAVE_VSSCANF 1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#endif
+/* This function is available with at least the VC++ 2008 C runtime library */
+#if _MSC_VER >= 1400
+#define HAVE__FSEEKI64 1
+#endif
+#endif
+#if !defined(_MSC_VER) || defined(_USE_MATH_DEFINES)
+#define HAVE_M_PI 1
+#endif
+#else
+#define HAVE_STDARG_H   1
+#define HAVE_STDDEF_H   1
+#endif
+
+/* Enable various audio drivers */
+#define SDL_AUDIO_DRIVER_WASAPI 1
+#define SDL_AUDIO_DRIVER_DSOUND 1
+#define SDL_AUDIO_DRIVER_WINMM  1
+#define SDL_AUDIO_DRIVER_DISK   1
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable various input drivers */
+#define SDL_JOYSTICK_DINPUT 1
+#define SDL_JOYSTICK_XINPUT 1
+#define SDL_JOYSTICK_HIDAPI 1
+#define SDL_HAPTIC_DINPUT   1
+#define SDL_HAPTIC_XINPUT   1
+
+/* Enable the dummy sensor driver */
+#define SDL_SENSOR_DUMMY  1
+
+/* Enable various shared object loading systems */
+#define SDL_LOADSO_WINDOWS  1
+
+/* Enable various threading systems */
+#define SDL_THREAD_WINDOWS  1
+
+/* Enable various timer systems */
+#define SDL_TIMER_WINDOWS   1
+
+/* Enable various video drivers */
+#define SDL_VIDEO_DRIVER_DUMMY  1
+#define SDL_VIDEO_DRIVER_WINDOWS    1
+
+#ifndef SDL_VIDEO_RENDER_D3D
+#define SDL_VIDEO_RENDER_D3D    1
+#endif
+#ifndef SDL_VIDEO_RENDER_D3D11
+#define SDL_VIDEO_RENDER_D3D11  0
+#endif
+
+/* Enable OpenGL support */
+#ifndef SDL_VIDEO_OPENGL
+#define SDL_VIDEO_OPENGL    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_WGL
+#define SDL_VIDEO_OPENGL_WGL    1
+#endif
+#ifndef SDL_VIDEO_RENDER_OGL
+#define SDL_VIDEO_RENDER_OGL    1
+#endif
+#ifndef SDL_VIDEO_RENDER_OGL_ES2
+#define SDL_VIDEO_RENDER_OGL_ES2    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_ES2
+#define SDL_VIDEO_OPENGL_ES2    1
+#endif
+#ifndef SDL_VIDEO_OPENGL_EGL
+#define SDL_VIDEO_OPENGL_EGL    1
+#endif
+
+/* Enable Vulkan support */
+#define SDL_VIDEO_VULKAN 1
+
+/* Enable system power support */
+#define SDL_POWER_WINDOWS 1
+
+/* Enable filesystem support */
+#define SDL_FILESYSTEM_WINDOWS  1
+
+/* Enable assembly routines (Win64 doesn't have inline asm) */
+#ifndef _WIN64
+#define SDL_ASSEMBLY_ROUTINES   1
+#endif
+
+#endif /* SDL_config_windows_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_winrt.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_winrt.h
@@ -1,0 +1,240 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_winrt_h_
+#define SDL_config_winrt_h_
+#define SDL_config_h_
+
+#include "SDL_platform.h"
+
+/* Make sure the Windows SDK's NTDDI_VERSION macro gets defined.  This is used
+   by SDL to determine which version of the Windows SDK is being used.
+*/
+#include <sdkddkver.h>
+
+/* Define possibly-undefined NTDDI values (used when compiling SDL against
+   older versions of the Windows SDK.
+*/
+#ifndef NTDDI_WINBLUE
+#define NTDDI_WINBLUE 0x06030000
+#endif
+#ifndef NTDDI_WIN10
+#define NTDDI_WIN10 0x0A000000
+#endif
+
+/* This is a set of defines to configure the SDL features */
+
+#if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
+#if defined(__GNUC__) || defined(__DMC__) || defined(__WATCOMC__)
+#define HAVE_STDINT_H   1
+#elif defined(_MSC_VER)
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#ifndef _UINTPTR_T_DEFINED
+#ifdef  _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned int uintptr_t;
+#endif
+#define _UINTPTR_T_DEFINED
+#endif
+/* Older Visual C++ headers don't have the Win64-compatible typedefs... */
+#if ((_MSC_VER <= 1200) && (!defined(DWORD_PTR)))
+#define DWORD_PTR DWORD
+#endif
+#if ((_MSC_VER <= 1200) && (!defined(LONG_PTR)))
+#define LONG_PTR LONG
+#endif
+#else /* !__GNUC__ && !_MSC_VER */
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef unsigned int size_t;
+#endif
+typedef unsigned int uintptr_t;
+#endif /* __GNUC__ || _MSC_VER */
+#endif /* !_STDINT_H_ && !HAVE_STDINT_H */
+
+#ifdef _WIN64
+# define SIZEOF_VOIDP 8
+#else
+# define SIZEOF_VOIDP 4
+#endif
+
+/* Useful headers */
+#define HAVE_DXGI_H 1
+#if WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP
+#define HAVE_XINPUT_H 1
+#endif
+
+#define HAVE_MMDEVICEAPI_H 1
+#define HAVE_AUDIOCLIENT_H 1
+#define HAVE_ENDPOINTVOLUME_H 1
+
+#define HAVE_LIBC 1
+#define STDC_HEADERS 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STRING_H 1
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#define HAVE_ALLOCA 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE__STRREV 1
+#define HAVE__STRUPR 1
+//#define HAVE__STRLWR 1    // TODO, WinRT: consider using _strlwr_s instead
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+//#define HAVE_ITOA 1   // TODO, WinRT: consider using _itoa_s instead
+//#define HAVE__LTOA 1  // TODO, WinRT: consider using _ltoa_s instead
+//#define HAVE__ULTOA 1 // TODO, WinRT: consider using _ultoa_s instead
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+//#define HAVE_STRTOLL 1
+#define HAVE_STRTOD 1
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#define HAVE__STRICMP 1
+#define HAVE__STRNICMP 1
+#define HAVE_VSNPRINTF 1
+//#define HAVE_SSCANF 1 // TODO, WinRT: consider using sscanf_s instead
+#define HAVE_M_PI 1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE__COPYSIGN 1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE__SCALB 1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE__FSEEKI64 1
+
+/* Enable various audio drivers */
+#define SDL_AUDIO_DRIVER_WASAPI 1
+#define SDL_AUDIO_DRIVER_DISK   1
+#define SDL_AUDIO_DRIVER_DUMMY  1
+
+/* Enable various input drivers */
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#define SDL_JOYSTICK_DISABLED 1
+#define SDL_HAPTIC_DISABLED 1
+#else
+#define SDL_JOYSTICK_XINPUT 1
+#define SDL_HAPTIC_XINPUT   1
+#endif
+
+/* Enable the dummy sensor driver */
+#define SDL_SENSOR_DUMMY  1
+
+/* Enable various shared object loading systems */
+#define SDL_LOADSO_WINDOWS  1
+
+/* Enable various threading systems */
+#if (NTDDI_VERSION >= NTDDI_WINBLUE)
+#define SDL_THREAD_WINDOWS  1
+#else
+/* WinRT on Windows 8.0 and Windows Phone 8.0 don't support CreateThread() */
+#define SDL_THREAD_STDCPP   1
+#endif
+
+/* Enable various timer systems */
+#define SDL_TIMER_WINDOWS   1
+
+/* Enable various video drivers */
+#define SDL_VIDEO_DRIVER_WINRT  1
+#define SDL_VIDEO_DRIVER_DUMMY  1
+
+/* Enable OpenGL ES 2.0 (via a modified ANGLE library) */
+#define SDL_VIDEO_OPENGL_ES2 1
+#define SDL_VIDEO_OPENGL_EGL 1
+
+/* Enable appropriate renderer(s) */
+#define SDL_VIDEO_RENDER_D3D11  1
+
+#if SDL_VIDEO_OPENGL_ES2
+#define SDL_VIDEO_RENDER_OGL_ES2 1
+#endif
+
+/* Enable system power support */
+#define SDL_POWER_WINRT 1
+
+/* Enable assembly routines (Win64 doesn't have inline asm) */
+#ifndef _WIN64
+#define SDL_ASSEMBLY_ROUTINES   1
+#endif
+
+#endif /* SDL_config_winrt_h_ */

--- a/sdl2-sys/SDL2-2.0.9/include/SDL_config_wiz.h
+++ b/sdl2-sys/SDL2-2.0.9/include/SDL_config_wiz.h
@@ -1,0 +1,146 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_wiz_h_
+#define SDL_config_wiz_h_
+#define SDL_config_h_
+
+/* This is a set of defines to configure the SDL features */
+
+/* General platform specific identifiers */
+#include "SDL_platform.h"
+
+#define SDL_BYTEORDER 1234
+
+#define STDC_HEADERS 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_ICONV_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MATH_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#define HAVE_ALLOCA 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+#define HAVE_UNSETENV 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_BCOPY 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_STRLEN 1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#define HAVE_STRCASECMP 1
+#define HAVE_STRNCASECMP 1
+#define HAVE_VSSCANF 1
+#define HAVE_VSNPRINTF 1
+#define HAVE_M_PI 1
+#define HAVE_ACOS   1
+#define HAVE_ACOSF  1
+#define HAVE_ASIN   1
+#define HAVE_ASINF  1
+#define HAVE_ATAN   1
+#define HAVE_ATANF  1
+#define HAVE_ATAN2  1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL   1
+#define HAVE_CEILF  1
+#define HAVE_COPYSIGN   1
+#define HAVE_COPYSIGNF  1
+#define HAVE_COS    1
+#define HAVE_COSF   1
+#define HAVE_EXP    1
+#define HAVE_EXPF   1
+#define HAVE_FABS   1
+#define HAVE_FABSF  1
+#define HAVE_FLOOR  1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD   1
+#define HAVE_FMODF  1
+#define HAVE_LOG    1
+#define HAVE_LOGF   1
+#define HAVE_LOG10  1
+#define HAVE_LOG10F 1
+#define HAVE_POW    1
+#define HAVE_POWF   1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF    1
+#define HAVE_SIN    1
+#define HAVE_SINF   1
+#define HAVE_SQRT   1
+#define HAVE_SQRTF  1
+#define HAVE_TAN    1
+#define HAVE_TANF   1
+#define HAVE_SIGACTION 1
+#define HAVE_SETJMP 1
+#define HAVE_NANOSLEEP 1
+#define HAVE_POW 1
+
+#define SDL_AUDIO_DRIVER_DUMMY 1
+#define SDL_AUDIO_DRIVER_OSS 1
+
+#define SDL_INPUT_LINUXEV 1
+#define SDL_INPUT_TSLIB 1
+#define SDL_JOYSTICK_LINUX 1
+#define SDL_HAPTIC_LINUX 1
+
+#define SDL_SENSOR_DUMMY  1
+
+#define SDL_LOADSO_DLOPEN 1
+
+#define SDL_THREAD_PTHREAD 1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP 1
+
+#define SDL_TIMER_UNIX 1
+
+#define SDL_VIDEO_DRIVER_DUMMY 1
+#define SDL_VIDEO_DRIVER_PANDORA 1
+#define SDL_VIDEO_RENDER_OGL_ES 1
+#define SDL_VIDEO_OPENGL_ES 1
+
+#endif /* SDL_config_wiz_h_ */


### PR DESCRIPTION
Somehow the config headers got messed up when they were updated to SDL 2.0.9. The ones currently in the repo contain a Windows-specific SDL_config.h found in the zip containing the development libraries from libsdl.org, so maybe it comes from there.
I replaced that header with all the SDL_config* files from the SDL 2.0.9 tarball and now it builds fine on Linux and macOS when using the `use-bindgen` feature with the bundled headers.