### PR TITLE
Replace reqwest with calls to curl/powershell

### DIFF
--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -27,10 +27,6 @@ optional = true
 version = "^0.1"
 optional = true
 
-[build-dependencies.reqwest]
-version = "^0.9"
-optional = true
-
 [build-dependencies.tar]
 version = "^0.4"
 optional = true
@@ -53,7 +49,7 @@ use-pkgconfig = ["pkg-config"]
 use-bindgen = ["bindgen"]
 static-link = []
 use_mac_framework = []
-bundled = ["cmake", "reqwest", "tar", "flate2", "unidiff"]
+bundled = ["cmake", "tar", "flate2", "unidiff"]
 mixer = []
 image = []
 ttf = []


### PR DESCRIPTION
This removes the dependency on the reqwest library and replaces it with calls to external tools (PowerShell on Windows and `curl` everywhere else) to download the SDL2 source when using the `bundled` feature. I've tested it on Windows 10; you probably want to give it a spin on Linux and MacOS before merging.

Closes #820