### PR TITLE
Update `sdl_bindings.rs` to SDL 2.0.9

### DIFF
--- a/sdl2-sys/sdl_bindings.rs
+++ b/sdl2-sys/sdl_bindings.rs
@@ -8,6 +8,7 @@ pub const HAVE_GCC_SYNC_LOCK_TEST_AND_SET: u32 = 1;
 pub const SDL_AUDIO_DRIVER_DUMMY: u32 = 1;
 pub const SDL_JOYSTICK_DISABLED: u32 = 1;
 pub const SDL_HAPTIC_DISABLED: u32 = 1;
+pub const SDL_SENSOR_DISABLED: u32 = 1;
 pub const SDL_LOADSO_DISABLED: u32 = 1;
 pub const SDL_THREADS_DISABLED: u32 = 1;
 pub const SDL_TIMERS_DISABLED: u32 = 1;
@@ -38,10 +39,9 @@ pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __STDC_NO_THREADS__: u32 = 1;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 27;
+pub const __GLIBC_MINOR__: u32 = 28;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
@@ -155,7 +155,8 @@ pub const AUDIO_F32SYS: u32 = 33056;
 pub const SDL_AUDIO_ALLOW_FREQUENCY_CHANGE: u32 = 1;
 pub const SDL_AUDIO_ALLOW_FORMAT_CHANGE: u32 = 2;
 pub const SDL_AUDIO_ALLOW_CHANNELS_CHANGE: u32 = 4;
-pub const SDL_AUDIO_ALLOW_ANY_CHANGE: u32 = 7;
+pub const SDL_AUDIO_ALLOW_SAMPLES_CHANGE: u32 = 8;
+pub const SDL_AUDIO_ALLOW_ANY_CHANGE: u32 = 15;
 pub const SDL_AUDIOCVT_MAX_FILTERS: u32 = 9;
 pub const SDL_MIX_MAXVOLUME: u32 = 128;
 pub const _STDLIB_H: u32 = 1;
@@ -168,7 +169,6 @@ pub const WNOWAIT: u32 = 16777216;
 pub const __WNOTHREAD: u32 = 536870912;
 pub const __WALL: u32 = 1073741824;
 pub const __WCLONE: u32 = 2147483648;
-pub const __ENUM_IDTYPE_T: u32 = 1;
 pub const __W_CONTINUED: u32 = 65535;
 pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
@@ -202,10 +202,8 @@ pub const _SYS_SELECT_H: u32 = 1;
 pub const __FD_ZERO_STOS: &'static [u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
-pub const __timespec_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
-pub const _SYS_SYSMACROS_H: u32 = 1;
-pub const _BITS_SYSMACROS_H: u32 = 1;
 pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
 pub const _THREAD_SHARED_TYPES_H: u32 = 1;
 pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
@@ -339,6 +337,10 @@ pub const SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL: &'static [u8; 35usize] =
 pub const SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP: &'static [u8; 31usize] =
     b"SDL_WINDOWS_ENABLE_MESSAGELOOP\0";
 pub const SDL_HINT_GRAB_KEYBOARD: &'static [u8; 18usize] = b"SDL_GRAB_KEYBOARD\0";
+pub const SDL_HINT_MOUSE_DOUBLE_CLICK_TIME: &'static [u8; 28usize] =
+    b"SDL_MOUSE_DOUBLE_CLICK_TIME\0";
+pub const SDL_HINT_MOUSE_DOUBLE_CLICK_RADIUS: &'static [u8; 30usize] =
+    b"SDL_MOUSE_DOUBLE_CLICK_RADIUS\0";
 pub const SDL_HINT_MOUSE_NORMAL_SPEED_SCALE: &'static [u8; 29usize] =
     b"SDL_MOUSE_NORMAL_SPEED_SCALE\0";
 pub const SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE: &'static [u8; 31usize] =
@@ -371,6 +373,15 @@ pub const SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT: &'static [u8; 41usize] 
     b"SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT\0";
 pub const SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS: &'static [u8; 37usize] =
     b"SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI: &'static [u8; 20usize] = b"SDL_JOYSTICK_HIDAPI\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI_PS4: &'static [u8; 24usize] = b"SDL_JOYSTICK_HIDAPI_PS4\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE: &'static [u8; 31usize] =
+    b"SDL_JOYSTICK_HIDAPI_PS4_RUMBLE\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI_STEAM: &'static [u8; 26usize] = b"SDL_JOYSTICK_HIDAPI_STEAM\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI_SWITCH: &'static [u8; 27usize] = b"SDL_JOYSTICK_HIDAPI_SWITCH\0";
+pub const SDL_HINT_JOYSTICK_HIDAPI_XBOX: &'static [u8; 25usize] = b"SDL_JOYSTICK_HIDAPI_XBOX\0";
+pub const SDL_HINT_ENABLE_STEAM_CONTROLLERS: &'static [u8; 29usize] =
+    b"SDL_ENABLE_STEAM_CONTROLLERS\0";
 pub const SDL_HINT_ALLOW_TOPMOST: &'static [u8; 18usize] = b"SDL_ALLOW_TOPMOST\0";
 pub const SDL_HINT_TIMER_RESOLUTION: &'static [u8; 21usize] = b"SDL_TIMER_RESOLUTION\0";
 pub const SDL_HINT_QTWAYLAND_CONTENT_ORIENTATION: &'static [u8; 34usize] =
@@ -399,6 +410,8 @@ pub const SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION: &'static [u8; 45usi
 pub const SDL_HINT_IME_INTERNAL_EDITING: &'static [u8; 25usize] = b"SDL_IME_INTERNAL_EDITING\0";
 pub const SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH: &'static [u8; 37usize] =
     b"SDL_ANDROID_SEPARATE_MOUSE_AND_TOUCH\0";
+pub const SDL_HINT_ANDROID_TRAP_BACK_BUTTON: &'static [u8; 29usize] =
+    b"SDL_ANDROID_TRAP_BACK_BUTTON\0";
 pub const SDL_HINT_RETURN_KEY_HIDES_IME: &'static [u8; 25usize] = b"SDL_RETURN_KEY_HIDES_IME\0";
 pub const SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT: &'static [u8; 32usize] =
     b"SDL_EMSCRIPTEN_KEYBOARD_ELEMENT\0";
@@ -414,12 +427,13 @@ pub const SDL_HINT_OPENGL_ES_DRIVER: &'static [u8; 21usize] = b"SDL_OPENGL_ES_DR
 pub const SDL_HINT_AUDIO_RESAMPLING_MODE: &'static [u8; 26usize] = b"SDL_AUDIO_RESAMPLING_MODE\0";
 pub const SDL_HINT_AUDIO_CATEGORY: &'static [u8; 19usize] = b"SDL_AUDIO_CATEGORY\0";
 pub const SDL_MAX_LOG_MESSAGE: u32 = 4096;
+pub const SDL_STANDARD_GRAVITY: f64 = 9.80665;
 pub const SDL_NONSHAPEABLE_WINDOW: i32 = -1;
 pub const SDL_INVALID_SHAPE_ARGUMENT: i32 = -2;
 pub const SDL_WINDOW_LACKS_SHAPE: i32 = -3;
 pub const SDL_MAJOR_VERSION: u32 = 2;
 pub const SDL_MINOR_VERSION: u32 = 0;
-pub const SDL_PATCHLEVEL: u32 = 8;
+pub const SDL_PATCHLEVEL: u32 = 9;
 pub const SDL_INIT_TIMER: u32 = 1;
 pub const SDL_INIT_AUDIO: u32 = 16;
 pub const SDL_INIT_VIDEO: u32 = 32;
@@ -427,8 +441,9 @@ pub const SDL_INIT_JOYSTICK: u32 = 512;
 pub const SDL_INIT_HAPTIC: u32 = 4096;
 pub const SDL_INIT_GAMECONTROLLER: u32 = 8192;
 pub const SDL_INIT_EVENTS: u32 = 16384;
+pub const SDL_INIT_SENSOR: u32 = 32768;
 pub const SDL_INIT_NOPARACHUTE: u32 = 1048576;
-pub const SDL_INIT_EVERYTHING: u32 = 29233;
+pub const SDL_INIT_EVERYTHING: u32 = 62001;
 pub const XlibSpecificationRelease: u32 = 6;
 pub const X_PROTOCOL: u32 = 11;
 pub const X_PROTOCOL_REVISION: u32 = 0;
@@ -883,7 +898,7 @@ pub const XIMHotKeyStateON: u32 = 1;
 pub const XIMHotKeyStateOFF: u32 = 2;
 pub const XATOM_H: u32 = 1;
 extern "C" {
-    /// \brief Gets the name of the platform.
+    ///  \brief Gets the name of the platform.
     pub fn SDL_GetPlatform() -> *const ::std::os::raw::c_char;
 }
 pub type wchar_t = ::std::os::raw::c_int;
@@ -901,6 +916,14 @@ pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
 pub type __quad_t = ::std::os::raw::c_long;
 pub type __u_quad_t = ::std::os::raw::c_ulong;
 pub type __intmax_t = ::std::os::raw::c_long;
@@ -970,14 +993,14 @@ pub type __caddr_t = *mut ::std::os::raw::c_char;
 pub type __intptr_t = ::std::os::raw::c_long;
 pub type __socklen_t = ::std::os::raw::c_uint;
 pub type __sig_atomic_t = ::std::os::raw::c_int;
-pub type int_least8_t = ::std::os::raw::c_schar;
-pub type int_least16_t = ::std::os::raw::c_short;
-pub type int_least32_t = ::std::os::raw::c_int;
-pub type int_least64_t = ::std::os::raw::c_long;
-pub type uint_least8_t = ::std::os::raw::c_uchar;
-pub type uint_least16_t = ::std::os::raw::c_ushort;
-pub type uint_least32_t = ::std::os::raw::c_uint;
-pub type uint_least64_t = ::std::os::raw::c_ulong;
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
 pub type int_fast8_t = ::std::os::raw::c_schar;
 pub type int_fast16_t = ::std::os::raw::c_long;
 pub type int_fast32_t = ::std::os::raw::c_long;
@@ -1037,13 +1060,15 @@ pub type SDL_calloc_func = ::std::option::Option<
     unsafe extern "C" fn(nmemb: usize, size: usize) -> *mut ::std::os::raw::c_void,
 >;
 pub type SDL_realloc_func = ::std::option::Option<
-    unsafe extern "C" fn(mem: *mut ::std::os::raw::c_void, size: usize)
-        -> *mut ::std::os::raw::c_void,
+    unsafe extern "C" fn(
+        mem: *mut ::std::os::raw::c_void,
+        size: usize,
+    ) -> *mut ::std::os::raw::c_void,
 >;
 pub type SDL_free_func =
     ::std::option::Option<unsafe extern "C" fn(mem: *mut ::std::os::raw::c_void)>;
 extern "C" {
-    /// \brief Get the current set of SDL memory functions
+    ///  \brief Get the current set of SDL memory functions
     pub fn SDL_GetMemoryFunctions(
         malloc_func: *mut SDL_malloc_func,
         calloc_func: *mut SDL_calloc_func,
@@ -1052,12 +1077,12 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Replace SDL's memory allocation functions with a custom set
+    ///  \brief Replace SDL's memory allocation functions with a custom set
     ///
-    /// \note If you are replacing SDL's memory functions, you should call
-    /// SDL_GetNumAllocations() and be very careful if it returns non-zero.
-    /// That means that your free function will be called with memory
-    /// allocated by the previous memory allocation functions.
+    ///  \note If you are replacing SDL's memory functions, you should call
+    ///        SDL_GetNumAllocations() and be very careful if it returns non-zero.
+    ///        That means that your free function will be called with memory
+    ///        allocated by the previous memory allocation functions.
     pub fn SDL_SetMemoryFunctions(
         malloc_func: SDL_malloc_func,
         calloc_func: SDL_calloc_func,
@@ -1066,7 +1091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the number of outstanding (unfreed) allocations
+    ///  \brief Get the number of outstanding (unfreed) allocations
     pub fn SDL_GetNumAllocations() -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1134,6 +1159,9 @@ extern "C" {
         s2: *const ::std::os::raw::c_void,
         len: usize,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SDL_wcsdup(wstr: *const wchar_t) -> *mut wchar_t;
 }
 extern "C" {
     pub fn SDL_wcslen(wstr: *const wchar_t) -> usize;
@@ -1385,6 +1413,12 @@ extern "C" {
     pub fn SDL_cosf(x: f32) -> f32;
 }
 extern "C" {
+    pub fn SDL_exp(x: f64) -> f64;
+}
+extern "C" {
+    pub fn SDL_expf(x: f32) -> f32;
+}
+extern "C" {
     pub fn SDL_fabs(x: f64) -> f64;
 }
 extern "C" {
@@ -1469,8 +1503,8 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    /// This function converts a string between encodings in one pass, returning a
-    /// string that must be freed with SDL_free() or NULL on error.
+    ///  This function converts a string between encodings in one pass, returning a
+    ///  string that must be freed with SDL_free() or NULL on error.
     pub fn SDL_iconv_string(
         tocode: *const ::std::os::raw::c_char,
         fromcode: *const ::std::os::raw::c_char,
@@ -1479,32 +1513,32 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    /// The prototype for the application's main() function
+    ///  The prototype for the application's main() function
     pub fn SDL_main(
         argc: ::std::os::raw::c_int,
         argv: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This is called by the real SDL main function to let the rest of the
-    /// library know that initialization was done properly.
+    ///  This is called by the real SDL main function to let the rest of the
+    ///  library know that initialization was done properly.
     ///
-    /// Calling this yourself without knowing what you're doing can cause
-    /// crashes and hard to diagnose problems with your application.
+    ///  Calling this yourself without knowing what you're doing can cause
+    ///  crashes and hard to diagnose problems with your application.
     pub fn SDL_SetMainReady();
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_AssertState {
-    /// < Retry the assert immediately.
+    ///< Retry the assert immediately.
     SDL_ASSERTION_RETRY = 0,
-    /// < Make the debugger trigger a breakpoint.
+    ///< Make the debugger trigger a breakpoint.
     SDL_ASSERTION_BREAK = 1,
-    /// < Terminate the program.
+    ///< Terminate the program.
     SDL_ASSERTION_ABORT = 2,
-    /// < Ignore the assert.
+    ///< Ignore the assert.
     SDL_ASSERTION_IGNORE = 3,
-    /// < Ignore the assert from now on.
+    ///< Ignore the assert from now on.
     SDL_ASSERTION_ALWAYS_IGNORE = 4,
 }
 #[repr(C)]
@@ -1610,91 +1644,93 @@ extern "C" {
     ) -> SDL_AssertState;
 }
 pub type SDL_AssertionHandler = ::std::option::Option<
-    unsafe extern "C" fn(data: *const SDL_AssertData, userdata: *mut ::std::os::raw::c_void)
-        -> SDL_AssertState,
+    unsafe extern "C" fn(
+        data: *const SDL_AssertData,
+        userdata: *mut ::std::os::raw::c_void,
+    ) -> SDL_AssertState,
 >;
 extern "C" {
-    /// \brief Set an application-defined assertion handler.
+    ///  \brief Set an application-defined assertion handler.
     ///
-    /// This allows an app to show its own assertion UI and/or force the
-    /// response to an assertion failure. If the app doesn't provide this, SDL
-    /// will try to do the right thing, popping up a system-specific GUI dialog,
-    /// and probably minimizing any fullscreen windows.
+    ///  This allows an app to show its own assertion UI and/or force the
+    ///  response to an assertion failure. If the app doesn't provide this, SDL
+    ///  will try to do the right thing, popping up a system-specific GUI dialog,
+    ///  and probably minimizing any fullscreen windows.
     ///
-    /// This callback may fire from any thread, but it runs wrapped in a mutex, so
-    /// it will only fire from one thread at a time.
+    ///  This callback may fire from any thread, but it runs wrapped in a mutex, so
+    ///  it will only fire from one thread at a time.
     ///
-    /// Setting the callback to NULL restores SDL's original internal handler.
+    ///  Setting the callback to NULL restores SDL's original internal handler.
     ///
-    /// This callback is NOT reset to SDL's internal handler upon SDL_Quit()!
+    ///  This callback is NOT reset to SDL's internal handler upon SDL_Quit()!
     ///
-    /// Return SDL_AssertState value of how to handle the assertion failure.
+    ///  Return SDL_AssertState value of how to handle the assertion failure.
     ///
-    /// \param handler Callback function, called when an assertion fails.
-    /// \param userdata A pointer passed to the callback as-is.
+    ///  \param handler Callback function, called when an assertion fails.
+    ///  \param userdata A pointer passed to the callback as-is.
     pub fn SDL_SetAssertionHandler(
         handler: SDL_AssertionHandler,
         userdata: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    /// \brief Get the default assertion handler.
+    ///  \brief Get the default assertion handler.
     ///
-    /// This returns the function pointer that is called by default when an
-    /// assertion is triggered. This is an internal function provided by SDL,
-    /// that is used for assertions when SDL_SetAssertionHandler() hasn't been
-    /// used to provide a different function.
+    ///  This returns the function pointer that is called by default when an
+    ///   assertion is triggered. This is an internal function provided by SDL,
+    ///   that is used for assertions when SDL_SetAssertionHandler() hasn't been
+    ///   used to provide a different function.
     ///
-    /// \return The default SDL_AssertionHandler that is called when an assert triggers.
+    ///  \return The default SDL_AssertionHandler that is called when an assert triggers.
     pub fn SDL_GetDefaultAssertionHandler() -> SDL_AssertionHandler;
 }
 extern "C" {
-    /// \brief Get the current assertion handler.
+    ///  \brief Get the current assertion handler.
     ///
-    /// This returns the function pointer that is called when an assertion is
-    /// triggered. This is either the value last passed to
-    /// SDL_SetAssertionHandler(), or if no application-specified function is
-    /// set, is equivalent to calling SDL_GetDefaultAssertionHandler().
+    ///  This returns the function pointer that is called when an assertion is
+    ///   triggered. This is either the value last passed to
+    ///   SDL_SetAssertionHandler(), or if no application-specified function is
+    ///   set, is equivalent to calling SDL_GetDefaultAssertionHandler().
     ///
-    /// \param puserdata Pointer to a void*, which will store the "userdata"
-    /// pointer that was passed to SDL_SetAssertionHandler().
-    /// This value will always be NULL for the default handler.
-    /// If you don't care about this data, it is safe to pass
-    /// a NULL pointer to this function to ignore it.
-    /// \return The SDL_AssertionHandler that is called when an assert triggers.
+    ///   \param puserdata Pointer to a void*, which will store the "userdata"
+    ///                    pointer that was passed to SDL_SetAssertionHandler().
+    ///                    This value will always be NULL for the default handler.
+    ///                    If you don't care about this data, it is safe to pass
+    ///                    a NULL pointer to this function to ignore it.
+    ///  \return The SDL_AssertionHandler that is called when an assert triggers.
     pub fn SDL_GetAssertionHandler(
         puserdata: *mut *mut ::std::os::raw::c_void,
     ) -> SDL_AssertionHandler;
 }
 extern "C" {
-    /// \brief Get a list of all assertion failures.
+    ///  \brief Get a list of all assertion failures.
     ///
-    /// Get all assertions triggered since last call to SDL_ResetAssertionReport(),
-    /// or the start of the program.
+    ///  Get all assertions triggered since last call to SDL_ResetAssertionReport(),
+    ///  or the start of the program.
     ///
-    /// The proper way to examine this data looks something like this:
+    ///  The proper way to examine this data looks something like this:
     ///
-    /// <code>
-    /// const SDL_AssertData *item = SDL_GetAssertionReport();
-    /// while (item) {
-    /// printf("'%s', %s (%s:%d), triggered %u times, always ignore: %s.\\n",
-    /// item->condition, item->function, item->filename,
-    /// item->linenum, item->trigger_count,
-    /// item->always_ignore ? "yes" : "no");
-    /// item = item->next;
-    /// }
-    /// </code>
+    ///  <code>
+    ///  const SDL_AssertData *item = SDL_GetAssertionReport();
+    ///  while (item) {
+    ///      printf("'%s', %s (%s:%d), triggered %u times, always ignore: %s.\\n",
+    ///             item->condition, item->function, item->filename,
+    ///             item->linenum, item->trigger_count,
+    ///             item->always_ignore ? "yes" : "no");
+    ///      item = item->next;
+    ///  }
+    ///  </code>
     ///
-    /// \return List of all assertions.
-    /// \sa SDL_ResetAssertionReport
+    ///  \return List of all assertions.
+    ///  \sa SDL_ResetAssertionReport
     pub fn SDL_GetAssertionReport() -> *const SDL_AssertData;
 }
 extern "C" {
-    /// \brief Reset the list of all assertion failures.
+    ///  \brief Reset the list of all assertion failures.
     ///
-    /// Reset list of all assertions triggered.
+    ///  Reset list of all assertions triggered.
     ///
-    /// \sa SDL_GetAssertionReport
+    ///  \sa SDL_GetAssertionReport
     pub fn SDL_ResetAssertionReport();
 }
 pub type SDL_SpinLock = ::std::os::raw::c_int;
@@ -1742,7 +1778,7 @@ extern "C" {
     pub fn SDL_MemoryBarrierAcquireFunction();
 }
 /// \brief A type representing an atomic integer value.  It is a struct
-/// so people don't accidentally use numeric operations on it.
+///        so people don't accidentally use numeric operations on it.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_atomic_t {
@@ -1854,23 +1890,23 @@ pub struct SDL_mutex {
     _unused: [u8; 0],
 }
 extern "C" {
-    /// Create a mutex, initialized unlocked.
+    ///  Create a mutex, initialized unlocked.
     pub fn SDL_CreateMutex() -> *mut SDL_mutex;
 }
 extern "C" {
     pub fn SDL_LockMutex(mutex: *mut SDL_mutex) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Try to lock the mutex
+    ///  Try to lock the mutex
     ///
-    /// \return 0, SDL_MUTEX_TIMEDOUT, or -1 on error
+    ///  \return 0, SDL_MUTEX_TIMEDOUT, or -1 on error
     pub fn SDL_TryLockMutex(mutex: *mut SDL_mutex) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SDL_UnlockMutex(mutex: *mut SDL_mutex) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Destroy a mutex.
+    ///  Destroy a mutex.
     pub fn SDL_DestroyMutex(mutex: *mut SDL_mutex);
 }
 #[repr(C)]
@@ -1880,44 +1916,44 @@ pub struct SDL_semaphore {
 }
 pub type SDL_sem = SDL_semaphore;
 extern "C" {
-    /// Create a semaphore, initialized with value, returns NULL on failure.
+    ///  Create a semaphore, initialized with value, returns NULL on failure.
     pub fn SDL_CreateSemaphore(initial_value: Uint32) -> *mut SDL_sem;
 }
 extern "C" {
-    /// Destroy a semaphore.
+    ///  Destroy a semaphore.
     pub fn SDL_DestroySemaphore(sem: *mut SDL_sem);
 }
 extern "C" {
-    /// This function suspends the calling thread until the semaphore pointed
-    /// to by \c sem has a positive count. It then atomically decreases the
-    /// semaphore count.
+    ///  This function suspends the calling thread until the semaphore pointed
+    ///  to by \c sem has a positive count. It then atomically decreases the
+    ///  semaphore count.
     pub fn SDL_SemWait(sem: *mut SDL_sem) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Non-blocking variant of SDL_SemWait().
+    ///  Non-blocking variant of SDL_SemWait().
     ///
-    /// \return 0 if the wait succeeds, ::SDL_MUTEX_TIMEDOUT if the wait would
-    /// block, and -1 on error.
+    ///  \return 0 if the wait succeeds, ::SDL_MUTEX_TIMEDOUT if the wait would
+    ///          block, and -1 on error.
     pub fn SDL_SemTryWait(sem: *mut SDL_sem) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Variant of SDL_SemWait() with a timeout in milliseconds.
+    ///  Variant of SDL_SemWait() with a timeout in milliseconds.
     ///
-    /// \return 0 if the wait succeeds, ::SDL_MUTEX_TIMEDOUT if the wait does not
-    /// succeed in the allotted time, and -1 on error.
+    ///  \return 0 if the wait succeeds, ::SDL_MUTEX_TIMEDOUT if the wait does not
+    ///          succeed in the allotted time, and -1 on error.
     ///
-    /// \warning On some platforms this function is implemented by looping with a
-    /// delay of 1 ms, and so should be avoided if possible.
+    ///  \warning On some platforms this function is implemented by looping with a
+    ///           delay of 1 ms, and so should be avoided if possible.
     pub fn SDL_SemWaitTimeout(sem: *mut SDL_sem, ms: Uint32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Atomically increases the semaphore's count (not blocking).
+    ///  Atomically increases the semaphore's count (not blocking).
     ///
-    /// \return 0, or -1 on error.
+    ///  \return 0, or -1 on error.
     pub fn SDL_SemPost(sem: *mut SDL_sem) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Returns the current count of the semaphore.
+    ///  Returns the current count of the semaphore.
     pub fn SDL_SemValue(sem: *mut SDL_sem) -> Uint32;
 }
 #[repr(C)]
@@ -1926,67 +1962,67 @@ pub struct SDL_cond {
     _unused: [u8; 0],
 }
 extern "C" {
-    /// Create a condition variable.
+    ///  Create a condition variable.
     ///
-    /// Typical use of condition variables:
+    ///  Typical use of condition variables:
     ///
-    /// Thread A:
-    /// SDL_LockMutex(lock);
-    /// while ( ! condition ) {
-    /// SDL_CondWait(cond, lock);
-    /// }
-    /// SDL_UnlockMutex(lock);
+    ///  Thread A:
+    ///    SDL_LockMutex(lock);
+    ///    while ( ! condition ) {
+    ///        SDL_CondWait(cond, lock);
+    ///    }
+    ///    SDL_UnlockMutex(lock);
     ///
-    /// Thread B:
-    /// SDL_LockMutex(lock);
-    /// ...
-    /// condition = true;
-    /// ...
-    /// SDL_CondSignal(cond);
-    /// SDL_UnlockMutex(lock);
+    ///  Thread B:
+    ///    SDL_LockMutex(lock);
+    ///    ...
+    ///    condition = true;
+    ///    ...
+    ///    SDL_CondSignal(cond);
+    ///    SDL_UnlockMutex(lock);
     ///
-    /// There is some discussion whether to signal the condition variable
-    /// with the mutex locked or not.  There is some potential performance
-    /// benefit to unlocking first on some platforms, but there are some
-    /// potential race conditions depending on how your code is structured.
+    ///  There is some discussion whether to signal the condition variable
+    ///  with the mutex locked or not.  There is some potential performance
+    ///  benefit to unlocking first on some platforms, but there are some
+    ///  potential race conditions depending on how your code is structured.
     ///
-    /// In general it's safer to signal the condition variable while the
-    /// mutex is locked.
+    ///  In general it's safer to signal the condition variable while the
+    ///  mutex is locked.
     pub fn SDL_CreateCond() -> *mut SDL_cond;
 }
 extern "C" {
-    /// Destroy a condition variable.
+    ///  Destroy a condition variable.
     pub fn SDL_DestroyCond(cond: *mut SDL_cond);
 }
 extern "C" {
-    /// Restart one of the threads that are waiting on the condition variable.
+    ///  Restart one of the threads that are waiting on the condition variable.
     ///
-    /// \return 0 or -1 on error.
+    ///  \return 0 or -1 on error.
     pub fn SDL_CondSignal(cond: *mut SDL_cond) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Restart all threads that are waiting on the condition variable.
+    ///  Restart all threads that are waiting on the condition variable.
     ///
-    /// \return 0 or -1 on error.
+    ///  \return 0 or -1 on error.
     pub fn SDL_CondBroadcast(cond: *mut SDL_cond) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Wait on the condition variable, unlocking the provided mutex.
+    ///  Wait on the condition variable, unlocking the provided mutex.
     ///
-    /// \warning The mutex must be locked before entering this function!
+    ///  \warning The mutex must be locked before entering this function!
     ///
-    /// The mutex is re-locked once the condition variable is signaled.
+    ///  The mutex is re-locked once the condition variable is signaled.
     ///
-    /// \return 0 when it is signaled, or -1 on error.
+    ///  \return 0 when it is signaled, or -1 on error.
     pub fn SDL_CondWait(cond: *mut SDL_cond, mutex: *mut SDL_mutex) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Waits for at most \c ms milliseconds, and returns 0 if the condition
-    /// variable is signaled, ::SDL_MUTEX_TIMEDOUT if the condition is not
-    /// signaled in the allotted time, and -1 on error.
+    ///  Waits for at most \c ms milliseconds, and returns 0 if the condition
+    ///  variable is signaled, ::SDL_MUTEX_TIMEDOUT if the condition is not
+    ///  signaled in the allotted time, and -1 on error.
     ///
-    /// \warning On some platforms this function is implemented by looping with a
-    /// delay of 1 ms, and so should be avoided if possible.
+    ///  \warning On some platforms this function is implemented by looping with a
+    ///           delay of 1 ms, and so should be avoided if possible.
     pub fn SDL_CondWaitTimeout(
         cond: *mut SDL_cond,
         mutex: *mut SDL_mutex,
@@ -2001,37 +2037,26 @@ pub struct SDL_Thread {
 pub type SDL_threadID = ::std::os::raw::c_ulong;
 pub type SDL_TLSID = ::std::os::raw::c_uint;
 #[repr(u32)]
-/// The SDL thread priority.
+///  The SDL thread priority.
 ///
-/// \note On many systems you require special privileges to set high priority.
+///  \note On many systems you require special privileges to set high or time critical priority.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_ThreadPriority {
     SDL_THREAD_PRIORITY_LOW = 0,
     SDL_THREAD_PRIORITY_NORMAL = 1,
     SDL_THREAD_PRIORITY_HIGH = 2,
+    SDL_THREAD_PRIORITY_TIME_CRITICAL = 3,
 }
-/// The function passed to SDL_CreateThread().
-/// It is passed a void* user context parameter and returns an int.
+///  The function passed to SDL_CreateThread().
+///  It is passed a void* user context parameter and returns an int.
 pub type SDL_ThreadFunction = ::std::option::Option<
     unsafe extern "C" fn(data: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    /// Create a thread.
+    ///  Create a thread with a default stack size.
     ///
-    /// Thread naming is a little complicated: Most systems have very small
-    /// limits for the string length (Haiku has 32 bytes, Linux currently has 16,
-    /// Visual C++ 6.0 has nine!), and possibly other arbitrary rules. You'll
-    /// have to see what happens with your system's debugger. The name should be
-    /// UTF-8 (but using the naming limits of C identifiers is a better bet).
-    /// There are no requirements for thread naming conventions, so long as the
-    /// string is null-terminated UTF-8, but these guidelines are helpful in
-    /// choosing a name:
-    ///
-    /// http://stackoverflow.com/questions/149932/naming-conventions-for-threads
-    ///
-    /// If a system imposes requirements, SDL will try to munge the string for
-    /// it (truncate, etc), but the original string contents will be available
-    /// from SDL_GetThreadName().
+    ///  This is equivalent to calling:
+    ///  SDL_CreateThreadWithStackSize(fn, name, 0, data);
     pub fn SDL_CreateThread(
         fn_: SDL_ThreadFunction,
         name: *const ::std::os::raw::c_char,
@@ -2039,126 +2064,158 @@ extern "C" {
     ) -> *mut SDL_Thread;
 }
 extern "C" {
+    ///  Create a thread.
+    ///
+    ///   Thread naming is a little complicated: Most systems have very small
+    ///    limits for the string length (Haiku has 32 bytes, Linux currently has 16,
+    ///    Visual C++ 6.0 has nine!), and possibly other arbitrary rules. You'll
+    ///    have to see what happens with your system's debugger. The name should be
+    ///    UTF-8 (but using the naming limits of C identifiers is a better bet).
+    ///   There are no requirements for thread naming conventions, so long as the
+    ///    string is null-terminated UTF-8, but these guidelines are helpful in
+    ///    choosing a name:
+    ///
+    ///    http://stackoverflow.com/questions/149932/naming-conventions-for-threads
+    ///
+    ///   If a system imposes requirements, SDL will try to munge the string for
+    ///    it (truncate, etc), but the original string contents will be available
+    ///    from SDL_GetThreadName().
+    ///
+    ///   The size (in bytes) of the new stack can be specified. Zero means "use
+    ///    the system default" which might be wildly different between platforms
+    ///    (x86 Linux generally defaults to eight megabytes, an embedded device
+    ///    might be a few kilobytes instead).
+    ///
+    ///   In SDL 2.1, stacksize will be folded into the original SDL_CreateThread
+    ///    function.
+    pub fn SDL_CreateThreadWithStackSize(
+        fn_: SDL_ThreadFunction,
+        name: *const ::std::os::raw::c_char,
+        stacksize: usize,
+        data: *mut ::std::os::raw::c_void,
+    ) -> *mut SDL_Thread;
+}
+extern "C" {
     /// Get the thread name, as it was specified in SDL_CreateThread().
-    /// This function returns a pointer to a UTF-8 string that names the
-    /// specified thread, or NULL if it doesn't have a name. This is internal
-    /// memory, not to be free()'d by the caller, and remains valid until the
-    /// specified thread is cleaned up by SDL_WaitThread().
+    ///  This function returns a pointer to a UTF-8 string that names the
+    ///  specified thread, or NULL if it doesn't have a name. This is internal
+    ///  memory, not to be free()'d by the caller, and remains valid until the
+    ///  specified thread is cleaned up by SDL_WaitThread().
     pub fn SDL_GetThreadName(thread: *mut SDL_Thread) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get the thread identifier for the current thread.
+    ///  Get the thread identifier for the current thread.
     pub fn SDL_ThreadID() -> SDL_threadID;
 }
 extern "C" {
-    /// Get the thread identifier for the specified thread.
+    ///  Get the thread identifier for the specified thread.
     ///
-    /// Equivalent to SDL_ThreadID() if the specified thread is NULL.
+    ///  Equivalent to SDL_ThreadID() if the specified thread is NULL.
     pub fn SDL_GetThreadID(thread: *mut SDL_Thread) -> SDL_threadID;
 }
 extern "C" {
-    /// Set the priority for the current thread
+    ///  Set the priority for the current thread
     pub fn SDL_SetThreadPriority(priority: SDL_ThreadPriority) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Wait for a thread to finish. Threads that haven't been detached will
-    /// remain (as a "zombie") until this function cleans them up. Not doing so
-    /// is a resource leak.
+    ///  Wait for a thread to finish. Threads that haven't been detached will
+    ///  remain (as a "zombie") until this function cleans them up. Not doing so
+    ///  is a resource leak.
     ///
-    /// Once a thread has been cleaned up through this function, the SDL_Thread
-    /// that references it becomes invalid and should not be referenced again.
-    /// As such, only one thread may call SDL_WaitThread() on another.
+    ///  Once a thread has been cleaned up through this function, the SDL_Thread
+    ///  that references it becomes invalid and should not be referenced again.
+    ///  As such, only one thread may call SDL_WaitThread() on another.
     ///
-    /// The return code for the thread function is placed in the area
-    /// pointed to by \c status, if \c status is not NULL.
+    ///  The return code for the thread function is placed in the area
+    ///  pointed to by \c status, if \c status is not NULL.
     ///
-    /// You may not wait on a thread that has been used in a call to
-    /// SDL_DetachThread(). Use either that function or this one, but not
-    /// both, or behavior is undefined.
+    ///  You may not wait on a thread that has been used in a call to
+    ///  SDL_DetachThread(). Use either that function or this one, but not
+    ///  both, or behavior is undefined.
     ///
-    /// It is safe to pass NULL to this function; it is a no-op.
+    ///  It is safe to pass NULL to this function; it is a no-op.
     pub fn SDL_WaitThread(thread: *mut SDL_Thread, status: *mut ::std::os::raw::c_int);
 }
 extern "C" {
-    /// A thread may be "detached" to signify that it should not remain until
-    /// another thread has called SDL_WaitThread() on it. Detaching a thread
-    /// is useful for long-running threads that nothing needs to synchronize
-    /// with or further manage. When a detached thread is done, it simply
-    /// goes away.
+    ///  A thread may be "detached" to signify that it should not remain until
+    ///  another thread has called SDL_WaitThread() on it. Detaching a thread
+    ///  is useful for long-running threads that nothing needs to synchronize
+    ///  with or further manage. When a detached thread is done, it simply
+    ///  goes away.
     ///
-    /// There is no way to recover the return code of a detached thread. If you
-    /// need this, don't detach the thread and instead use SDL_WaitThread().
+    ///  There is no way to recover the return code of a detached thread. If you
+    ///  need this, don't detach the thread and instead use SDL_WaitThread().
     ///
-    /// Once a thread is detached, you should usually assume the SDL_Thread isn't
-    /// safe to reference again, as it will become invalid immediately upon
-    /// the detached thread's exit, instead of remaining until someone has called
-    /// SDL_WaitThread() to finally clean it up. As such, don't detach the same
-    /// thread more than once.
+    ///  Once a thread is detached, you should usually assume the SDL_Thread isn't
+    ///  safe to reference again, as it will become invalid immediately upon
+    ///  the detached thread's exit, instead of remaining until someone has called
+    ///  SDL_WaitThread() to finally clean it up. As such, don't detach the same
+    ///  thread more than once.
     ///
-    /// If a thread has already exited when passed to SDL_DetachThread(), it will
-    /// stop waiting for a call to SDL_WaitThread() and clean up immediately.
-    /// It is not safe to detach a thread that might be used with SDL_WaitThread().
+    ///  If a thread has already exited when passed to SDL_DetachThread(), it will
+    ///  stop waiting for a call to SDL_WaitThread() and clean up immediately.
+    ///  It is not safe to detach a thread that might be used with SDL_WaitThread().
     ///
-    /// You may not call SDL_WaitThread() on a thread that has been detached.
-    /// Use either that function or this one, but not both, or behavior is
-    /// undefined.
+    ///  You may not call SDL_WaitThread() on a thread that has been detached.
+    ///  Use either that function or this one, but not both, or behavior is
+    ///  undefined.
     ///
-    /// It is safe to pass NULL to this function; it is a no-op.
+    ///  It is safe to pass NULL to this function; it is a no-op.
     pub fn SDL_DetachThread(thread: *mut SDL_Thread);
 }
 extern "C" {
-    /// \brief Create an identifier that is globally visible to all threads but refers to data that is thread-specific.
+    ///  \brief Create an identifier that is globally visible to all threads but refers to data that is thread-specific.
     ///
-    /// \return The newly created thread local storage identifier, or 0 on error
+    ///  \return The newly created thread local storage identifier, or 0 on error
     ///
-    /// \code
-    /// static SDL_SpinLock tls_lock;
-    /// static SDL_TLSID thread_local_storage;
+    ///  \code
+    ///  static SDL_SpinLock tls_lock;
+    ///  static SDL_TLSID thread_local_storage;
     ///
-    /// void SetMyThreadData(void *value)
-    /// {
-    /// if (!thread_local_storage) {
-    /// SDL_AtomicLock(&tls_lock);
-    /// if (!thread_local_storage) {
-    /// thread_local_storage = SDL_TLSCreate();
-    /// }
-    /// SDL_AtomicUnlock(&tls_lock);
-    /// }
-    /// SDL_TLSSet(thread_local_storage, value, 0);
-    /// }
+    ///  void SetMyThreadData(void *value)
+    ///  {
+    ///      if (!thread_local_storage) {
+    ///          SDL_AtomicLock(&tls_lock);
+    ///          if (!thread_local_storage) {
+    ///              thread_local_storage = SDL_TLSCreate();
+    ///          }
+    ///          SDL_AtomicUnlock(&tls_lock);
+    ///      }
+    ///      SDL_TLSSet(thread_local_storage, value, 0);
+    ///  }
     ///
-    /// void *GetMyThreadData(void)
-    /// {
-    /// return SDL_TLSGet(thread_local_storage);
-    /// }
-    /// \endcode
+    ///  void *GetMyThreadData(void)
+    ///  {
+    ///      return SDL_TLSGet(thread_local_storage);
+    ///  }
+    ///  \endcode
     ///
-    /// \sa SDL_TLSGet()
-    /// \sa SDL_TLSSet()
+    ///  \sa SDL_TLSGet()
+    ///  \sa SDL_TLSSet()
     pub fn SDL_TLSCreate() -> SDL_TLSID;
 }
 extern "C" {
-    /// \brief Get the value associated with a thread local storage ID for the current thread.
+    ///  \brief Get the value associated with a thread local storage ID for the current thread.
     ///
-    /// \param id The thread local storage ID
+    ///  \param id The thread local storage ID
     ///
-    /// \return The value associated with the ID for the current thread, or NULL if no value has been set.
+    ///  \return The value associated with the ID for the current thread, or NULL if no value has been set.
     ///
-    /// \sa SDL_TLSCreate()
-    /// \sa SDL_TLSSet()
+    ///  \sa SDL_TLSCreate()
+    ///  \sa SDL_TLSSet()
     pub fn SDL_TLSGet(id: SDL_TLSID) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Set the value associated with a thread local storage ID for the current thread.
+    ///  \brief Set the value associated with a thread local storage ID for the current thread.
     ///
-    /// \param id The thread local storage ID
-    /// \param value The value to associate with the ID for the current thread
-    /// \param destructor A function called when the thread exits, to free the value.
+    ///  \param id The thread local storage ID
+    ///  \param value The value to associate with the ID for the current thread
+    ///  \param destructor A function called when the thread exits, to free the value.
     ///
-    /// \return 0 on success, -1 on error
+    ///  \return 0 on success, -1 on error
     ///
-    /// \sa SDL_TLSCreate()
-    /// \sa SDL_TLSGet()
+    ///  \sa SDL_TLSCreate()
+    ///  \sa SDL_TLSGet()
     pub fn SDL_TLSSet(
         id: SDL_TLSID,
         value: *const ::std::os::raw::c_void,
@@ -2169,12 +2226,12 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct SDL_RWops {
-    /// Return the size of the file in this rwops, or -1 if unknown
+    ///  Return the size of the file in this rwops, or -1 if unknown
     pub size: ::std::option::Option<unsafe extern "C" fn(context: *mut SDL_RWops) -> Sint64>,
-    /// Seek to \c offset relative to \c whence, one of stdio's whence values:
-    /// RW_SEEK_SET, RW_SEEK_CUR, RW_SEEK_END
+    ///  Seek to \c offset relative to \c whence, one of stdio's whence values:
+    ///  RW_SEEK_SET, RW_SEEK_CUR, RW_SEEK_END
     ///
-    /// \return the final offset in the data stream, or -1 on error.
+    ///  \return the final offset in the data stream, or -1 on error.
     pub seek: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut SDL_RWops,
@@ -2182,10 +2239,10 @@ pub struct SDL_RWops {
             whence: ::std::os::raw::c_int,
         ) -> Sint64,
     >,
-    /// Read up to \c maxnum objects each of size \c size from the data
-    /// stream to the area pointed at by \c ptr.
+    ///  Read up to \c maxnum objects each of size \c size from the data
+    ///  stream to the area pointed at by \c ptr.
     ///
-    /// \return the number of objects read, or 0 at error or end of file.
+    ///  \return the number of objects read, or 0 at error or end of file.
     pub read: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut SDL_RWops,
@@ -2194,10 +2251,10 @@ pub struct SDL_RWops {
             maxnum: usize,
         ) -> usize,
     >,
-    /// Write exactly \c num objects each of size \c size from the area
-    /// pointed at by \c ptr to data stream.
+    ///  Write exactly \c num objects each of size \c size from the area
+    ///  pointed at by \c ptr to data stream.
     ///
-    /// \return the number of objects written, or 0 at error or end of file.
+    ///  \return the number of objects written, or 0 at error or end of file.
     pub write: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut SDL_RWops,
@@ -2206,9 +2263,9 @@ pub struct SDL_RWops {
             num: usize,
         ) -> usize,
     >,
-    /// Close and free an allocated SDL_RWops structure.
+    ///  Close and free an allocated SDL_RWops structure.
     ///
-    /// \return 0 if successful or -1 on write error when flushing data.
+    ///  \return 0 if successful or -1 on write error when flushing data.
     pub close: ::std::option::Option<
         unsafe extern "C" fn(context: *mut SDL_RWops) -> ::std::os::raw::c_int,
     >,
@@ -2482,17 +2539,17 @@ extern "C" {
     pub fn SDL_FreeRW(area: *mut SDL_RWops);
 }
 extern "C" {
-    /// Load all the data from an SDL data stream.
+    ///  Load all the data from an SDL data stream.
     ///
-    /// The data is allocated with a zero byte at the end (null terminated)
+    ///  The data is allocated with a zero byte at the end (null terminated)
     ///
-    /// If \c datasize is not NULL, it is filled with the size of the data read.
+    ///  If \c datasize is not NULL, it is filled with the size of the data read.
     ///
-    /// If \c freesrc is non-zero, the stream will be closed after being read.
+    ///  If \c freesrc is non-zero, the stream will be closed after being read.
     ///
-    /// The data should be freed with SDL_free().
+    ///  The data should be freed with SDL_free().
     ///
-    /// \return the data, or NULL if there was an error.
+    ///  \return the data, or NULL if there was an error.
     pub fn SDL_LoadFile_RW(
         src: *mut SDL_RWops,
         datasize: *mut usize,
@@ -2541,37 +2598,37 @@ extern "C" {
 extern "C" {
     pub fn SDL_WriteBE64(dst: *mut SDL_RWops, value: Uint64) -> usize;
 }
-/// \brief Audio format flags.
+///  \brief Audio format flags.
 ///
-/// These are what the 16 bits in SDL_AudioFormat currently mean...
-/// (Unspecified bits are always zero).
+///  These are what the 16 bits in SDL_AudioFormat currently mean...
+///  (Unspecified bits are always zero).
 ///
-/// \verbatim
-/// ++-----------------------sample is signed if set
-/// ||
-/// ||       ++-----------sample is bigendian if set
-/// ||       ||
-/// ||       ||          ++---sample is float if set
-/// ||       ||          ||
-/// ||       ||          || +---sample bit size---+
-/// ||       ||          || |                     |
-/// 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
-/// \endverbatim
+///  \verbatim
+///++-----------------------sample is signed if set
+///||
+///||       ++-----------sample is bigendian if set
+///||       ||
+///||       ||          ++---sample is float if set
+///||       ||          ||
+///||       ||          || +---sample bit size---+
+///||       ||          || |                     |
+///15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
+///\endverbatim
 ///
-/// There are macros in SDL 2.0 and later to query these bits.
+///  There are macros in SDL 2.0 and later to query these bits.
 pub type SDL_AudioFormat = Uint16;
-/// This function is called when the audio device needs more data.
+///  This function is called when the audio device needs more data.
 ///
-/// \param userdata An application-specific parameter saved in
-/// the SDL_AudioSpec structure
-/// \param stream A pointer to the audio data buffer.
-/// \param len    The length of that buffer in bytes.
+///  \param userdata An application-specific parameter saved in
+///                  the SDL_AudioSpec structure
+///  \param stream A pointer to the audio data buffer.
+///  \param len    The length of that buffer in bytes.
 ///
-/// Once the callback returns, the buffer will no longer be valid.
-/// Stereo samples are stored in a LRLRLR ordering.
+///  Once the callback returns, the buffer will no longer be valid.
+///  Stereo samples are stored in a LRLRLR ordering.
 ///
-/// You can choose to avoid callbacks and use SDL_QueueAudio() instead, if
-/// you like. Just open your audio device with a NULL callback.
+///  You can choose to avoid callbacks and use SDL_QueueAudio() instead, if
+///  you like. Just open your audio device with a NULL callback.
 pub type SDL_AudioCallback = ::std::option::Option<
     unsafe extern "C" fn(
         userdata: *mut ::std::os::raw::c_void,
@@ -2579,36 +2636,36 @@ pub type SDL_AudioCallback = ::std::option::Option<
         len: ::std::os::raw::c_int,
     ),
 >;
-/// The calculated values in this structure are calculated by SDL_OpenAudio().
+///  The calculated values in this structure are calculated by SDL_OpenAudio().
 ///
-/// For multi-channel audio, the default SDL channel mapping is:
-/// 2:  FL FR                       (stereo)
-/// 3:  FL FR LFE                   (2.1 surround)
-/// 4:  FL FR BL BR                 (quad)
-/// 5:  FL FR FC BL BR              (quad + center)
-/// 6:  FL FR FC LFE SL SR          (5.1 surround - last two can also be BL BR)
-/// 7:  FL FR FC LFE BC SL SR       (6.1 surround)
-/// 8:  FL FR FC LFE BL BR SL SR    (7.1 surround)
+///  For multi-channel audio, the default SDL channel mapping is:
+///  2:  FL FR                       (stereo)
+///  3:  FL FR LFE                   (2.1 surround)
+///  4:  FL FR BL BR                 (quad)
+///  5:  FL FR FC BL BR              (quad + center)
+///  6:  FL FR FC LFE SL SR          (5.1 surround - last two can also be BL BR)
+///  7:  FL FR FC LFE BC SL SR       (6.1 surround)
+///  8:  FL FR FC LFE BL BR SL SR    (7.1 surround)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_AudioSpec {
-    /// < DSP frequency -- samples per second
+    ///< DSP frequency -- samples per second
     pub freq: ::std::os::raw::c_int,
-    /// < Audio data format
+    ///< Audio data format
     pub format: SDL_AudioFormat,
-    /// < Number of channels: 1 mono, 2 stereo
+    ///< Number of channels: 1 mono, 2 stereo
     pub channels: Uint8,
-    /// < Audio buffer silence value (calculated)
+    ///< Audio buffer silence value (calculated)
     pub silence: Uint8,
-    /// < Audio buffer size in sample FRAMES (total samples divided by channel count)
+    ///< Audio buffer size in sample FRAMES (total samples divided by channel count)
     pub samples: Uint16,
-    /// < Necessary for some compile environments
+    ///< Necessary for some compile environments
     pub padding: Uint16,
-    /// < Audio buffer size in bytes (calculated)
+    ///< Audio buffer size in bytes (calculated)
     pub size: Uint32,
-    /// < Callback that feeds the audio device (NULL to use SDL_QueueAudio()).
+    ///< Callback that feeds the audio device (NULL to use SDL_QueueAudio()).
     pub callback: SDL_AudioCallback,
-    /// < Userdata passed to callback (ignored for NULL callbacks).
+    ///< Userdata passed to callback (ignored for NULL callbacks).
     pub userdata: *mut ::std::os::raw::c_void,
 }
 #[test]
@@ -2719,27 +2776,27 @@ pub type SDL_AudioFilter =
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_AudioCVT {
-    /// < Set to 1 if conversion possible
+    ///< Set to 1 if conversion possible
     pub needed: ::std::os::raw::c_int,
-    /// < Source audio format
+    ///< Source audio format
     pub src_format: SDL_AudioFormat,
-    /// < Target audio format
+    ///< Target audio format
     pub dst_format: SDL_AudioFormat,
-    /// < Rate conversion increment
+    ///< Rate conversion increment
     pub rate_incr: f64,
-    /// < Buffer to hold entire audio data
+    ///< Buffer to hold entire audio data
     pub buf: *mut Uint8,
-    /// < Length of original audio buffer
+    ///< Length of original audio buffer
     pub len: ::std::os::raw::c_int,
-    /// < Length of converted audio buffer
+    ///< Length of converted audio buffer
     pub len_cvt: ::std::os::raw::c_int,
-    /// < buffer must be len*len_mult big
+    ///< buffer must be len*len_mult big
     pub len_mult: ::std::os::raw::c_int,
-    /// < Given len, final size is len*len_ratio
+    ///< Given len, final size is len*len_ratio
     pub len_ratio: f64,
-    /// < NULL-terminated list of filter functions
+    ///< NULL-terminated list of filter functions
     pub filters: [SDL_AudioFilter; 10usize],
-    /// < Current audio conversion function
+    ///< Current audio conversion function
     pub filter_index: ::std::os::raw::c_int,
 }
 #[test]
@@ -2878,109 +2935,109 @@ extern "C" {
     pub fn SDL_AudioQuit();
 }
 extern "C" {
-    /// This function returns the name of the current audio driver, or NULL
-    /// if no driver has been initialized.
+    ///  This function returns the name of the current audio driver, or NULL
+    ///  if no driver has been initialized.
     pub fn SDL_GetCurrentAudioDriver() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// This function opens the audio device with the desired parameters, and
-    /// returns 0 if successful, placing the actual hardware parameters in the
-    /// structure pointed to by \c obtained.  If \c obtained is NULL, the audio
-    /// data passed to the callback function will be guaranteed to be in the
-    /// requested format, and will be automatically converted to the hardware
-    /// audio format if necessary.  This function returns -1 if it failed
-    /// to open the audio device, or couldn't set up the audio thread.
+    ///  This function opens the audio device with the desired parameters, and
+    ///  returns 0 if successful, placing the actual hardware parameters in the
+    ///  structure pointed to by \c obtained.  If \c obtained is NULL, the audio
+    ///  data passed to the callback function will be guaranteed to be in the
+    ///  requested format, and will be automatically converted to the hardware
+    ///  audio format if necessary.  This function returns -1 if it failed
+    ///  to open the audio device, or couldn't set up the audio thread.
     ///
-    /// When filling in the desired audio spec structure,
-    /// - \c desired->freq should be the desired audio frequency in samples-per-
-    /// second.
-    /// - \c desired->format should be the desired audio format.
-    /// - \c desired->samples is the desired size of the audio buffer, in
-    /// samples.  This number should be a power of two, and may be adjusted by
-    /// the audio driver to a value more suitable for the hardware.  Good values
-    /// seem to range between 512 and 8096 inclusive, depending on the
-    /// application and CPU speed.  Smaller values yield faster response time,
-    /// but can lead to underflow if the application is doing heavy processing
-    /// and cannot fill the audio buffer in time.  A stereo sample consists of
-    /// both right and left channels in LR ordering.
-    /// Note that the number of samples is directly related to time by the
-    /// following formula:  \code ms = (samples*1000)/freq \endcode
-    /// - \c desired->size is the size in bytes of the audio buffer, and is
-    /// calculated by SDL_OpenAudio().
-    /// - \c desired->silence is the value used to set the buffer to silence,
-    /// and is calculated by SDL_OpenAudio().
-    /// - \c desired->callback should be set to a function that will be called
-    /// when the audio device is ready for more data.  It is passed a pointer
-    /// to the audio buffer, and the length in bytes of the audio buffer.
-    /// This function usually runs in a separate thread, and so you should
-    /// protect data structures that it accesses by calling SDL_LockAudio()
-    /// and SDL_UnlockAudio() in your code. Alternately, you may pass a NULL
-    /// pointer here, and call SDL_QueueAudio() with some frequency, to queue
-    /// more audio samples to be played (or for capture devices, call
-    /// SDL_DequeueAudio() with some frequency, to obtain audio samples).
-    /// - \c desired->userdata is passed as the first parameter to your callback
-    /// function. If you passed a NULL callback, this value is ignored.
+    ///  When filling in the desired audio spec structure,
+    ///    - \c desired->freq should be the desired audio frequency in samples-per-
+    ///      second.
+    ///    - \c desired->format should be the desired audio format.
+    ///    - \c desired->samples is the desired size of the audio buffer, in
+    ///      samples.  This number should be a power of two, and may be adjusted by
+    ///      the audio driver to a value more suitable for the hardware.  Good values
+    ///      seem to range between 512 and 8096 inclusive, depending on the
+    ///      application and CPU speed.  Smaller values yield faster response time,
+    ///      but can lead to underflow if the application is doing heavy processing
+    ///      and cannot fill the audio buffer in time.  A stereo sample consists of
+    ///      both right and left channels in LR ordering.
+    ///      Note that the number of samples is directly related to time by the
+    ///      following formula:  \code ms = (samples*1000)/freq \endcode
+    ///    - \c desired->size is the size in bytes of the audio buffer, and is
+    ///      calculated by SDL_OpenAudio().
+    ///    - \c desired->silence is the value used to set the buffer to silence,
+    ///      and is calculated by SDL_OpenAudio().
+    ///    - \c desired->callback should be set to a function that will be called
+    ///      when the audio device is ready for more data.  It is passed a pointer
+    ///      to the audio buffer, and the length in bytes of the audio buffer.
+    ///      This function usually runs in a separate thread, and so you should
+    ///      protect data structures that it accesses by calling SDL_LockAudio()
+    ///      and SDL_UnlockAudio() in your code. Alternately, you may pass a NULL
+    ///      pointer here, and call SDL_QueueAudio() with some frequency, to queue
+    ///      more audio samples to be played (or for capture devices, call
+    ///      SDL_DequeueAudio() with some frequency, to obtain audio samples).
+    ///    - \c desired->userdata is passed as the first parameter to your callback
+    ///      function. If you passed a NULL callback, this value is ignored.
     ///
-    /// The audio device starts out playing silence when it's opened, and should
-    /// be enabled for playing by calling \c SDL_PauseAudio(0) when you are ready
-    /// for your audio callback function to be called.  Since the audio driver
-    /// may modify the requested size of the audio buffer, you should allocate
-    /// any local mixing buffers after you open the audio device.
+    ///  The audio device starts out playing silence when it's opened, and should
+    ///  be enabled for playing by calling \c SDL_PauseAudio(0) when you are ready
+    ///  for your audio callback function to be called.  Since the audio driver
+    ///  may modify the requested size of the audio buffer, you should allocate
+    ///  any local mixing buffers after you open the audio device.
     pub fn SDL_OpenAudio(
         desired: *mut SDL_AudioSpec,
         obtained: *mut SDL_AudioSpec,
     ) -> ::std::os::raw::c_int;
 }
-/// SDL Audio Device IDs.
+///  SDL Audio Device IDs.
 ///
-/// A successful call to SDL_OpenAudio() is always device id 1, and legacy
-/// SDL audio APIs assume you want this device ID. SDL_OpenAudioDevice() calls
-/// always returns devices >= 2 on success. The legacy calls are good both
-/// for backwards compatibility and when you don't care about multiple,
-/// specific, or capture devices.
+///  A successful call to SDL_OpenAudio() is always device id 1, and legacy
+///  SDL audio APIs assume you want this device ID. SDL_OpenAudioDevice() calls
+///  always returns devices >= 2 on success. The legacy calls are good both
+///  for backwards compatibility and when you don't care about multiple,
+///  specific, or capture devices.
 pub type SDL_AudioDeviceID = Uint32;
 extern "C" {
-    /// Get the number of available devices exposed by the current driver.
-    /// Only valid after a successfully initializing the audio subsystem.
-    /// Returns -1 if an explicit list of devices can't be determined; this is
-    /// not an error. For example, if SDL is set up to talk to a remote audio
-    /// server, it can't list every one available on the Internet, but it will
-    /// still allow a specific host to be specified to SDL_OpenAudioDevice().
+    ///  Get the number of available devices exposed by the current driver.
+    ///  Only valid after a successfully initializing the audio subsystem.
+    ///  Returns -1 if an explicit list of devices can't be determined; this is
+    ///  not an error. For example, if SDL is set up to talk to a remote audio
+    ///  server, it can't list every one available on the Internet, but it will
+    ///  still allow a specific host to be specified to SDL_OpenAudioDevice().
     ///
-    /// In many common cases, when this function returns a value <= 0, it can still
-    /// successfully open the default device (NULL for first argument of
-    /// SDL_OpenAudioDevice()).
+    ///  In many common cases, when this function returns a value <= 0, it can still
+    ///  successfully open the default device (NULL for first argument of
+    ///  SDL_OpenAudioDevice()).
     pub fn SDL_GetNumAudioDevices(iscapture: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the human-readable name of a specific audio device.
-    /// Must be a value between 0 and (number of audio devices-1).
-    /// Only valid after a successfully initializing the audio subsystem.
-    /// The values returned by this function reflect the latest call to
-    /// SDL_GetNumAudioDevices(); recall that function to redetect available
-    /// hardware.
+    ///  Get the human-readable name of a specific audio device.
+    ///  Must be a value between 0 and (number of audio devices-1).
+    ///  Only valid after a successfully initializing the audio subsystem.
+    ///  The values returned by this function reflect the latest call to
+    ///  SDL_GetNumAudioDevices(); recall that function to redetect available
+    ///  hardware.
     ///
-    /// The string returned by this function is UTF-8 encoded, read-only, and
-    /// managed internally. You are not to free it. If you need to keep the
-    /// string for any length of time, you should make your own copy of it, as it
-    /// will be invalid next time any of several other SDL functions is called.
+    ///  The string returned by this function is UTF-8 encoded, read-only, and
+    ///  managed internally. You are not to free it. If you need to keep the
+    ///  string for any length of time, you should make your own copy of it, as it
+    ///  will be invalid next time any of several other SDL functions is called.
     pub fn SDL_GetAudioDeviceName(
         index: ::std::os::raw::c_int,
         iscapture: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Open a specific audio device. Passing in a device name of NULL requests
-    /// the most reasonable default (and is equivalent to calling SDL_OpenAudio()).
+    ///  Open a specific audio device. Passing in a device name of NULL requests
+    ///  the most reasonable default (and is equivalent to calling SDL_OpenAudio()).
     ///
-    /// The device name is a UTF-8 string reported by SDL_GetAudioDeviceName(), but
-    /// some drivers allow arbitrary and driver-specific strings, such as a
-    /// hostname/IP address for a remote audio server, or a filename in the
-    /// diskaudio driver.
+    ///  The device name is a UTF-8 string reported by SDL_GetAudioDeviceName(), but
+    ///  some drivers allow arbitrary and driver-specific strings, such as a
+    ///  hostname/IP address for a remote audio server, or a filename in the
+    ///  diskaudio driver.
     ///
-    /// \return 0 on error, a valid device ID that is >= 2 on success.
+    ///  \return 0 on error, a valid device ID that is >= 2 on success.
     ///
-    /// SDL_OpenAudio(), unlike this function, always acts on device ID 1.
+    ///  SDL_OpenAudio(), unlike this function, always acts on device ID 1.
     pub fn SDL_OpenAudioDevice(
         device: *const ::std::os::raw::c_char,
         iscapture: ::std::os::raw::c_int,
@@ -3009,23 +3066,23 @@ extern "C" {
     pub fn SDL_PauseAudioDevice(dev: SDL_AudioDeviceID, pause_on: ::std::os::raw::c_int);
 }
 extern "C" {
-    /// This function loads a WAVE from the data source, automatically freeing
-    /// that source if \c freesrc is non-zero.  For example, to load a WAVE file,
-    /// you could do:
-    /// \code
-    /// SDL_LoadWAV_RW(SDL_RWFromFile("sample.wav", "rb"), 1, ...);
-    /// \endcode
+    ///  This function loads a WAVE from the data source, automatically freeing
+    ///  that source if \c freesrc is non-zero.  For example, to load a WAVE file,
+    ///  you could do:
+    ///  \code
+    ///      SDL_LoadWAV_RW(SDL_RWFromFile("sample.wav", "rb"), 1, ...);
+    ///  \endcode
     ///
-    /// If this function succeeds, it returns the given SDL_AudioSpec,
-    /// filled with the audio data format of the wave data, and sets
-    /// \c *audio_buf to a malloc()'d buffer containing the audio data,
-    /// and sets \c *audio_len to the length of that audio buffer, in bytes.
-    /// You need to free the audio buffer with SDL_FreeWAV() when you are
-    /// done with it.
+    ///  If this function succeeds, it returns the given SDL_AudioSpec,
+    ///  filled with the audio data format of the wave data, and sets
+    ///  \c *audio_buf to a malloc()'d buffer containing the audio data,
+    ///  and sets \c *audio_len to the length of that audio buffer, in bytes.
+    ///  You need to free the audio buffer with SDL_FreeWAV() when you are
+    ///  done with it.
     ///
-    /// This function returns NULL and sets the SDL error message if the
-    /// wave file cannot be opened, uses an unknown data format, or is
-    /// corrupt.  Currently raw and MS-ADPCM WAVE files are supported.
+    ///  This function returns NULL and sets the SDL error message if the
+    ///  wave file cannot be opened, uses an unknown data format, or is
+    ///  corrupt.  Currently raw and MS-ADPCM WAVE files are supported.
     pub fn SDL_LoadWAV_RW(
         src: *mut SDL_RWops,
         freesrc: ::std::os::raw::c_int,
@@ -3035,17 +3092,17 @@ extern "C" {
     ) -> *mut SDL_AudioSpec;
 }
 extern "C" {
-    /// This function frees data previously allocated with SDL_LoadWAV_RW()
+    ///  This function frees data previously allocated with SDL_LoadWAV_RW()
     pub fn SDL_FreeWAV(audio_buf: *mut Uint8);
 }
 extern "C" {
-    /// This function takes a source format and rate and a destination format
-    /// and rate, and initializes the \c cvt structure with information needed
-    /// by SDL_ConvertAudio() to convert a buffer of audio data from one format
-    /// to the other. An unsupported format causes an error and -1 will be returned.
+    ///  This function takes a source format and rate and a destination format
+    ///  and rate, and initializes the \c cvt structure with information needed
+    ///  by SDL_ConvertAudio() to convert a buffer of audio data from one format
+    ///  to the other. An unsupported format causes an error and -1 will be returned.
     ///
-    /// \return 0 if no conversion is needed, 1 if the audio filter is set up,
-    /// or -1 on error.
+    ///  \return 0 if no conversion is needed, 1 if the audio filter is set up,
+    ///  or -1 on error.
     pub fn SDL_BuildAudioCVT(
         cvt: *mut SDL_AudioCVT,
         src_format: SDL_AudioFormat,
@@ -3057,16 +3114,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Once you have initialized the \c cvt structure using SDL_BuildAudioCVT(),
-    /// created an audio buffer \c cvt->buf, and filled it with \c cvt->len bytes of
-    /// audio data in the source format, this function will convert it in-place
-    /// to the desired format.
+    ///  Once you have initialized the \c cvt structure using SDL_BuildAudioCVT(),
+    ///  created an audio buffer \c cvt->buf, and filled it with \c cvt->len bytes of
+    ///  audio data in the source format, this function will convert it in-place
+    ///  to the desired format.
     ///
-    /// The data conversion may expand the size of the audio data, so the buffer
-    /// \c cvt->buf should be allocated after the \c cvt structure is initialized by
-    /// SDL_BuildAudioCVT(), and should be \c cvt->len*cvt->len_mult bytes long.
+    ///  The data conversion may expand the size of the audio data, so the buffer
+    ///  \c cvt->buf should be allocated after the \c cvt structure is initialized by
+    ///  SDL_BuildAudioCVT(), and should be \c cvt->len*cvt->len_mult bytes long.
     ///
-    /// \return 0 on success or -1 if \c cvt->buf is NULL.
+    ///  \return 0 on success or -1 if \c cvt->buf is NULL.
     pub fn SDL_ConvertAudio(cvt: *mut SDL_AudioCVT) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -3076,22 +3133,22 @@ pub struct _SDL_AudioStream {
 }
 pub type SDL_AudioStream = _SDL_AudioStream;
 extern "C" {
-    /// Create a new audio stream
+    ///  Create a new audio stream
     ///
-    /// \param src_format The format of the source audio
-    /// \param src_channels The number of channels of the source audio
-    /// \param src_rate The sampling rate of the source audio
-    /// \param dst_format The format of the desired audio output
-    /// \param dst_channels The number of channels of the desired audio output
-    /// \param dst_rate The sampling rate of the desired audio output
-    /// \return 0 on success, or -1 on error.
+    ///  \param src_format The format of the source audio
+    ///  \param src_channels The number of channels of the source audio
+    ///  \param src_rate The sampling rate of the source audio
+    ///  \param dst_format The format of the desired audio output
+    ///  \param dst_channels The number of channels of the desired audio output
+    ///  \param dst_rate The sampling rate of the desired audio output
+    ///  \return 0 on success, or -1 on error.
     ///
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_AudioStreamClear
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_AudioStreamClear
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_NewAudioStream(
         src_format: SDL_AudioFormat,
         src_channels: Uint8,
@@ -3102,19 +3159,19 @@ extern "C" {
     ) -> *mut SDL_AudioStream;
 }
 extern "C" {
-    /// Add data to be converted/resampled to the stream
+    ///  Add data to be converted/resampled to the stream
     ///
-    /// \param stream The stream the audio data is being added to
-    /// \param buf A pointer to the audio data to add
-    /// \param len The number of bytes to write to the stream
-    /// \return 0 on success, or -1 on error.
+    ///  \param stream The stream the audio data is being added to
+    ///  \param buf A pointer to the audio data to add
+    ///  \param len The number of bytes to write to the stream
+    ///  \return 0 on success, or -1 on error.
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_AudioStreamClear
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_AudioStreamClear
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_AudioStreamPut(
         stream: *mut SDL_AudioStream,
         buf: *const ::std::os::raw::c_void,
@@ -3122,19 +3179,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get converted/resampled data from the stream
+    ///  Get converted/resampled data from the stream
     ///
-    /// \param stream The stream the audio is being requested from
-    /// \param buf A buffer to fill with audio data
-    /// \param len The maximum number of bytes to fill
-    /// \return The number of bytes read from the stream, or -1 on error
+    ///  \param stream The stream the audio is being requested from
+    ///  \param buf A buffer to fill with audio data
+    ///  \param len The maximum number of bytes to fill
+    ///  \return The number of bytes read from the stream, or -1 on error
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_AudioStreamClear
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_AudioStreamClear
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_AudioStreamGet(
         stream: *mut SDL_AudioStream,
         buf: *mut ::std::os::raw::c_void,
@@ -3143,62 +3200,62 @@ extern "C" {
 }
 extern "C" {
     /// Get the number of converted/resampled bytes available. The stream may be
-    /// buffering data behind the scenes until it has enough to resample
-    /// correctly, so this number might be lower than what you expect, or even
-    /// be zero. Add more data or flush the stream if you need the data now.
+    ///  buffering data behind the scenes until it has enough to resample
+    ///  correctly, so this number might be lower than what you expect, or even
+    ///  be zero. Add more data or flush the stream if you need the data now.
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_AudioStreamClear
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_AudioStreamClear
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_AudioStreamAvailable(stream: *mut SDL_AudioStream) -> ::std::os::raw::c_int;
 }
 extern "C" {
     /// Tell the stream that you're done sending data, and anything being buffered
-    /// should be converted/resampled and made available immediately.
+    ///  should be converted/resampled and made available immediately.
     ///
     /// It is legal to add more data to a stream after flushing, but there will
-    /// be audio gaps in the output. Generally this is intended to signal the
-    /// end of input, so the complete output becomes available.
+    ///  be audio gaps in the output. Generally this is intended to signal the
+    ///  end of input, so the complete output becomes available.
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamClear
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamClear
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_AudioStreamFlush(stream: *mut SDL_AudioStream) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Clear any pending data in the stream without converting it
+    ///  Clear any pending data in the stream without converting it
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_FreeAudioStream
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_FreeAudioStream
     pub fn SDL_AudioStreamClear(stream: *mut SDL_AudioStream);
 }
 extern "C" {
     /// Free an audio stream
     ///
-    /// \sa SDL_NewAudioStream
-    /// \sa SDL_AudioStreamPut
-    /// \sa SDL_AudioStreamGet
-    /// \sa SDL_AudioStreamAvailable
-    /// \sa SDL_AudioStreamFlush
-    /// \sa SDL_AudioStreamClear
+    ///  \sa SDL_NewAudioStream
+    ///  \sa SDL_AudioStreamPut
+    ///  \sa SDL_AudioStreamGet
+    ///  \sa SDL_AudioStreamAvailable
+    ///  \sa SDL_AudioStreamFlush
+    ///  \sa SDL_AudioStreamClear
     pub fn SDL_FreeAudioStream(stream: *mut SDL_AudioStream);
 }
 extern "C" {
-    /// This takes two audio buffers of the playing audio format and mixes
-    /// them, performing addition, volume adjustment, and overflow clipping.
-    /// The volume ranges from 0 - 128, and should be set to ::SDL_MIX_MAXVOLUME
-    /// for full audio volume.  Note this does not change hardware volume.
-    /// This is provided for convenience -- you can mix your own audio data.
+    ///  This takes two audio buffers of the playing audio format and mixes
+    ///  them, performing addition, volume adjustment, and overflow clipping.
+    ///  The volume ranges from 0 - 128, and should be set to ::SDL_MIX_MAXVOLUME
+    ///  for full audio volume.  Note this does not change hardware volume.
+    ///  This is provided for convenience -- you can mix your own audio data.
     pub fn SDL_MixAudio(
         dst: *mut Uint8,
         src: *const Uint8,
@@ -3207,9 +3264,9 @@ extern "C" {
     );
 }
 extern "C" {
-    /// This works like SDL_MixAudio(), but you specify the audio format instead of
-    /// using the format of audio device 1. Thus it can be used when no audio
-    /// device is open at all.
+    ///  This works like SDL_MixAudio(), but you specify the audio format instead of
+    ///  using the format of audio device 1. Thus it can be used when no audio
+    ///  device is open at all.
     pub fn SDL_MixAudioFormat(
         dst: *mut Uint8,
         src: *const Uint8,
@@ -3219,43 +3276,43 @@ extern "C" {
     );
 }
 extern "C" {
-    /// Queue more audio on non-callback devices.
+    ///  Queue more audio on non-callback devices.
     ///
-    /// (If you are looking to retrieve queued audio from a non-callback capture
-    /// device, you want SDL_DequeueAudio() instead. This will return -1 to
-    /// signify an error if you use it with capture devices.)
+    ///  (If you are looking to retrieve queued audio from a non-callback capture
+    ///  device, you want SDL_DequeueAudio() instead. This will return -1 to
+    ///  signify an error if you use it with capture devices.)
     ///
-    /// SDL offers two ways to feed audio to the device: you can either supply a
-    /// callback that SDL triggers with some frequency to obtain more audio
-    /// (pull method), or you can supply no callback, and then SDL will expect
-    /// you to supply data at regular intervals (push method) with this function.
+    ///  SDL offers two ways to feed audio to the device: you can either supply a
+    ///  callback that SDL triggers with some frequency to obtain more audio
+    ///  (pull method), or you can supply no callback, and then SDL will expect
+    ///  you to supply data at regular intervals (push method) with this function.
     ///
-    /// There are no limits on the amount of data you can queue, short of
-    /// exhaustion of address space. Queued data will drain to the device as
-    /// necessary without further intervention from you. If the device needs
-    /// audio but there is not enough queued, it will play silence to make up
-    /// the difference. This means you will have skips in your audio playback
-    /// if you aren't routinely queueing sufficient data.
+    ///  There are no limits on the amount of data you can queue, short of
+    ///  exhaustion of address space. Queued data will drain to the device as
+    ///  necessary without further intervention from you. If the device needs
+    ///  audio but there is not enough queued, it will play silence to make up
+    ///  the difference. This means you will have skips in your audio playback
+    ///  if you aren't routinely queueing sufficient data.
     ///
-    /// This function copies the supplied data, so you are safe to free it when
-    /// the function returns. This function is thread-safe, but queueing to the
-    /// same device from two threads at once does not promise which buffer will
-    /// be queued first.
+    ///  This function copies the supplied data, so you are safe to free it when
+    ///  the function returns. This function is thread-safe, but queueing to the
+    ///  same device from two threads at once does not promise which buffer will
+    ///  be queued first.
     ///
-    /// You may not queue audio on a device that is using an application-supplied
-    /// callback; doing so returns an error. You have to use the audio callback
-    /// or queue audio with this function, but not both.
+    ///  You may not queue audio on a device that is using an application-supplied
+    ///  callback; doing so returns an error. You have to use the audio callback
+    ///  or queue audio with this function, but not both.
     ///
-    /// You should not call SDL_LockAudio() on the device before queueing; SDL
-    /// handles locking internally for this function.
+    ///  You should not call SDL_LockAudio() on the device before queueing; SDL
+    ///  handles locking internally for this function.
     ///
-    /// \param dev The device ID to which we will queue audio.
-    /// \param data The data to queue to the device for later playback.
-    /// \param len The number of bytes (not samples!) to which (data) points.
-    /// \return 0 on success, or -1 on error.
+    ///  \param dev The device ID to which we will queue audio.
+    ///  \param data The data to queue to the device for later playback.
+    ///  \param len The number of bytes (not samples!) to which (data) points.
+    ///  \return 0 on success, or -1 on error.
     ///
-    /// \sa SDL_GetQueuedAudioSize
-    /// \sa SDL_ClearQueuedAudio
+    ///  \sa SDL_GetQueuedAudioSize
+    ///  \sa SDL_ClearQueuedAudio
     pub fn SDL_QueueAudio(
         dev: SDL_AudioDeviceID,
         data: *const ::std::os::raw::c_void,
@@ -3263,48 +3320,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Dequeue more audio on non-callback devices.
+    ///  Dequeue more audio on non-callback devices.
     ///
-    /// (If you are looking to queue audio for output on a non-callback playback
-    /// device, you want SDL_QueueAudio() instead. This will always return 0
-    /// if you use it with playback devices.)
+    ///  (If you are looking to queue audio for output on a non-callback playback
+    ///  device, you want SDL_QueueAudio() instead. This will always return 0
+    ///  if you use it with playback devices.)
     ///
-    /// SDL offers two ways to retrieve audio from a capture device: you can
-    /// either supply a callback that SDL triggers with some frequency as the
-    /// device records more audio data, (push method), or you can supply no
-    /// callback, and then SDL will expect you to retrieve data at regular
-    /// intervals (pull method) with this function.
+    ///  SDL offers two ways to retrieve audio from a capture device: you can
+    ///  either supply a callback that SDL triggers with some frequency as the
+    ///  device records more audio data, (push method), or you can supply no
+    ///  callback, and then SDL will expect you to retrieve data at regular
+    ///  intervals (pull method) with this function.
     ///
-    /// There are no limits on the amount of data you can queue, short of
-    /// exhaustion of address space. Data from the device will keep queuing as
-    /// necessary without further intervention from you. This means you will
-    /// eventually run out of memory if you aren't routinely dequeueing data.
+    ///  There are no limits on the amount of data you can queue, short of
+    ///  exhaustion of address space. Data from the device will keep queuing as
+    ///  necessary without further intervention from you. This means you will
+    ///  eventually run out of memory if you aren't routinely dequeueing data.
     ///
-    /// Capture devices will not queue data when paused; if you are expecting
-    /// to not need captured audio for some length of time, use
-    /// SDL_PauseAudioDevice() to stop the capture device from queueing more
-    /// data. This can be useful during, say, level loading times. When
-    /// unpaused, capture devices will start queueing data from that point,
-    /// having flushed any capturable data available while paused.
+    ///  Capture devices will not queue data when paused; if you are expecting
+    ///  to not need captured audio for some length of time, use
+    ///  SDL_PauseAudioDevice() to stop the capture device from queueing more
+    ///  data. This can be useful during, say, level loading times. When
+    ///  unpaused, capture devices will start queueing data from that point,
+    ///  having flushed any capturable data available while paused.
     ///
-    /// This function is thread-safe, but dequeueing from the same device from
-    /// two threads at once does not promise which thread will dequeued data
-    /// first.
+    ///  This function is thread-safe, but dequeueing from the same device from
+    ///  two threads at once does not promise which thread will dequeued data
+    ///  first.
     ///
-    /// You may not dequeue audio from a device that is using an
-    /// application-supplied callback; doing so returns an error. You have to use
-    /// the audio callback, or dequeue audio with this function, but not both.
+    ///  You may not dequeue audio from a device that is using an
+    ///  application-supplied callback; doing so returns an error. You have to use
+    ///  the audio callback, or dequeue audio with this function, but not both.
     ///
-    /// You should not call SDL_LockAudio() on the device before queueing; SDL
-    /// handles locking internally for this function.
+    ///  You should not call SDL_LockAudio() on the device before queueing; SDL
+    ///  handles locking internally for this function.
     ///
-    /// \param dev The device ID from which we will dequeue audio.
-    /// \param data A pointer into where audio data should be copied.
-    /// \param len The number of bytes (not samples!) to which (data) points.
-    /// \return number of bytes dequeued, which could be less than requested.
+    ///  \param dev The device ID from which we will dequeue audio.
+    ///  \param data A pointer into where audio data should be copied.
+    ///  \param len The number of bytes (not samples!) to which (data) points.
+    ///  \return number of bytes dequeued, which could be less than requested.
     ///
-    /// \sa SDL_GetQueuedAudioSize
-    /// \sa SDL_ClearQueuedAudio
+    ///  \sa SDL_GetQueuedAudioSize
+    ///  \sa SDL_ClearQueuedAudio
     pub fn SDL_DequeueAudio(
         dev: SDL_AudioDeviceID,
         data: *mut ::std::os::raw::c_void,
@@ -3312,73 +3369,73 @@ extern "C" {
     ) -> Uint32;
 }
 extern "C" {
-    /// Get the number of bytes of still-queued audio.
+    ///  Get the number of bytes of still-queued audio.
     ///
-    /// For playback device:
+    ///  For playback device:
     ///
-    /// This is the number of bytes that have been queued for playback with
-    /// SDL_QueueAudio(), but have not yet been sent to the hardware. This
-    /// number may shrink at any time, so this only informs of pending data.
+    ///    This is the number of bytes that have been queued for playback with
+    ///    SDL_QueueAudio(), but have not yet been sent to the hardware. This
+    ///    number may shrink at any time, so this only informs of pending data.
     ///
-    /// Once we've sent it to the hardware, this function can not decide the
-    /// exact byte boundary of what has been played. It's possible that we just
-    /// gave the hardware several kilobytes right before you called this
-    /// function, but it hasn't played any of it yet, or maybe half of it, etc.
+    ///    Once we've sent it to the hardware, this function can not decide the
+    ///    exact byte boundary of what has been played. It's possible that we just
+    ///    gave the hardware several kilobytes right before you called this
+    ///    function, but it hasn't played any of it yet, or maybe half of it, etc.
     ///
-    /// For capture devices:
+    ///  For capture devices:
     ///
-    /// This is the number of bytes that have been captured by the device and
-    /// are waiting for you to dequeue. This number may grow at any time, so
-    /// this only informs of the lower-bound of available data.
+    ///    This is the number of bytes that have been captured by the device and
+    ///    are waiting for you to dequeue. This number may grow at any time, so
+    ///    this only informs of the lower-bound of available data.
     ///
-    /// You may not queue audio on a device that is using an application-supplied
-    /// callback; calling this function on such a device always returns 0.
-    /// You have to queue audio with SDL_QueueAudio()/SDL_DequeueAudio(), or use
-    /// the audio callback, but not both.
+    ///  You may not queue audio on a device that is using an application-supplied
+    ///  callback; calling this function on such a device always returns 0.
+    ///  You have to queue audio with SDL_QueueAudio()/SDL_DequeueAudio(), or use
+    ///  the audio callback, but not both.
     ///
-    /// You should not call SDL_LockAudio() on the device before querying; SDL
-    /// handles locking internally for this function.
+    ///  You should not call SDL_LockAudio() on the device before querying; SDL
+    ///  handles locking internally for this function.
     ///
-    /// \param dev The device ID of which we will query queued audio size.
-    /// \return Number of bytes (not samples!) of queued audio.
+    ///  \param dev The device ID of which we will query queued audio size.
+    ///  \return Number of bytes (not samples!) of queued audio.
     ///
-    /// \sa SDL_QueueAudio
-    /// \sa SDL_ClearQueuedAudio
+    ///  \sa SDL_QueueAudio
+    ///  \sa SDL_ClearQueuedAudio
     pub fn SDL_GetQueuedAudioSize(dev: SDL_AudioDeviceID) -> Uint32;
 }
 extern "C" {
-    /// Drop any queued audio data. For playback devices, this is any queued data
-    /// still waiting to be submitted to the hardware. For capture devices, this
-    /// is any data that was queued by the device that hasn't yet been dequeued by
-    /// the application.
+    ///  Drop any queued audio data. For playback devices, this is any queued data
+    ///  still waiting to be submitted to the hardware. For capture devices, this
+    ///  is any data that was queued by the device that hasn't yet been dequeued by
+    ///  the application.
     ///
-    /// Immediately after this call, SDL_GetQueuedAudioSize() will return 0. For
-    /// playback devices, the hardware will start playing silence if more audio
-    /// isn't queued. Unpaused capture devices will start filling the queue again
-    /// as soon as they have more data available (which, depending on the state
-    /// of the hardware and the thread, could be before this function call
-    /// returns!).
+    ///  Immediately after this call, SDL_GetQueuedAudioSize() will return 0. For
+    ///  playback devices, the hardware will start playing silence if more audio
+    ///  isn't queued. Unpaused capture devices will start filling the queue again
+    ///  as soon as they have more data available (which, depending on the state
+    ///  of the hardware and the thread, could be before this function call
+    ///  returns!).
     ///
-    /// This will not prevent playback of queued audio that's already been sent
-    /// to the hardware, as we can not undo that, so expect there to be some
-    /// fraction of a second of audio that might still be heard. This can be
-    /// useful if you want to, say, drop any pending music during a level change
-    /// in your game.
+    ///  This will not prevent playback of queued audio that's already been sent
+    ///  to the hardware, as we can not undo that, so expect there to be some
+    ///  fraction of a second of audio that might still be heard. This can be
+    ///  useful if you want to, say, drop any pending music during a level change
+    ///  in your game.
     ///
-    /// You may not queue audio on a device that is using an application-supplied
-    /// callback; calling this function on such a device is always a no-op.
-    /// You have to queue audio with SDL_QueueAudio()/SDL_DequeueAudio(), or use
-    /// the audio callback, but not both.
+    ///  You may not queue audio on a device that is using an application-supplied
+    ///  callback; calling this function on such a device is always a no-op.
+    ///  You have to queue audio with SDL_QueueAudio()/SDL_DequeueAudio(), or use
+    ///  the audio callback, but not both.
     ///
-    /// You should not call SDL_LockAudio() on the device before clearing the
-    /// queue; SDL handles locking internally for this function.
+    ///  You should not call SDL_LockAudio() on the device before clearing the
+    ///  queue; SDL handles locking internally for this function.
     ///
-    /// This function always succeeds and thus returns void.
+    ///  This function always succeeds and thus returns void.
     ///
-    /// \param dev The device ID of which to clear the audio queue.
+    ///  \param dev The device ID of which to clear the audio queue.
     ///
-    /// \sa SDL_QueueAudio
-    /// \sa SDL_GetQueuedAudioSize
+    ///  \sa SDL_QueueAudio
+    ///  \sa SDL_GetQueuedAudioSize
     pub fn SDL_ClearQueuedAudio(dev: SDL_AudioDeviceID);
 }
 extern "C" {
@@ -3394,7 +3451,7 @@ extern "C" {
     pub fn SDL_UnlockAudioDevice(dev: SDL_AudioDeviceID);
 }
 extern "C" {
-    /// This function shuts down audio processing and closes the audio device.
+    ///  This function shuts down audio processing and closes the audio device.
     pub fn SDL_CloseAudio();
 }
 extern "C" {
@@ -3427,13 +3484,6 @@ pub type __v4si = [::std::os::raw::c_int; 4usize];
 pub type __v4sf = [f32; 4usize];
 pub type __m128 = [f32; 4usize];
 pub type __v4su = [::std::os::raw::c_uint; 4usize];
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum idtype_t {
-    P_ALL = 0,
-    P_PID = 1,
-    P_PGID = 2,
-}
 pub type _Float32 = f32;
 pub type _Float64 = f64;
 pub type _Float32x = f64;
@@ -3824,18 +3874,6 @@ extern "C" {
         __timeout: *const timespec,
         __sigmask: *const __sigset_t,
     ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn gnu_dev_major(__dev: __dev_t) -> ::std::os::raw::c_uint;
-}
-extern "C" {
-    pub fn gnu_dev_minor(__dev: __dev_t) -> ::std::os::raw::c_uint;
-}
-extern "C" {
-    pub fn gnu_dev_makedev(
-        __major: ::std::os::raw::c_uint,
-        __minor: ::std::os::raw::c_uint,
-    ) -> __dev_t;
 }
 pub type blksize_t = __blksize_t;
 pub type blkcnt_t = __blkcnt_t;
@@ -5213,8 +5251,10 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 pub type __compar_fn_t = ::std::option::Option<
-    unsafe extern "C" fn(arg1: *const ::std::os::raw::c_void, arg2: *const ::std::os::raw::c_void)
-        -> ::std::os::raw::c_int,
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
     pub fn bsearch(
@@ -5365,7 +5405,7 @@ extern "C" {
 extern "C" {
     pub fn getsubopt(
         __optionp: *mut *mut ::std::os::raw::c_char,
-        __tokens: *const *const ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
         __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
@@ -5405,66 +5445,70 @@ extern "C" {
     pub fn _mm_pause();
 }
 extern "C" {
-    /// This function returns the number of CPU cores available.
+    ///  This function returns the number of CPU cores available.
     pub fn SDL_GetCPUCount() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This function returns the L1 cache line size of the CPU
+    ///  This function returns the L1 cache line size of the CPU
     ///
-    /// This is useful for determining multi-threaded structure padding
-    /// or SIMD prefetch sizes.
+    ///  This is useful for determining multi-threaded structure padding
+    ///  or SIMD prefetch sizes.
     pub fn SDL_GetCPUCacheLineSize() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This function returns true if the CPU has the RDTSC instruction.
+    ///  This function returns true if the CPU has the RDTSC instruction.
     pub fn SDL_HasRDTSC() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has AltiVec features.
+    ///  This function returns true if the CPU has AltiVec features.
     pub fn SDL_HasAltiVec() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has MMX features.
+    ///  This function returns true if the CPU has MMX features.
     pub fn SDL_HasMMX() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has 3DNow! features.
+    ///  This function returns true if the CPU has 3DNow! features.
     pub fn SDL_Has3DNow() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has SSE features.
+    ///  This function returns true if the CPU has SSE features.
     pub fn SDL_HasSSE() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has SSE2 features.
+    ///  This function returns true if the CPU has SSE2 features.
     pub fn SDL_HasSSE2() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has SSE3 features.
+    ///  This function returns true if the CPU has SSE3 features.
     pub fn SDL_HasSSE3() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has SSE4.1 features.
+    ///  This function returns true if the CPU has SSE4.1 features.
     pub fn SDL_HasSSE41() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has SSE4.2 features.
+    ///  This function returns true if the CPU has SSE4.2 features.
     pub fn SDL_HasSSE42() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has AVX features.
+    ///  This function returns true if the CPU has AVX features.
     pub fn SDL_HasAVX() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has AVX2 features.
+    ///  This function returns true if the CPU has AVX2 features.
     pub fn SDL_HasAVX2() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns true if the CPU has NEON (ARM SIMD) features.
+    ///  This function returns true if the CPU has AVX-512F (foundation) features.
+    pub fn SDL_HasAVX512F() -> SDL_bool;
+}
+extern "C" {
+    ///  This function returns true if the CPU has NEON (ARM SIMD) features.
     pub fn SDL_HasNEON() -> SDL_bool;
 }
 extern "C" {
-    /// This function returns the amount of RAM configured in the system, in MB.
+    ///  This function returns the amount of RAM configured in the system, in MB.
     pub fn SDL_GetSystemRAM() -> ::std::os::raw::c_int;
 }
 pub const SDL_PIXELTYPE_UNKNOWN: _bindgen_ty_1 = _bindgen_ty_1::SDL_PIXELTYPE_UNKNOWN;
@@ -5649,21 +5693,21 @@ pub enum _bindgen_ty_6 {
     SDL_PIXELFORMAT_ABGR8888 = 376840196,
     SDL_PIXELFORMAT_BGRA8888 = 377888772,
     SDL_PIXELFORMAT_ARGB2101010 = 372711428,
-    /// < Planar mode: Y + V + U  (3 planes)
+    ///< Planar mode: Y + V + U  (3 planes)
     SDL_PIXELFORMAT_YV12 = 842094169,
-    /// < Planar mode: Y + U + V  (3 planes)
+    ///< Planar mode: Y + U + V  (3 planes)
     SDL_PIXELFORMAT_IYUV = 1448433993,
-    /// < Packed mode: Y0+U0+Y1+V0 (1 plane)
+    ///< Packed mode: Y0+U0+Y1+V0 (1 plane)
     SDL_PIXELFORMAT_YUY2 = 844715353,
-    /// < Packed mode: U0+Y0+V0+Y1 (1 plane)
+    ///< Packed mode: U0+Y0+V0+Y1 (1 plane)
     SDL_PIXELFORMAT_UYVY = 1498831189,
-    /// < Packed mode: Y0+V0+Y1+U0 (1 plane)
+    ///< Packed mode: Y0+V0+Y1+U0 (1 plane)
     SDL_PIXELFORMAT_YVYU = 1431918169,
-    /// < Planar mode: Y + U/V interleaved  (2 planes)
+    ///< Planar mode: Y + U/V interleaved  (2 planes)
     SDL_PIXELFORMAT_NV12 = 842094158,
-    /// < Planar mode: Y + V/U interleaved  (2 planes)
+    ///< Planar mode: Y + V/U interleaved  (2 planes)
     SDL_PIXELFORMAT_NV21 = 825382478,
-    /// < Android video texture format
+    ///< Android video texture format
     SDL_PIXELFORMAT_EXTERNAL_OES = 542328143,
 }
 #[repr(C)]
@@ -5788,7 +5832,7 @@ fn bindgen_test_layout_SDL_Palette() {
         )
     );
 }
-/// \note Everything in the pixel format structure is read-only.
+///  \note Everything in the pixel format structure is read-only.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_PixelFormat {
@@ -6020,11 +6064,11 @@ extern "C" {
     pub fn SDL_GetPixelFormatName(format: Uint32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Convert one of the enumerated pixel formats to a bpp and RGBA masks.
+    ///  \brief Convert one of the enumerated pixel formats to a bpp and RGBA masks.
     ///
-    /// \return SDL_TRUE, or SDL_FALSE if the conversion wasn't possible.
+    ///  \return SDL_TRUE, or SDL_FALSE if the conversion wasn't possible.
     ///
-    /// \sa SDL_MasksToPixelFormatEnum()
+    ///  \sa SDL_MasksToPixelFormatEnum()
     pub fn SDL_PixelFormatEnumToMasks(
         format: Uint32,
         bpp: *mut ::std::os::raw::c_int,
@@ -6035,12 +6079,12 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Convert a bpp and RGBA masks to an enumerated pixel format.
+    ///  \brief Convert a bpp and RGBA masks to an enumerated pixel format.
     ///
-    /// \return The pixel format, or ::SDL_PIXELFORMAT_UNKNOWN if the conversion
-    /// wasn't possible.
+    ///  \return The pixel format, or ::SDL_PIXELFORMAT_UNKNOWN if the conversion
+    ///          wasn't possible.
     ///
-    /// \sa SDL_PixelFormatEnumToMasks()
+    ///  \sa SDL_PixelFormatEnumToMasks()
     pub fn SDL_MasksToPixelFormatEnum(
         bpp: ::std::os::raw::c_int,
         Rmask: Uint32,
@@ -6050,40 +6094,40 @@ extern "C" {
     ) -> Uint32;
 }
 extern "C" {
-    /// \brief Create an SDL_PixelFormat structure from a pixel format enum.
+    ///  \brief Create an SDL_PixelFormat structure from a pixel format enum.
     pub fn SDL_AllocFormat(pixel_format: Uint32) -> *mut SDL_PixelFormat;
 }
 extern "C" {
-    /// \brief Free an SDL_PixelFormat structure.
+    ///  \brief Free an SDL_PixelFormat structure.
     pub fn SDL_FreeFormat(format: *mut SDL_PixelFormat);
 }
 extern "C" {
-    /// \brief Create a palette structure with the specified number of color
-    /// entries.
+    ///  \brief Create a palette structure with the specified number of color
+    ///         entries.
     ///
-    /// \return A new palette, or NULL if there wasn't enough memory.
+    ///  \return A new palette, or NULL if there wasn't enough memory.
     ///
-    /// \note The palette entries are initialized to white.
+    ///  \note The palette entries are initialized to white.
     ///
-    /// \sa SDL_FreePalette()
+    ///  \sa SDL_FreePalette()
     pub fn SDL_AllocPalette(ncolors: ::std::os::raw::c_int) -> *mut SDL_Palette;
 }
 extern "C" {
-    /// \brief Set the palette for a pixel format structure.
+    ///  \brief Set the palette for a pixel format structure.
     pub fn SDL_SetPixelFormatPalette(
         format: *mut SDL_PixelFormat,
         palette: *mut SDL_Palette,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set a range of colors in a palette.
+    ///  \brief Set a range of colors in a palette.
     ///
-    /// \param palette    The palette to modify.
-    /// \param colors     An array of colors to copy into the palette.
-    /// \param firstcolor The index of the first palette entry to modify.
-    /// \param ncolors    The number of entries to modify.
+    ///  \param palette    The palette to modify.
+    ///  \param colors     An array of colors to copy into the palette.
+    ///  \param firstcolor The index of the first palette entry to modify.
+    ///  \param ncolors    The number of entries to modify.
     ///
-    /// \return 0 on success, or -1 if not all of the colors could be set.
+    ///  \return 0 on success, or -1 if not all of the colors could be set.
     pub fn SDL_SetPaletteColors(
         palette: *mut SDL_Palette,
         colors: *const SDL_Color,
@@ -6092,21 +6136,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Free a palette created with SDL_AllocPalette().
+    ///  \brief Free a palette created with SDL_AllocPalette().
     ///
-    /// \sa SDL_AllocPalette()
+    ///  \sa SDL_AllocPalette()
     pub fn SDL_FreePalette(palette: *mut SDL_Palette);
 }
 extern "C" {
-    /// \brief Maps an RGB triple to an opaque pixel value for a given pixel format.
+    ///  \brief Maps an RGB triple to an opaque pixel value for a given pixel format.
     ///
-    /// \sa SDL_MapRGBA
+    ///  \sa SDL_MapRGBA
     pub fn SDL_MapRGB(format: *const SDL_PixelFormat, r: Uint8, g: Uint8, b: Uint8) -> Uint32;
 }
 extern "C" {
-    /// \brief Maps an RGBA quadruple to a pixel value for a given pixel format.
+    ///  \brief Maps an RGBA quadruple to a pixel value for a given pixel format.
     ///
-    /// \sa SDL_MapRGB
+    ///  \sa SDL_MapRGB
     pub fn SDL_MapRGBA(
         format: *const SDL_PixelFormat,
         r: Uint8,
@@ -6116,9 +6160,9 @@ extern "C" {
     ) -> Uint32;
 }
 extern "C" {
-    /// \brief Get the RGB components from a pixel of the specified format.
+    ///  \brief Get the RGB components from a pixel of the specified format.
     ///
-    /// \sa SDL_GetRGBA
+    ///  \sa SDL_GetRGBA
     pub fn SDL_GetRGB(
         pixel: Uint32,
         format: *const SDL_PixelFormat,
@@ -6128,9 +6172,9 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the RGBA components from a pixel of the specified format.
+    ///  \brief Get the RGBA components from a pixel of the specified format.
     ///
-    /// \sa SDL_GetRGB
+    ///  \sa SDL_GetRGB
     pub fn SDL_GetRGBA(
         pixel: Uint32,
         format: *const SDL_PixelFormat,
@@ -6141,13 +6185,13 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Calculate a 256 entry gamma ramp for a gamma value.
+    ///  \brief Calculate a 256 entry gamma ramp for a gamma value.
     pub fn SDL_CalculateGammaRamp(gamma: f32, ramp: *mut Uint16);
 }
-/// \brief  The structure that defines a point
+///  \brief  The structure that defines a point
 ///
-/// \sa SDL_EnclosePoints
-/// \sa SDL_PointInRect
+///  \sa SDL_EnclosePoints
+///  \sa SDL_PointInRect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Point {
@@ -6187,14 +6231,14 @@ fn bindgen_test_layout_SDL_Point() {
         )
     );
 }
-/// \brief A rectangle, with the origin at the upper left.
+///  \brief A rectangle, with the origin at the upper left.
 ///
-/// \sa SDL_RectEmpty
-/// \sa SDL_RectEquals
-/// \sa SDL_HasIntersection
-/// \sa SDL_IntersectRect
-/// \sa SDL_UnionRect
-/// \sa SDL_EnclosePoints
+///  \sa SDL_RectEmpty
+///  \sa SDL_RectEquals
+///  \sa SDL_HasIntersection
+///  \sa SDL_IntersectRect
+///  \sa SDL_UnionRect
+///  \sa SDL_EnclosePoints
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Rect {
@@ -6257,15 +6301,15 @@ fn bindgen_test_layout_SDL_Rect() {
     );
 }
 extern "C" {
-    /// \brief Determine whether two rectangles intersect.
+    ///  \brief Determine whether two rectangles intersect.
     ///
-    /// \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+    ///  \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
     pub fn SDL_HasIntersection(A: *const SDL_Rect, B: *const SDL_Rect) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Calculate the intersection of two rectangles.
+    ///  \brief Calculate the intersection of two rectangles.
     ///
-    /// \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+    ///  \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
     pub fn SDL_IntersectRect(
         A: *const SDL_Rect,
         B: *const SDL_Rect,
@@ -6273,13 +6317,13 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Calculate the union of two rectangles.
+    ///  \brief Calculate the union of two rectangles.
     pub fn SDL_UnionRect(A: *const SDL_Rect, B: *const SDL_Rect, result: *mut SDL_Rect);
 }
 extern "C" {
-    /// \brief Calculate a minimal rectangle enclosing a set of points
+    ///  \brief Calculate a minimal rectangle enclosing a set of points
     ///
-    /// \return SDL_TRUE if any points were within the clipping rect
+    ///  \return SDL_TRUE if any points were within the clipping rect
     pub fn SDL_EnclosePoints(
         points: *const SDL_Point,
         count: ::std::os::raw::c_int,
@@ -6288,9 +6332,9 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Calculate the intersection of a rectangle and line segment.
+    ///  \brief Calculate the intersection of a rectangle and line segment.
     ///
-    /// \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
+    ///  \return SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
     pub fn SDL_IntersectRectAndLine(
         rect: *const SDL_Rect,
         X1: *mut ::std::os::raw::c_int,
@@ -6300,80 +6344,80 @@ extern "C" {
     ) -> SDL_bool;
 }
 #[repr(u32)]
-/// \brief The blend mode used in SDL_RenderCopy() and drawing operations.
+///  \brief The blend mode used in SDL_RenderCopy() and drawing operations.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_BlendMode {
-    /// < no blending
-    /// dstRGBA = srcRGBA
+    ///< no blending
+    ///dstRGBA = srcRGBA
     SDL_BLENDMODE_NONE = 0,
-    /// < alpha blending
-    /// dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
-    /// dstA = srcA + (dstA * (1-srcA))
+    ///< alpha blending
+    ///dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
+    ///dstA = srcA + (dstA * (1-srcA))
     SDL_BLENDMODE_BLEND = 1,
-    /// < additive blending
-    /// dstRGB = (srcRGB * srcA) + dstRGB
-    /// dstA = dstA
+    ///< additive blending
+    ///dstRGB = (srcRGB * srcA) + dstRGB
+    ///dstA = dstA
     SDL_BLENDMODE_ADD = 2,
-    /// < color modulate
-    /// dstRGB = srcRGB * dstRGB
-    /// dstA = dstA
+    ///< color modulate
+    ///dstRGB = srcRGB * dstRGB
+    ///dstA = dstA
     SDL_BLENDMODE_MOD = 4,
     SDL_BLENDMODE_INVALID = 2147483647,
 }
 #[repr(u32)]
-/// \brief The blend operation used when combining source and destination pixel components
+///  \brief The blend operation used when combining source and destination pixel components
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_BlendOperation {
-    /// < dst + src: supported by all renderers
+    ///< dst + src: supported by all renderers
     SDL_BLENDOPERATION_ADD = 1,
-    /// < dst - src : supported by D3D9, D3D11, OpenGL, OpenGLES
+    ///< dst - src : supported by D3D9, D3D11, OpenGL, OpenGLES
     SDL_BLENDOPERATION_SUBTRACT = 2,
-    /// < src - dst : supported by D3D9, D3D11, OpenGL, OpenGLES
+    ///< src - dst : supported by D3D9, D3D11, OpenGL, OpenGLES
     SDL_BLENDOPERATION_REV_SUBTRACT = 3,
-    /// < min(dst, src) : supported by D3D11
+    ///< min(dst, src) : supported by D3D11
     SDL_BLENDOPERATION_MINIMUM = 4,
-    /// < max(dst, src) : supported by D3D11
+    ///< max(dst, src) : supported by D3D11
     SDL_BLENDOPERATION_MAXIMUM = 5,
 }
 #[repr(u32)]
-/// \brief The normalized factor used to multiply pixel components
+///  \brief The normalized factor used to multiply pixel components
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_BlendFactor {
-    /// < 0, 0, 0, 0
+    ///< 0, 0, 0, 0
     SDL_BLENDFACTOR_ZERO = 1,
-    /// < 1, 1, 1, 1
+    ///< 1, 1, 1, 1
     SDL_BLENDFACTOR_ONE = 2,
-    /// < srcR, srcG, srcB, srcA
+    ///< srcR, srcG, srcB, srcA
     SDL_BLENDFACTOR_SRC_COLOR = 3,
-    /// < 1-srcR, 1-srcG, 1-srcB, 1-srcA
+    ///< 1-srcR, 1-srcG, 1-srcB, 1-srcA
     SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR = 4,
-    /// < srcA, srcA, srcA, srcA
+    ///< srcA, srcA, srcA, srcA
     SDL_BLENDFACTOR_SRC_ALPHA = 5,
-    /// < 1-srcA, 1-srcA, 1-srcA, 1-srcA
+    ///< 1-srcA, 1-srcA, 1-srcA, 1-srcA
     SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA = 6,
-    /// < dstR, dstG, dstB, dstA
+    ///< dstR, dstG, dstB, dstA
     SDL_BLENDFACTOR_DST_COLOR = 7,
-    /// < 1-dstR, 1-dstG, 1-dstB, 1-dstA
+    ///< 1-dstR, 1-dstG, 1-dstB, 1-dstA
     SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR = 8,
-    /// < dstA, dstA, dstA, dstA
+    ///< dstA, dstA, dstA, dstA
     SDL_BLENDFACTOR_DST_ALPHA = 9,
-    /// < 1-dstA, 1-dstA, 1-dstA, 1-dstA
+    ///< 1-dstA, 1-dstA, 1-dstA, 1-dstA
     SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA = 10,
 }
 extern "C" {
-    /// \brief Create a custom blend mode, which may or may not be supported by a given renderer
+    ///  \brief Create a custom blend mode, which may or may not be supported by a given renderer
     ///
-    /// \param srcColorFactor
-    /// \param dstColorFactor
-    /// \param colorOperation
-    /// \param srcAlphaFactor
-    /// \param dstAlphaFactor
-    /// \param alphaOperation
+    ///  \param srcColorFactor
+    ///  \param dstColorFactor
+    ///  \param colorOperation
+    ///  \param srcAlphaFactor
+    ///  \param dstAlphaFactor
+    ///  \param alphaOperation
     ///
-    /// The result of the blend mode operation will be:
-    /// dstRGB = dstRGB * dstColorFactor colorOperation srcRGB * srcColorFactor
-    /// and
-    /// dstA = dstA * dstAlphaFactor alphaOperation srcA * srcAlphaFactor
+    ///  The result of the blend mode operation will be:
+    ///      dstRGB = dstRGB * dstColorFactor colorOperation srcRGB * srcColorFactor
+    ///  and
+    ///      dstA = dstA * dstAlphaFactor alphaOperation srcA * srcAlphaFactor
     pub fn SDL_ComposeCustomBlendMode(
         srcColorFactor: SDL_BlendFactor,
         dstColorFactor: SDL_BlendFactor,
@@ -6386,33 +6430,33 @@ extern "C" {
 /// \brief A collection of pixels used in software blitting.
 ///
 /// \note  This structure should be treated as read-only, except for \c pixels,
-/// which, if not NULL, contains the raw pixel data for the surface.
+///        which, if not NULL, contains the raw pixel data for the surface.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Surface {
-    /// < Read-only
+    ///< Read-only
     pub flags: Uint32,
-    /// < Read-only
+    ///< Read-only
     pub format: *mut SDL_PixelFormat,
-    /// < Read-only
+    ///< Read-only
     pub w: ::std::os::raw::c_int,
-    /// < Read-only
+    ///< Read-only
     pub h: ::std::os::raw::c_int,
-    /// < Read-only
+    ///< Read-only
     pub pitch: ::std::os::raw::c_int,
-    /// < Read-write
+    ///< Read-write
     pub pixels: *mut ::std::os::raw::c_void,
-    /// < Read-write
+    ///< Read-write
     pub userdata: *mut ::std::os::raw::c_void,
-    /// < Read-only
+    ///< Read-only
     pub locked: ::std::os::raw::c_int,
-    /// < Read-only
+    ///< Read-only
     pub lock_data: *mut ::std::os::raw::c_void,
-    /// < Read-only
+    ///< Read-only
     pub clip_rect: SDL_Rect,
-    /// < Private
+    ///< Private
     pub map: *mut SDL_BlitMap,
-    /// < Read-mostly
+    ///< Read-mostly
     pub refcount: ::std::os::raw::c_int,
 }
 #[test]
@@ -6561,32 +6605,32 @@ pub type SDL_blit = ::std::option::Option<
 /// \brief The formula used for converting between YUV and RGB
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_YUV_CONVERSION_MODE {
-    /// < Full range JPEG
+    ///< Full range JPEG
     SDL_YUV_CONVERSION_JPEG = 0,
-    /// < BT.601 (the default)
+    ///< BT.601 (the default)
     SDL_YUV_CONVERSION_BT601 = 1,
-    /// < BT.709
+    ///< BT.709
     SDL_YUV_CONVERSION_BT709 = 2,
-    /// < BT.601 for SD content, BT.709 for HD content
+    ///< BT.601 for SD content, BT.709 for HD content
     SDL_YUV_CONVERSION_AUTOMATIC = 3,
 }
 extern "C" {
-    /// Allocate and free an RGB surface.
+    ///  Allocate and free an RGB surface.
     ///
-    /// If the depth is 4 or 8 bits, an empty palette is allocated for the surface.
-    /// If the depth is greater than 8 bits, the pixel format is set using the
-    /// flags '[RGB]mask'.
+    ///  If the depth is 4 or 8 bits, an empty palette is allocated for the surface.
+    ///  If the depth is greater than 8 bits, the pixel format is set using the
+    ///  flags '[RGB]mask'.
     ///
-    /// If the function runs out of memory, it will return NULL.
+    ///  If the function runs out of memory, it will return NULL.
     ///
-    /// \param flags The \c flags are obsolete and should be set to 0.
-    /// \param width The width in pixels of the surface to create.
-    /// \param height The height in pixels of the surface to create.
-    /// \param depth The depth in bits of the surface to create.
-    /// \param Rmask The red mask of the surface to create.
-    /// \param Gmask The green mask of the surface to create.
-    /// \param Bmask The blue mask of the surface to create.
-    /// \param Amask The alpha mask of the surface to create.
+    ///  \param flags The \c flags are obsolete and should be set to 0.
+    ///  \param width The width in pixels of the surface to create.
+    ///  \param height The height in pixels of the surface to create.
+    ///  \param depth The depth in bits of the surface to create.
+    ///  \param Rmask The red mask of the surface to create.
+    ///  \param Gmask The green mask of the surface to create.
+    ///  \param Bmask The blue mask of the surface to create.
+    ///  \param Amask The alpha mask of the surface to create.
     pub fn SDL_CreateRGBSurface(
         flags: Uint32,
         width: ::std::os::raw::c_int,
@@ -6634,34 +6678,34 @@ extern "C" {
     pub fn SDL_FreeSurface(surface: *mut SDL_Surface);
 }
 extern "C" {
-    /// \brief Set the palette used by a surface.
+    ///  \brief Set the palette used by a surface.
     ///
-    /// \return 0, or -1 if the surface format doesn't use a palette.
+    ///  \return 0, or -1 if the surface format doesn't use a palette.
     ///
-    /// \note A single palette can be shared with many surfaces.
+    ///  \note A single palette can be shared with many surfaces.
     pub fn SDL_SetSurfacePalette(
         surface: *mut SDL_Surface,
         palette: *mut SDL_Palette,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets up a surface for directly accessing the pixels.
+    ///  \brief Sets up a surface for directly accessing the pixels.
     ///
-    /// Between calls to SDL_LockSurface() / SDL_UnlockSurface(), you can write
-    /// to and read from \c surface->pixels, using the pixel format stored in
-    /// \c surface->format.  Once you are done accessing the surface, you should
-    /// use SDL_UnlockSurface() to release it.
+    ///  Between calls to SDL_LockSurface() / SDL_UnlockSurface(), you can write
+    ///  to and read from \c surface->pixels, using the pixel format stored in
+    ///  \c surface->format.  Once you are done accessing the surface, you should
+    ///  use SDL_UnlockSurface() to release it.
     ///
-    /// Not all surfaces require locking.  If SDL_MUSTLOCK(surface) evaluates
-    /// to 0, then you can read and write to the surface at any time, and the
-    /// pixel format of the surface will not change.
+    ///  Not all surfaces require locking.  If SDL_MUSTLOCK(surface) evaluates
+    ///  to 0, then you can read and write to the surface at any time, and the
+    ///  pixel format of the surface will not change.
     ///
-    /// No operating system or library calls should be made between lock/unlock
-    /// pairs, as critical system locks may be held during this time.
+    ///  No operating system or library calls should be made between lock/unlock
+    ///  pairs, as critical system locks may be held during this time.
     ///
-    /// SDL_LockSurface() returns 0, or -1 if the surface couldn't be locked.
+    ///  SDL_LockSurface() returns 0, or -1 if the surface couldn't be locked.
     ///
-    /// \sa SDL_UnlockSurface()
+    ///  \sa SDL_UnlockSurface()
     pub fn SDL_LockSurface(surface: *mut SDL_Surface) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -6669,27 +6713,27 @@ extern "C" {
     pub fn SDL_UnlockSurface(surface: *mut SDL_Surface);
 }
 extern "C" {
-    /// Load a surface from a seekable SDL data stream (memory or file).
+    ///  Load a surface from a seekable SDL data stream (memory or file).
     ///
-    /// If \c freesrc is non-zero, the stream will be closed after being read.
+    ///  If \c freesrc is non-zero, the stream will be closed after being read.
     ///
-    /// The new surface should be freed with SDL_FreeSurface().
+    ///  The new surface should be freed with SDL_FreeSurface().
     ///
-    /// \return the new surface, or NULL if there was an error.
+    ///  \return the new surface, or NULL if there was an error.
     pub fn SDL_LoadBMP_RW(src: *mut SDL_RWops, freesrc: ::std::os::raw::c_int) -> *mut SDL_Surface;
 }
 extern "C" {
-    /// Save a surface to a seekable SDL data stream (memory or file).
+    ///  Save a surface to a seekable SDL data stream (memory or file).
     ///
-    /// Surfaces with a 24-bit, 32-bit and paletted 8-bit format get saved in the
-    /// BMP directly. Other RGB formats with 8-bit or higher get converted to a
-    /// 24-bit surface or, if they have an alpha mask or a colorkey, to a 32-bit
-    /// surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
-    /// not supported.
+    ///  Surfaces with a 24-bit, 32-bit and paletted 8-bit format get saved in the
+    ///  BMP directly. Other RGB formats with 8-bit or higher get converted to a
+    ///  24-bit surface or, if they have an alpha mask or a colorkey, to a 32-bit
+    ///  surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
+    ///  not supported.
     ///
-    /// If \c freedst is non-zero, the stream will be closed after being written.
+    ///  If \c freedst is non-zero, the stream will be closed after being written.
     ///
-    /// \return 0 if successful or -1 if there was an error.
+    ///  \return 0 if successful or -1 if there was an error.
     pub fn SDL_SaveBMP_RW(
         surface: *mut SDL_Surface,
         dst: *mut SDL_RWops,
@@ -6697,27 +6741,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets the RLE acceleration hint for a surface.
+    ///  \brief Sets the RLE acceleration hint for a surface.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid
+    ///  \return 0 on success, or -1 if the surface is not valid
     ///
-    /// \note If RLE is enabled, colorkey and alpha blending blits are much faster,
-    /// but the surface must be locked before directly accessing the pixels.
+    ///  \note If RLE is enabled, colorkey and alpha blending blits are much faster,
+    ///        but the surface must be locked before directly accessing the pixels.
     pub fn SDL_SetSurfaceRLE(
         surface: *mut SDL_Surface,
         flag: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets the color key (transparent pixel) in a blittable surface.
+    ///  \brief Sets the color key (transparent pixel) in a blittable surface.
     ///
-    /// \param surface The surface to update
-    /// \param flag Non-zero to enable colorkey and 0 to disable colorkey
-    /// \param key The transparent pixel in the native surface format
+    ///  \param surface The surface to update
+    ///  \param flag Non-zero to enable colorkey and 0 to disable colorkey
+    ///  \param key The transparent pixel in the native surface format
     ///
-    /// \return 0 on success, or -1 if the surface is not valid
+    ///  \return 0 on success, or -1 if the surface is not valid
     ///
-    /// You can pass SDL_RLEACCEL to enable RLE accelerated blits.
+    ///  You can pass SDL_RLEACCEL to enable RLE accelerated blits.
     pub fn SDL_SetColorKey(
         surface: *mut SDL_Surface,
         flag: ::std::os::raw::c_int,
@@ -6725,27 +6769,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Gets the color key (transparent pixel) in a blittable surface.
+    ///  \brief Returns whether the surface has a color key
     ///
-    /// \param surface The surface to update
-    /// \param key A pointer filled in with the transparent pixel in the native
-    /// surface format
+    ///  \return SDL_TRUE if the surface has a color key, or SDL_FALSE if the surface is NULL or has no color key
+    pub fn SDL_HasColorKey(surface: *mut SDL_Surface) -> SDL_bool;
+}
+extern "C" {
+    ///  \brief Gets the color key (transparent pixel) in a blittable surface.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid or colorkey is not
-    /// enabled.
+    ///  \param surface The surface to update
+    ///  \param key A pointer filled in with the transparent pixel in the native
+    ///             surface format
+    ///
+    ///  \return 0 on success, or -1 if the surface is not valid or colorkey is not
+    ///          enabled.
     pub fn SDL_GetColorKey(surface: *mut SDL_Surface, key: *mut Uint32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set an additional color value used in blit operations.
+    ///  \brief Set an additional color value used in blit operations.
     ///
-    /// \param surface The surface to update.
-    /// \param r The red color value multiplied into blit operations.
-    /// \param g The green color value multiplied into blit operations.
-    /// \param b The blue color value multiplied into blit operations.
+    ///  \param surface The surface to update.
+    ///  \param r The red color value multiplied into blit operations.
+    ///  \param g The green color value multiplied into blit operations.
+    ///  \param b The blue color value multiplied into blit operations.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid.
+    ///  \return 0 on success, or -1 if the surface is not valid.
     ///
-    /// \sa SDL_GetSurfaceColorMod()
+    ///  \sa SDL_GetSurfaceColorMod()
     pub fn SDL_SetSurfaceColorMod(
         surface: *mut SDL_Surface,
         r: Uint8,
@@ -6754,16 +6804,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the additional color value used in blit operations.
+    ///  \brief Get the additional color value used in blit operations.
     ///
-    /// \param surface The surface to query.
-    /// \param r A pointer filled in with the current red color value.
-    /// \param g A pointer filled in with the current green color value.
-    /// \param b A pointer filled in with the current blue color value.
+    ///  \param surface The surface to query.
+    ///  \param r A pointer filled in with the current red color value.
+    ///  \param g A pointer filled in with the current green color value.
+    ///  \param b A pointer filled in with the current blue color value.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid.
+    ///  \return 0 on success, or -1 if the surface is not valid.
     ///
-    /// \sa SDL_SetSurfaceColorMod()
+    ///  \sa SDL_SetSurfaceColorMod()
     pub fn SDL_GetSurfaceColorMod(
         surface: *mut SDL_Surface,
         r: *mut Uint8,
@@ -6772,92 +6822,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set an additional alpha value used in blit operations.
+    ///  \brief Set an additional alpha value used in blit operations.
     ///
-    /// \param surface The surface to update.
-    /// \param alpha The alpha value multiplied into blit operations.
+    ///  \param surface The surface to update.
+    ///  \param alpha The alpha value multiplied into blit operations.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid.
+    ///  \return 0 on success, or -1 if the surface is not valid.
     ///
-    /// \sa SDL_GetSurfaceAlphaMod()
+    ///  \sa SDL_GetSurfaceAlphaMod()
     pub fn SDL_SetSurfaceAlphaMod(surface: *mut SDL_Surface, alpha: Uint8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the additional alpha value used in blit operations.
+    ///  \brief Get the additional alpha value used in blit operations.
     ///
-    /// \param surface The surface to query.
-    /// \param alpha A pointer filled in with the current alpha value.
+    ///  \param surface The surface to query.
+    ///  \param alpha A pointer filled in with the current alpha value.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid.
+    ///  \return 0 on success, or -1 if the surface is not valid.
     ///
-    /// \sa SDL_SetSurfaceAlphaMod()
+    ///  \sa SDL_SetSurfaceAlphaMod()
     pub fn SDL_GetSurfaceAlphaMod(
         surface: *mut SDL_Surface,
         alpha: *mut Uint8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the blend mode used for blit operations.
+    ///  \brief Set the blend mode used for blit operations.
     ///
-    /// \param surface The surface to update.
-    /// \param blendMode ::SDL_BlendMode to use for blit blending.
+    ///  \param surface The surface to update.
+    ///  \param blendMode ::SDL_BlendMode to use for blit blending.
     ///
-    /// \return 0 on success, or -1 if the parameters are not valid.
+    ///  \return 0 on success, or -1 if the parameters are not valid.
     ///
-    /// \sa SDL_GetSurfaceBlendMode()
+    ///  \sa SDL_GetSurfaceBlendMode()
     pub fn SDL_SetSurfaceBlendMode(
         surface: *mut SDL_Surface,
         blendMode: SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the blend mode used for blit operations.
+    ///  \brief Get the blend mode used for blit operations.
     ///
-    /// \param surface   The surface to query.
-    /// \param blendMode A pointer filled in with the current blend mode.
+    ///  \param surface   The surface to query.
+    ///  \param blendMode A pointer filled in with the current blend mode.
     ///
-    /// \return 0 on success, or -1 if the surface is not valid.
+    ///  \return 0 on success, or -1 if the surface is not valid.
     ///
-    /// \sa SDL_SetSurfaceBlendMode()
+    ///  \sa SDL_SetSurfaceBlendMode()
     pub fn SDL_GetSurfaceBlendMode(
         surface: *mut SDL_Surface,
         blendMode: *mut SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Sets the clipping rectangle for the destination surface in a blit.
+    ///  Sets the clipping rectangle for the destination surface in a blit.
     ///
-    /// If the clip rectangle is NULL, clipping will be disabled.
+    ///  If the clip rectangle is NULL, clipping will be disabled.
     ///
-    /// If the clip rectangle doesn't intersect the surface, the function will
-    /// return SDL_FALSE and blits will be completely clipped.  Otherwise the
-    /// function returns SDL_TRUE and blits to the surface will be clipped to
-    /// the intersection of the surface area and the clipping rectangle.
+    ///  If the clip rectangle doesn't intersect the surface, the function will
+    ///  return SDL_FALSE and blits will be completely clipped.  Otherwise the
+    ///  function returns SDL_TRUE and blits to the surface will be clipped to
+    ///  the intersection of the surface area and the clipping rectangle.
     ///
-    /// Note that blits are automatically clipped to the edges of the source
-    /// and destination surfaces.
+    ///  Note that blits are automatically clipped to the edges of the source
+    ///  and destination surfaces.
     pub fn SDL_SetClipRect(surface: *mut SDL_Surface, rect: *const SDL_Rect) -> SDL_bool;
 }
 extern "C" {
-    /// Gets the clipping rectangle for the destination surface in a blit.
+    ///  Gets the clipping rectangle for the destination surface in a blit.
     ///
-    /// \c rect must be a pointer to a valid rectangle which will be filled
-    /// with the correct values.
+    ///  \c rect must be a pointer to a valid rectangle which will be filled
+    ///  with the correct values.
     pub fn SDL_GetClipRect(surface: *mut SDL_Surface, rect: *mut SDL_Rect);
 }
 extern "C" {
     pub fn SDL_DuplicateSurface(surface: *mut SDL_Surface) -> *mut SDL_Surface;
 }
 extern "C" {
-    /// Creates a new surface of the specified format, and then copies and maps
-    /// the given surface to it so the blit of the converted surface will be as
-    /// fast as possible.  If this function fails, it returns NULL.
+    ///  Creates a new surface of the specified format, and then copies and maps
+    ///  the given surface to it so the blit of the converted surface will be as
+    ///  fast as possible.  If this function fails, it returns NULL.
     ///
-    /// The \c flags parameter is passed to SDL_CreateRGBSurface() and has those
-    /// semantics.  You can also pass ::SDL_RLEACCEL in the flags parameter and
-    /// SDL will try to RLE accelerate colorkey and alpha blits in the resulting
-    /// surface.
+    ///  The \c flags parameter is passed to SDL_CreateRGBSurface() and has those
+    ///  semantics.  You can also pass ::SDL_RLEACCEL in the flags parameter and
+    ///  SDL will try to RLE accelerate colorkey and alpha blits in the resulting
+    ///  surface.
     pub fn SDL_ConvertSurface(
         src: *mut SDL_Surface,
         fmt: *const SDL_PixelFormat,
@@ -6874,7 +6924,7 @@ extern "C" {
 extern "C" {
     /// \brief Copy a block of pixels of one format to another format
     ///
-    /// \return 0 on success, or -1 if there was an error
+    ///  \return 0 on success, or -1 if there was an error
     pub fn SDL_ConvertPixels(
         width: ::std::os::raw::c_int,
         height: ::std::os::raw::c_int,
@@ -6887,14 +6937,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Performs a fast fill of the given rectangle with \c color.
+    ///  Performs a fast fill of the given rectangle with \c color.
     ///
-    /// If \c rect is NULL, the whole surface will be filled with \c color.
+    ///  If \c rect is NULL, the whole surface will be filled with \c color.
     ///
-    /// The color should be a pixel of the format used by the surface, and
-    /// can be generated by the SDL_MapRGB() function.
+    ///  The color should be a pixel of the format used by the surface, and
+    ///  can be generated by the SDL_MapRGB() function.
     ///
-    /// \return 0 on success, or -1 on error.
+    ///  \return 0 on success, or -1 on error.
     pub fn SDL_FillRect(
         dst: *mut SDL_Surface,
         rect: *const SDL_Rect,
@@ -6910,8 +6960,8 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This is the public blit function, SDL_BlitSurface(), and it performs
-    /// rectangle validation and clipping before passing it to SDL_LowerBlit()
+    ///  This is the public blit function, SDL_BlitSurface(), and it performs
+    ///  rectangle validation and clipping before passing it to SDL_LowerBlit()
     pub fn SDL_UpperBlit(
         src: *mut SDL_Surface,
         srcrect: *const SDL_Rect,
@@ -6920,8 +6970,8 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This is a semi-private blit function and it performs low-level surface
-    /// blitting only.
+    ///  This is a semi-private blit function and it performs low-level surface
+    ///  blitting only.
     pub fn SDL_LowerBlit(
         src: *mut SDL_Surface,
         srcrect: *mut SDL_Rect,
@@ -6930,10 +6980,10 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Perform a fast, low quality, stretch blit between two surfaces of the
-    /// same pixel format.
+    ///  \brief Perform a fast, low quality, stretch blit between two surfaces of the
+    ///         same pixel format.
     ///
-    /// \note This function uses a static buffer, and is not thread-safe.
+    ///  \note This function uses a static buffer, and is not thread-safe.
     pub fn SDL_SoftStretch(
         src: *mut SDL_Surface,
         srcrect: *const SDL_Rect,
@@ -6942,8 +6992,8 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This is the public scaled blit function, SDL_BlitScaled(), and it performs
-    /// rectangle validation and clipping before passing it to SDL_LowerBlitScaled()
+    ///  This is the public scaled blit function, SDL_BlitScaled(), and it performs
+    ///  rectangle validation and clipping before passing it to SDL_LowerBlitScaled()
     pub fn SDL_UpperBlitScaled(
         src: *mut SDL_Surface,
         srcrect: *const SDL_Rect,
@@ -6952,8 +7002,8 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This is a semi-private blit function and it performs low-level surface
-    /// scaled blitting only.
+    ///  This is a semi-private blit function and it performs low-level surface
+    ///  scaled blitting only.
     pub fn SDL_LowerBlitScaled(
         src: *mut SDL_Surface,
         srcrect: *mut SDL_Rect,
@@ -6962,41 +7012,41 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the YUV conversion mode
+    ///  \brief Set the YUV conversion mode
     pub fn SDL_SetYUVConversionMode(mode: SDL_YUV_CONVERSION_MODE);
 }
 extern "C" {
-    /// \brief Get the YUV conversion mode
+    ///  \brief Get the YUV conversion mode
     pub fn SDL_GetYUVConversionMode() -> SDL_YUV_CONVERSION_MODE;
 }
 extern "C" {
-    /// \brief Get the YUV conversion mode, returning the correct mode for the resolution when the current conversion mode is SDL_YUV_CONVERSION_AUTOMATIC
+    ///  \brief Get the YUV conversion mode, returning the correct mode for the resolution when the current conversion mode is SDL_YUV_CONVERSION_AUTOMATIC
     pub fn SDL_GetYUVConversionModeForResolution(
         width: ::std::os::raw::c_int,
         height: ::std::os::raw::c_int,
     ) -> SDL_YUV_CONVERSION_MODE;
 }
-/// \brief  The structure that defines a display mode
+///  \brief  The structure that defines a display mode
 ///
-/// \sa SDL_GetNumDisplayModes()
-/// \sa SDL_GetDisplayMode()
-/// \sa SDL_GetDesktopDisplayMode()
-/// \sa SDL_GetCurrentDisplayMode()
-/// \sa SDL_GetClosestDisplayMode()
-/// \sa SDL_SetWindowDisplayMode()
-/// \sa SDL_GetWindowDisplayMode()
+///  \sa SDL_GetNumDisplayModes()
+///  \sa SDL_GetDisplayMode()
+///  \sa SDL_GetDesktopDisplayMode()
+///  \sa SDL_GetCurrentDisplayMode()
+///  \sa SDL_GetClosestDisplayMode()
+///  \sa SDL_SetWindowDisplayMode()
+///  \sa SDL_GetWindowDisplayMode()
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_DisplayMode {
-    /// < pixel format
+    ///< pixel format
     pub format: Uint32,
-    /// < width, in screen coordinates
+    ///< width, in screen coordinates
     pub w: ::std::os::raw::c_int,
-    /// < height, in screen coordinates
+    ///< height, in screen coordinates
     pub h: ::std::os::raw::c_int,
-    /// < refresh rate (or zero for unspecified)
+    ///< refresh rate (or zero for unspecified)
     pub refresh_rate: ::std::os::raw::c_int,
-    /// < driver-specific data, initialize to 0
+    ///< driver-specific data, initialize to 0
     pub driverdata: *mut ::std::os::raw::c_void,
 }
 #[test]
@@ -7068,102 +7118,125 @@ pub struct SDL_Window {
     _unused: [u8; 0],
 }
 #[repr(u32)]
-/// \brief The flags on a window
+///  \brief The flags on a window
 ///
-/// \sa SDL_GetWindowFlags()
+///  \sa SDL_GetWindowFlags()
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_WindowFlags {
-    /// < fullscreen window
+    ///< fullscreen window
     SDL_WINDOW_FULLSCREEN = 1,
-    /// < window usable with OpenGL context
+    ///< window usable with OpenGL context
     SDL_WINDOW_OPENGL = 2,
-    /// < window is visible
+    ///< window is visible
     SDL_WINDOW_SHOWN = 4,
-    /// < window is not visible
+    ///< window is not visible
     SDL_WINDOW_HIDDEN = 8,
-    /// < no window decoration
+    ///< no window decoration
     SDL_WINDOW_BORDERLESS = 16,
-    /// < window can be resized
+    ///< window can be resized
     SDL_WINDOW_RESIZABLE = 32,
-    /// < window is minimized
+    ///< window is minimized
     SDL_WINDOW_MINIMIZED = 64,
-    /// < window is maximized
+    ///< window is maximized
     SDL_WINDOW_MAXIMIZED = 128,
-    /// < window has grabbed input focus
+    ///< window has grabbed input focus
     SDL_WINDOW_INPUT_GRABBED = 256,
-    /// < window has input focus
+    ///< window has input focus
     SDL_WINDOW_INPUT_FOCUS = 512,
-    /// < window has mouse focus
+    ///< window has mouse focus
     SDL_WINDOW_MOUSE_FOCUS = 1024,
     SDL_WINDOW_FULLSCREEN_DESKTOP = 4097,
-    /// < window not created by SDL
+    ///< window not created by SDL
     SDL_WINDOW_FOREIGN = 2048,
-    /// < window should be created in high-DPI mode if supported.
-    /// On macOS NSHighResolutionCapable must be set true in the
-    /// application's Info.plist for this to have any effect.
+    ///< window should be created in high-DPI mode if supported.
+    ///On macOS NSHighResolutionCapable must be set true in the
+    ///application's Info.plist for this to have any effect.
     SDL_WINDOW_ALLOW_HIGHDPI = 8192,
-    /// < window has mouse captured (unrelated to INPUT_GRABBED)
+    ///< window has mouse captured (unrelated to INPUT_GRABBED)
     SDL_WINDOW_MOUSE_CAPTURE = 16384,
-    /// < window should always be above others
+    ///< window should always be above others
     SDL_WINDOW_ALWAYS_ON_TOP = 32768,
-    /// < window should not be added to the taskbar
+    ///< window should not be added to the taskbar
     SDL_WINDOW_SKIP_TASKBAR = 65536,
-    /// < window should be treated as a utility window
+    ///< window should be treated as a utility window
     SDL_WINDOW_UTILITY = 131072,
-    /// < window should be treated as a tooltip
+    ///< window should be treated as a tooltip
     SDL_WINDOW_TOOLTIP = 262144,
-    /// < window should be treated as a popup menu
+    ///< window should be treated as a popup menu
     SDL_WINDOW_POPUP_MENU = 524288,
-    /// < window usable for Vulkan surface
+    ///< window usable for Vulkan surface
     SDL_WINDOW_VULKAN = 268435456,
 }
 #[repr(u32)]
-/// \brief Event subtype for window events
+///  \brief Event subtype for window events
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_WindowEventID {
-    /// < Never used
+    ///< Never used
     SDL_WINDOWEVENT_NONE = 0,
-    /// < Window has been shown
+    ///< Window has been shown
     SDL_WINDOWEVENT_SHOWN = 1,
-    /// < Window has been hidden
+    ///< Window has been hidden
     SDL_WINDOWEVENT_HIDDEN = 2,
-    /// < Window has been exposed and should be
-    /// redrawn
+    ///< Window has been exposed and should be
+    ///redrawn
     SDL_WINDOWEVENT_EXPOSED = 3,
-    /// < Window has been moved to data1, data2
+    ///< Window has been moved to data1, data2
     SDL_WINDOWEVENT_MOVED = 4,
-    /// < Window has been resized to data1xdata2
+    ///< Window has been resized to data1xdata2
     SDL_WINDOWEVENT_RESIZED = 5,
-    /// < The window size has changed, either as
-    /// a result of an API call or through the
-    /// system or user changing the window size.
+    ///< The window size has changed, either as
+    ///a result of an API call or through the
+    ///system or user changing the window size.
     SDL_WINDOWEVENT_SIZE_CHANGED = 6,
-    /// < Window has been minimized
+    ///< Window has been minimized
     SDL_WINDOWEVENT_MINIMIZED = 7,
-    /// < Window has been maximized
+    ///< Window has been maximized
     SDL_WINDOWEVENT_MAXIMIZED = 8,
-    /// < Window has been restored to normal size
-    /// and position
+    ///< Window has been restored to normal size
+    ///and position
     SDL_WINDOWEVENT_RESTORED = 9,
-    /// < Window has gained mouse focus
+    ///< Window has gained mouse focus
     SDL_WINDOWEVENT_ENTER = 10,
-    /// < Window has lost mouse focus
+    ///< Window has lost mouse focus
     SDL_WINDOWEVENT_LEAVE = 11,
-    /// < Window has gained keyboard focus
+    ///< Window has gained keyboard focus
     SDL_WINDOWEVENT_FOCUS_GAINED = 12,
-    /// < Window has lost keyboard focus
+    ///< Window has lost keyboard focus
     SDL_WINDOWEVENT_FOCUS_LOST = 13,
-    /// < The window manager requests that the window be closed
+    ///< The window manager requests that the window be closed
     SDL_WINDOWEVENT_CLOSE = 14,
-    /// < Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore)
+    ///< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore)
     SDL_WINDOWEVENT_TAKE_FOCUS = 15,
-    /// < Window had a hit test that wasn't SDL_HITTEST_NORMAL.
+    ///< Window had a hit test that wasn't SDL_HITTEST_NORMAL.
     SDL_WINDOWEVENT_HIT_TEST = 16,
 }
-/// \brief An opaque handle to an OpenGL context.
+#[repr(u32)]
+///  \brief Event subtype for display events
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum SDL_DisplayEventID {
+    ///< Never used
+    SDL_DISPLAYEVENT_NONE = 0,
+    ///< Display orientation has changed to data1
+    SDL_DISPLAYEVENT_ORIENTATION = 1,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum SDL_DisplayOrientation {
+    ///< The display orientation can't be determined
+    SDL_ORIENTATION_UNKNOWN = 0,
+    ///< The display is in landscape mode, with the right side up, relative to portrait mode
+    SDL_ORIENTATION_LANDSCAPE = 1,
+    ///< The display is in landscape mode, with the left side up, relative to portrait mode
+    SDL_ORIENTATION_LANDSCAPE_FLIPPED = 2,
+    ///< The display is in portrait mode
+    SDL_ORIENTATION_PORTRAIT = 3,
+    ///< The display is in portrait mode, upside down
+    SDL_ORIENTATION_PORTRAIT_FLIPPED = 4,
+}
+///  \brief An opaque handle to an OpenGL context.
 pub type SDL_GLContext = *mut ::std::os::raw::c_void;
 #[repr(u32)]
-/// \brief OpenGL configuration attributes
+///  \brief OpenGL configuration attributes
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_GLattr {
     SDL_GL_RED_SIZE = 0,
@@ -7199,7 +7272,7 @@ pub enum SDL_GLattr {
 pub enum SDL_GLprofile {
     SDL_GL_CONTEXT_PROFILE_CORE = 1,
     SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = 2,
-    /// < GLX_CONTEXT_ES2_PROFILE_BIT_EXT
+    ///< GLX_CONTEXT_ES2_PROFILE_BIT_EXT
     SDL_GL_CONTEXT_PROFILE_ES = 4,
 }
 #[repr(u32)]
@@ -7223,89 +7296,110 @@ pub enum SDL_GLContextResetNotification {
     SDL_GL_CONTEXT_RESET_LOSE_CONTEXT = 1,
 }
 extern "C" {
-    /// \brief Get the number of video drivers compiled into SDL
+    ///  \brief Get the number of video drivers compiled into SDL
     ///
-    /// \sa SDL_GetVideoDriver()
+    ///  \sa SDL_GetVideoDriver()
     pub fn SDL_GetNumVideoDrivers() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the name of a built in video driver.
+    ///  \brief Get the name of a built in video driver.
     ///
-    /// \note The video drivers are presented in the order in which they are
-    /// normally checked during initialization.
+    ///  \note The video drivers are presented in the order in which they are
+    ///        normally checked during initialization.
     ///
-    /// \sa SDL_GetNumVideoDrivers()
+    ///  \sa SDL_GetNumVideoDrivers()
     pub fn SDL_GetVideoDriver(index: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Initialize the video subsystem, optionally specifying a video driver.
+    ///  \brief Initialize the video subsystem, optionally specifying a video driver.
     ///
-    /// \param driver_name Initialize a specific driver by name, or NULL for the
-    /// default video driver.
+    ///  \param driver_name Initialize a specific driver by name, or NULL for the
+    ///                     default video driver.
     ///
-    /// \return 0 on success, -1 on error
+    ///  \return 0 on success, -1 on error
     ///
-    /// This function initializes the video subsystem; setting up a connection
-    /// to the window manager, etc, and determines the available display modes
-    /// and pixel formats, but does not initialize a window or graphics mode.
+    ///  This function initializes the video subsystem; setting up a connection
+    ///  to the window manager, etc, and determines the available display modes
+    ///  and pixel formats, but does not initialize a window or graphics mode.
     ///
-    /// \sa SDL_VideoQuit()
+    ///  \sa SDL_VideoQuit()
     pub fn SDL_VideoInit(driver_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Shuts down the video subsystem.
+    ///  \brief Shuts down the video subsystem.
     ///
-    /// This function closes all windows, and restores the original video mode.
+    ///  This function closes all windows, and restores the original video mode.
     ///
-    /// \sa SDL_VideoInit()
+    ///  \sa SDL_VideoInit()
     pub fn SDL_VideoQuit();
 }
 extern "C" {
-    /// \brief Returns the name of the currently initialized video driver.
+    ///  \brief Returns the name of the currently initialized video driver.
     ///
-    /// \return The name of the current video driver or NULL if no driver
-    /// has been initialized
+    ///  \return The name of the current video driver or NULL if no driver
+    ///          has been initialized
     ///
-    /// \sa SDL_GetNumVideoDrivers()
-    /// \sa SDL_GetVideoDriver()
+    ///  \sa SDL_GetNumVideoDrivers()
+    ///  \sa SDL_GetVideoDriver()
     pub fn SDL_GetCurrentVideoDriver() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Returns the number of available video displays.
+    ///  \brief Returns the number of available video displays.
     ///
-    /// \sa SDL_GetDisplayBounds()
+    ///  \sa SDL_GetDisplayBounds()
     pub fn SDL_GetNumVideoDisplays() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the name of a display in UTF-8 encoding
+    ///  \brief Get the name of a display in UTF-8 encoding
     ///
-    /// \return The name of a display, or NULL for an invalid display index.
+    ///  \return The name of a display, or NULL for an invalid display index.
     ///
-    /// \sa SDL_GetNumVideoDisplays()
+    ///  \sa SDL_GetNumVideoDisplays()
     pub fn SDL_GetDisplayName(displayIndex: ::std::os::raw::c_int)
         -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Get the desktop area represented by a display, with the primary
-    /// display located at 0,0
+    ///  \brief Get the desktop area represented by a display, with the primary
+    ///         display located at 0,0
     ///
-    /// \return 0 on success, or -1 if the index is out of range.
+    ///  \return 0 on success, or -1 if the index is out of range.
     ///
-    /// \sa SDL_GetNumVideoDisplays()
+    ///  \sa SDL_GetNumVideoDisplays()
     pub fn SDL_GetDisplayBounds(
         displayIndex: ::std::os::raw::c_int,
         rect: *mut SDL_Rect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the dots/pixels-per-inch for a display
+    ///  \brief Get the usable desktop area represented by a display, with the
+    ///         primary display located at 0,0
     ///
-    /// \note Diagonal, horizontal and vertical DPI can all be optionally
-    /// returned if the parameter is non-NULL.
+    ///  This is the same area as SDL_GetDisplayBounds() reports, but with portions
+    ///  reserved by the system removed. For example, on Mac OS X, this subtracts
+    ///  the area occupied by the menu bar and dock.
     ///
-    /// \return 0 on success, or -1 if no DPI information is available or the index is out of range.
+    ///  Setting a window to be fullscreen generally bypasses these unusable areas,
+    ///  so these are good guidelines for the maximum space available to a
+    ///  non-fullscreen window.
     ///
-    /// \sa SDL_GetNumVideoDisplays()
+    ///  \return 0 on success, or -1 if the index is out of range.
+    ///
+    ///  \sa SDL_GetDisplayBounds()
+    ///  \sa SDL_GetNumVideoDisplays()
+    pub fn SDL_GetDisplayUsableBounds(
+        displayIndex: ::std::os::raw::c_int,
+        rect: *mut SDL_Rect,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  \brief Get the dots/pixels-per-inch for a display
+    ///
+    ///  \note Diagonal, horizontal and vertical DPI can all be optionally
+    ///        returned if the parameter is non-NULL.
+    ///
+    ///  \return 0 on success, or -1 if no DPI information is available or the index is out of range.
+    ///
+    ///  \sa SDL_GetNumVideoDisplays()
     pub fn SDL_GetDisplayDPI(
         displayIndex: ::std::os::raw::c_int,
         ddpi: *mut f32,
@@ -7314,42 +7408,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the usable desktop area represented by a display, with the
-    /// primary display located at 0,0
+    ///  \brief Get the orientation of a display
     ///
-    /// This is the same area as SDL_GetDisplayBounds() reports, but with portions
-    /// reserved by the system removed. For example, on Mac OS X, this subtracts
-    /// the area occupied by the menu bar and dock.
+    ///  \return The orientation of the display, or SDL_ORIENTATION_UNKNOWN if it isn't available.
     ///
-    /// Setting a window to be fullscreen generally bypasses these unusable areas,
-    /// so these are good guidelines for the maximum space available to a
-    /// non-fullscreen window.
-    ///
-    /// \return 0 on success, or -1 if the index is out of range.
-    ///
-    /// \sa SDL_GetDisplayBounds()
-    /// \sa SDL_GetNumVideoDisplays()
-    pub fn SDL_GetDisplayUsableBounds(
-        displayIndex: ::std::os::raw::c_int,
-        rect: *mut SDL_Rect,
-    ) -> ::std::os::raw::c_int;
+    ///  \sa SDL_GetNumVideoDisplays()
+    pub fn SDL_GetDisplayOrientation(displayIndex: ::std::os::raw::c_int)
+        -> SDL_DisplayOrientation;
 }
 extern "C" {
-    /// \brief Returns the number of available display modes.
+    ///  \brief Returns the number of available display modes.
     ///
-    /// \sa SDL_GetDisplayMode()
+    ///  \sa SDL_GetDisplayMode()
     pub fn SDL_GetNumDisplayModes(displayIndex: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill in information about a specific display mode.
+    ///  \brief Fill in information about a specific display mode.
     ///
-    /// \note The display modes are sorted in this priority:
-    /// \li bits per pixel -> more colors to fewer colors
-    /// \li width -> largest to smallest
-    /// \li height -> largest to smallest
-    /// \li refresh rate -> highest to lowest
+    ///  \note The display modes are sorted in this priority:
+    ///        \li bits per pixel -> more colors to fewer colors
+    ///        \li width -> largest to smallest
+    ///        \li height -> largest to smallest
+    ///        \li refresh rate -> highest to lowest
     ///
-    /// \sa SDL_GetNumDisplayModes()
+    ///  \sa SDL_GetNumDisplayModes()
     pub fn SDL_GetDisplayMode(
         displayIndex: ::std::os::raw::c_int,
         modeIndex: ::std::os::raw::c_int,
@@ -7357,39 +7439,39 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill in information about the desktop display mode.
+    ///  \brief Fill in information about the desktop display mode.
     pub fn SDL_GetDesktopDisplayMode(
         displayIndex: ::std::os::raw::c_int,
         mode: *mut SDL_DisplayMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill in information about the current display mode.
+    ///  \brief Fill in information about the current display mode.
     pub fn SDL_GetCurrentDisplayMode(
         displayIndex: ::std::os::raw::c_int,
         mode: *mut SDL_DisplayMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the closest match to the requested display mode.
+    ///  \brief Get the closest match to the requested display mode.
     ///
-    /// \param displayIndex The index of display from which mode should be queried.
-    /// \param mode The desired display mode
-    /// \param closest A pointer to a display mode to be filled in with the closest
-    /// match of the available display modes.
+    ///  \param displayIndex The index of display from which mode should be queried.
+    ///  \param mode The desired display mode
+    ///  \param closest A pointer to a display mode to be filled in with the closest
+    ///                 match of the available display modes.
     ///
-    /// \return The passed in value \c closest, or NULL if no matching video mode
-    /// was available.
+    ///  \return The passed in value \c closest, or NULL if no matching video mode
+    ///          was available.
     ///
-    /// The available display modes are scanned, and \c closest is filled in with the
-    /// closest mode matching the requested mode and returned.  The mode format and
-    /// refresh_rate default to the desktop mode if they are 0.  The modes are
-    /// scanned with size being first priority, format being second priority, and
-    /// finally checking the refresh_rate.  If all the available modes are too
-    /// small, then NULL is returned.
+    ///  The available display modes are scanned, and \c closest is filled in with the
+    ///  closest mode matching the requested mode and returned.  The mode format and
+    ///  refresh_rate default to the desktop mode if they are 0.  The modes are
+    ///  scanned with size being first priority, format being second priority, and
+    ///  finally checking the refresh_rate.  If all the available modes are too
+    ///  small, then NULL is returned.
     ///
-    /// \sa SDL_GetNumDisplayModes()
-    /// \sa SDL_GetDisplayMode()
+    ///  \sa SDL_GetNumDisplayModes()
+    ///  \sa SDL_GetDisplayMode()
     pub fn SDL_GetClosestDisplayMode(
         displayIndex: ::std::os::raw::c_int,
         mode: *const SDL_DisplayMode,
@@ -7397,86 +7479,86 @@ extern "C" {
     ) -> *mut SDL_DisplayMode;
 }
 extern "C" {
-    /// \brief Get the display index associated with a window.
+    ///  \brief Get the display index associated with a window.
     ///
-    /// \return the display index of the display containing the center of the
-    /// window, or -1 on error.
+    ///  \return the display index of the display containing the center of the
+    ///          window, or -1 on error.
     pub fn SDL_GetWindowDisplayIndex(window: *mut SDL_Window) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the display mode used when a fullscreen window is visible.
+    ///  \brief Set the display mode used when a fullscreen window is visible.
     ///
-    /// By default the window's dimensions and the desktop format and refresh rate
-    /// are used.
+    ///  By default the window's dimensions and the desktop format and refresh rate
+    ///  are used.
     ///
-    /// \param window The window for which the display mode should be set.
-    /// \param mode The mode to use, or NULL for the default mode.
+    ///  \param window The window for which the display mode should be set.
+    ///  \param mode The mode to use, or NULL for the default mode.
     ///
-    /// \return 0 on success, or -1 if setting the display mode failed.
+    ///  \return 0 on success, or -1 if setting the display mode failed.
     ///
-    /// \sa SDL_GetWindowDisplayMode()
-    /// \sa SDL_SetWindowFullscreen()
+    ///  \sa SDL_GetWindowDisplayMode()
+    ///  \sa SDL_SetWindowFullscreen()
     pub fn SDL_SetWindowDisplayMode(
         window: *mut SDL_Window,
         mode: *const SDL_DisplayMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill in information about the display mode used when a fullscreen
-    /// window is visible.
+    ///  \brief Fill in information about the display mode used when a fullscreen
+    ///         window is visible.
     ///
-    /// \sa SDL_SetWindowDisplayMode()
-    /// \sa SDL_SetWindowFullscreen()
+    ///  \sa SDL_SetWindowDisplayMode()
+    ///  \sa SDL_SetWindowFullscreen()
     pub fn SDL_GetWindowDisplayMode(
         window: *mut SDL_Window,
         mode: *mut SDL_DisplayMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the pixel format associated with the window.
+    ///  \brief Get the pixel format associated with the window.
     pub fn SDL_GetWindowPixelFormat(window: *mut SDL_Window) -> Uint32;
 }
 extern "C" {
-    /// \brief Create a window with the specified position, dimensions, and flags.
+    ///  \brief Create a window with the specified position, dimensions, and flags.
     ///
-    /// \param title The title of the window, in UTF-8 encoding.
-    /// \param x     The x position of the window, ::SDL_WINDOWPOS_CENTERED, or
-    /// ::SDL_WINDOWPOS_UNDEFINED.
-    /// \param y     The y position of the window, ::SDL_WINDOWPOS_CENTERED, or
-    /// ::SDL_WINDOWPOS_UNDEFINED.
-    /// \param w     The width of the window, in screen coordinates.
-    /// \param h     The height of the window, in screen coordinates.
-    /// \param flags The flags for the window, a mask of any of the following:
-    /// ::SDL_WINDOW_FULLSCREEN,    ::SDL_WINDOW_OPENGL,
-    /// ::SDL_WINDOW_HIDDEN,        ::SDL_WINDOW_BORDERLESS,
-    /// ::SDL_WINDOW_RESIZABLE,     ::SDL_WINDOW_MAXIMIZED,
-    /// ::SDL_WINDOW_MINIMIZED,     ::SDL_WINDOW_INPUT_GRABBED,
-    /// ::SDL_WINDOW_ALLOW_HIGHDPI, ::SDL_WINDOW_VULKAN.
+    ///  \param title The title of the window, in UTF-8 encoding.
+    ///  \param x     The x position of the window, ::SDL_WINDOWPOS_CENTERED, or
+    ///               ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param y     The y position of the window, ::SDL_WINDOWPOS_CENTERED, or
+    ///               ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param w     The width of the window, in screen coordinates.
+    ///  \param h     The height of the window, in screen coordinates.
+    ///  \param flags The flags for the window, a mask of any of the following:
+    ///               ::SDL_WINDOW_FULLSCREEN,    ::SDL_WINDOW_OPENGL,
+    ///               ::SDL_WINDOW_HIDDEN,        ::SDL_WINDOW_BORDERLESS,
+    ///               ::SDL_WINDOW_RESIZABLE,     ::SDL_WINDOW_MAXIMIZED,
+    ///               ::SDL_WINDOW_MINIMIZED,     ::SDL_WINDOW_INPUT_GRABBED,
+    ///               ::SDL_WINDOW_ALLOW_HIGHDPI, ::SDL_WINDOW_VULKAN.
     ///
-    /// \return The created window, or NULL if window creation failed.
+    ///  \return The created window, or NULL if window creation failed.
     ///
-    /// If the window is created with the SDL_WINDOW_ALLOW_HIGHDPI flag, its size
-    /// in pixels may differ from its size in screen coordinates on platforms with
-    /// high-DPI support (e.g. iOS and Mac OS X). Use SDL_GetWindowSize() to query
-    /// the client area's size in screen coordinates, and SDL_GL_GetDrawableSize(),
-    /// SDL_Vulkan_GetDrawableSize(), or SDL_GetRendererOutputSize() to query the
-    /// drawable size in pixels.
+    ///  If the window is created with the SDL_WINDOW_ALLOW_HIGHDPI flag, its size
+    ///  in pixels may differ from its size in screen coordinates on platforms with
+    ///  high-DPI support (e.g. iOS and Mac OS X). Use SDL_GetWindowSize() to query
+    ///  the client area's size in screen coordinates, and SDL_GL_GetDrawableSize(),
+    ///  SDL_Vulkan_GetDrawableSize(), or SDL_GetRendererOutputSize() to query the
+    ///  drawable size in pixels.
     ///
-    /// If the window is created with any of the SDL_WINDOW_OPENGL or
-    /// SDL_WINDOW_VULKAN flags, then the corresponding LoadLibrary function
-    /// (SDL_GL_LoadLibrary or SDL_Vulkan_LoadLibrary) is called and the
-    /// corresponding UnloadLibrary function is called by SDL_DestroyWindow().
+    ///  If the window is created with any of the SDL_WINDOW_OPENGL or
+    ///  SDL_WINDOW_VULKAN flags, then the corresponding LoadLibrary function
+    ///  (SDL_GL_LoadLibrary or SDL_Vulkan_LoadLibrary) is called and the
+    ///  corresponding UnloadLibrary function is called by SDL_DestroyWindow().
     ///
-    /// If SDL_WINDOW_VULKAN is specified and there isn't a working Vulkan driver,
-    /// SDL_CreateWindow() will fail because SDL_Vulkan_LoadLibrary() will fail.
+    ///  If SDL_WINDOW_VULKAN is specified and there isn't a working Vulkan driver,
+    ///  SDL_CreateWindow() will fail because SDL_Vulkan_LoadLibrary() will fail.
     ///
-    /// \note On non-Apple devices, SDL requires you to either not link to the
-    /// Vulkan loader or link to a dynamic library version. This limitation
-    /// may be removed in a future version of SDL.
+    ///  \note On non-Apple devices, SDL requires you to either not link to the
+    ///        Vulkan loader or link to a dynamic library version. This limitation
+    ///        may be removed in a future version of SDL.
     ///
-    /// \sa SDL_DestroyWindow()
-    /// \sa SDL_GL_LoadLibrary()
-    /// \sa SDL_Vulkan_LoadLibrary()
+    ///  \sa SDL_DestroyWindow()
+    ///  \sa SDL_GL_LoadLibrary()
+    ///  \sa SDL_Vulkan_LoadLibrary()
     pub fn SDL_CreateWindow(
         title: *const ::std::os::raw::c_char,
         x: ::std::os::raw::c_int,
@@ -7487,58 +7569,58 @@ extern "C" {
     ) -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Create an SDL window from an existing native window.
+    ///  \brief Create an SDL window from an existing native window.
     ///
-    /// \param data A pointer to driver-dependent window creation data
+    ///  \param data A pointer to driver-dependent window creation data
     ///
-    /// \return The created window, or NULL if window creation failed.
+    ///  \return The created window, or NULL if window creation failed.
     ///
-    /// \sa SDL_DestroyWindow()
+    ///  \sa SDL_DestroyWindow()
     pub fn SDL_CreateWindowFrom(data: *const ::std::os::raw::c_void) -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Get the numeric ID of a window, for logging purposes.
+    ///  \brief Get the numeric ID of a window, for logging purposes.
     pub fn SDL_GetWindowID(window: *mut SDL_Window) -> Uint32;
 }
 extern "C" {
-    /// \brief Get a window from a stored ID, or NULL if it doesn't exist.
+    ///  \brief Get a window from a stored ID, or NULL if it doesn't exist.
     pub fn SDL_GetWindowFromID(id: Uint32) -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Get the window flags.
+    ///  \brief Get the window flags.
     pub fn SDL_GetWindowFlags(window: *mut SDL_Window) -> Uint32;
 }
 extern "C" {
-    /// \brief Set the title of a window, in UTF-8 format.
+    ///  \brief Set the title of a window, in UTF-8 format.
     ///
-    /// \sa SDL_GetWindowTitle()
+    ///  \sa SDL_GetWindowTitle()
     pub fn SDL_SetWindowTitle(window: *mut SDL_Window, title: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    /// \brief Get the title of a window, in UTF-8 format.
+    ///  \brief Get the title of a window, in UTF-8 format.
     ///
-    /// \sa SDL_SetWindowTitle()
+    ///  \sa SDL_SetWindowTitle()
     pub fn SDL_GetWindowTitle(window: *mut SDL_Window) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Set the icon for a window.
+    ///  \brief Set the icon for a window.
     ///
-    /// \param window The window for which the icon should be set.
-    /// \param icon The icon for the window.
+    ///  \param window The window for which the icon should be set.
+    ///  \param icon The icon for the window.
     pub fn SDL_SetWindowIcon(window: *mut SDL_Window, icon: *mut SDL_Surface);
 }
 extern "C" {
-    /// \brief Associate an arbitrary named pointer with a window.
+    ///  \brief Associate an arbitrary named pointer with a window.
     ///
-    /// \param window   The window to associate with the pointer.
-    /// \param name     The name of the pointer.
-    /// \param userdata The associated pointer.
+    ///  \param window   The window to associate with the pointer.
+    ///  \param name     The name of the pointer.
+    ///  \param userdata The associated pointer.
     ///
-    /// \return The previous value associated with 'name'
+    ///  \return The previous value associated with 'name'
     ///
-    /// \note The name is case-sensitive.
+    ///  \note The name is case-sensitive.
     ///
-    /// \sa SDL_GetWindowData()
+    ///  \sa SDL_GetWindowData()
     pub fn SDL_SetWindowData(
         window: *mut SDL_Window,
         name: *const ::std::os::raw::c_char,
@@ -7546,31 +7628,31 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Retrieve the data pointer associated with a window.
+    ///  \brief Retrieve the data pointer associated with a window.
     ///
-    /// \param window   The window to query.
-    /// \param name     The name of the pointer.
+    ///  \param window   The window to query.
+    ///  \param name     The name of the pointer.
     ///
-    /// \return The value associated with 'name'
+    ///  \return The value associated with 'name'
     ///
-    /// \sa SDL_SetWindowData()
+    ///  \sa SDL_SetWindowData()
     pub fn SDL_GetWindowData(
         window: *mut SDL_Window,
         name: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Set the position of a window.
+    ///  \brief Set the position of a window.
     ///
-    /// \param window   The window to reposition.
-    /// \param x        The x coordinate of the window in screen coordinates, or
-    /// ::SDL_WINDOWPOS_CENTERED or ::SDL_WINDOWPOS_UNDEFINED.
-    /// \param y        The y coordinate of the window in screen coordinates, or
-    /// ::SDL_WINDOWPOS_CENTERED or ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param window   The window to reposition.
+    ///  \param x        The x coordinate of the window in screen coordinates, or
+    ///                  ::SDL_WINDOWPOS_CENTERED or ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param y        The y coordinate of the window in screen coordinates, or
+    ///                  ::SDL_WINDOWPOS_CENTERED or ::SDL_WINDOWPOS_UNDEFINED.
     ///
-    /// \note The window coordinate origin is the upper left of the display.
+    ///  \note The window coordinate origin is the upper left of the display.
     ///
-    /// \sa SDL_GetWindowPosition()
+    ///  \sa SDL_GetWindowPosition()
     pub fn SDL_SetWindowPosition(
         window: *mut SDL_Window,
         x: ::std::os::raw::c_int,
@@ -7578,15 +7660,15 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the position of a window.
+    ///  \brief Get the position of a window.
     ///
-    /// \param window   The window to query.
-    /// \param x        Pointer to variable for storing the x position, in screen
-    /// coordinates. May be NULL.
-    /// \param y        Pointer to variable for storing the y position, in screen
-    /// coordinates. May be NULL.
+    ///  \param window   The window to query.
+    ///  \param x        Pointer to variable for storing the x position, in screen
+    ///                  coordinates. May be NULL.
+    ///  \param y        Pointer to variable for storing the y position, in screen
+    ///                  coordinates. May be NULL.
     ///
-    /// \sa SDL_SetWindowPosition()
+    ///  \sa SDL_SetWindowPosition()
     pub fn SDL_GetWindowPosition(
         window: *mut SDL_Window,
         x: *mut ::std::os::raw::c_int,
@@ -7594,22 +7676,22 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Set the size of a window's client area.
+    ///  \brief Set the size of a window's client area.
     ///
-    /// \param window   The window to resize.
-    /// \param w        The width of the window, in screen coordinates. Must be >0.
-    /// \param h        The height of the window, in screen coordinates. Must be >0.
+    ///  \param window   The window to resize.
+    ///  \param w        The width of the window, in screen coordinates. Must be >0.
+    ///  \param h        The height of the window, in screen coordinates. Must be >0.
     ///
-    /// \note Fullscreen windows automatically match the size of the display mode,
-    /// and you should use SDL_SetWindowDisplayMode() to change their size.
+    ///  \note Fullscreen windows automatically match the size of the display mode,
+    ///        and you should use SDL_SetWindowDisplayMode() to change their size.
     ///
-    /// The window size in screen coordinates may differ from the size in pixels, if
-    /// the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a platform with
-    /// high-dpi support (e.g. iOS or OS X). Use SDL_GL_GetDrawableSize() or
-    /// SDL_GetRendererOutputSize() to get the real client area size in pixels.
+    ///  The window size in screen coordinates may differ from the size in pixels, if
+    ///  the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a platform with
+    ///  high-dpi support (e.g. iOS or OS X). Use SDL_GL_GetDrawableSize() or
+    ///  SDL_GetRendererOutputSize() to get the real client area size in pixels.
     ///
-    /// \sa SDL_GetWindowSize()
-    /// \sa SDL_SetWindowDisplayMode()
+    ///  \sa SDL_GetWindowSize()
+    ///  \sa SDL_SetWindowDisplayMode()
     pub fn SDL_SetWindowSize(
         window: *mut SDL_Window,
         w: ::std::os::raw::c_int,
@@ -7617,20 +7699,20 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the size of a window's client area.
+    ///  \brief Get the size of a window's client area.
     ///
-    /// \param window   The window to query.
-    /// \param w        Pointer to variable for storing the width, in screen
-    /// coordinates. May be NULL.
-    /// \param h        Pointer to variable for storing the height, in screen
-    /// coordinates. May be NULL.
+    ///  \param window   The window to query.
+    ///  \param w        Pointer to variable for storing the width, in screen
+    ///                  coordinates. May be NULL.
+    ///  \param h        Pointer to variable for storing the height, in screen
+    ///                  coordinates. May be NULL.
     ///
-    /// The window size in screen coordinates may differ from the size in pixels, if
-    /// the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a platform with
-    /// high-dpi support (e.g. iOS or OS X). Use SDL_GL_GetDrawableSize() or
-    /// SDL_GetRendererOutputSize() to get the real client area size in pixels.
+    ///  The window size in screen coordinates may differ from the size in pixels, if
+    ///  the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a platform with
+    ///  high-dpi support (e.g. iOS or OS X). Use SDL_GL_GetDrawableSize() or
+    ///  SDL_GetRendererOutputSize() to get the real client area size in pixels.
     ///
-    /// \sa SDL_SetWindowSize()
+    ///  \sa SDL_SetWindowSize()
     pub fn SDL_GetWindowSize(
         window: *mut SDL_Window,
         w: *mut ::std::os::raw::c_int,
@@ -7638,19 +7720,19 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the size of a window's borders (decorations) around the client area.
+    ///  \brief Get the size of a window's borders (decorations) around the client area.
     ///
-    /// \param window The window to query.
-    /// \param top Pointer to variable for storing the size of the top border. NULL is permitted.
-    /// \param left Pointer to variable for storing the size of the left border. NULL is permitted.
-    /// \param bottom Pointer to variable for storing the size of the bottom border. NULL is permitted.
-    /// \param right Pointer to variable for storing the size of the right border. NULL is permitted.
+    ///  \param window The window to query.
+    ///  \param top Pointer to variable for storing the size of the top border. NULL is permitted.
+    ///  \param left Pointer to variable for storing the size of the left border. NULL is permitted.
+    ///  \param bottom Pointer to variable for storing the size of the bottom border. NULL is permitted.
+    ///  \param right Pointer to variable for storing the size of the right border. NULL is permitted.
     ///
-    /// \return 0 on success, or -1 if getting this information is not supported.
+    ///  \return 0 on success, or -1 if getting this information is not supported.
     ///
-    /// \note if this function fails (returns -1), the size values will be
-    /// initialized to 0, 0, 0, 0 (if a non-NULL pointer is provided), as
-    /// if the window in question was borderless.
+    ///  \note if this function fails (returns -1), the size values will be
+    ///        initialized to 0, 0, 0, 0 (if a non-NULL pointer is provided), as
+    ///        if the window in question was borderless.
     pub fn SDL_GetWindowBordersSize(
         window: *mut SDL_Window,
         top: *mut ::std::os::raw::c_int,
@@ -7660,17 +7742,17 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the minimum size of a window's client area.
+    ///  \brief Set the minimum size of a window's client area.
     ///
-    /// \param window    The window to set a new minimum size.
-    /// \param min_w     The minimum width of the window, must be >0
-    /// \param min_h     The minimum height of the window, must be >0
+    ///  \param window    The window to set a new minimum size.
+    ///  \param min_w     The minimum width of the window, must be >0
+    ///  \param min_h     The minimum height of the window, must be >0
     ///
-    /// \note You can't change the minimum size of a fullscreen window, it
-    /// automatically matches the size of the display mode.
+    ///  \note You can't change the minimum size of a fullscreen window, it
+    ///        automatically matches the size of the display mode.
     ///
-    /// \sa SDL_GetWindowMinimumSize()
-    /// \sa SDL_SetWindowMaximumSize()
+    ///  \sa SDL_GetWindowMinimumSize()
+    ///  \sa SDL_SetWindowMaximumSize()
     pub fn SDL_SetWindowMinimumSize(
         window: *mut SDL_Window,
         min_w: ::std::os::raw::c_int,
@@ -7678,14 +7760,14 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the minimum size of a window's client area.
+    ///  \brief Get the minimum size of a window's client area.
     ///
-    /// \param window   The window to query.
-    /// \param w        Pointer to variable for storing the minimum width, may be NULL
-    /// \param h        Pointer to variable for storing the minimum height, may be NULL
+    ///  \param window   The window to query.
+    ///  \param w        Pointer to variable for storing the minimum width, may be NULL
+    ///  \param h        Pointer to variable for storing the minimum height, may be NULL
     ///
-    /// \sa SDL_GetWindowMaximumSize()
-    /// \sa SDL_SetWindowMinimumSize()
+    ///  \sa SDL_GetWindowMaximumSize()
+    ///  \sa SDL_SetWindowMinimumSize()
     pub fn SDL_GetWindowMinimumSize(
         window: *mut SDL_Window,
         w: *mut ::std::os::raw::c_int,
@@ -7693,17 +7775,17 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Set the maximum size of a window's client area.
+    ///  \brief Set the maximum size of a window's client area.
     ///
-    /// \param window    The window to set a new maximum size.
-    /// \param max_w     The maximum width of the window, must be >0
-    /// \param max_h     The maximum height of the window, must be >0
+    ///  \param window    The window to set a new maximum size.
+    ///  \param max_w     The maximum width of the window, must be >0
+    ///  \param max_h     The maximum height of the window, must be >0
     ///
-    /// \note You can't change the maximum size of a fullscreen window, it
-    /// automatically matches the size of the display mode.
+    ///  \note You can't change the maximum size of a fullscreen window, it
+    ///        automatically matches the size of the display mode.
     ///
-    /// \sa SDL_GetWindowMaximumSize()
-    /// \sa SDL_SetWindowMinimumSize()
+    ///  \sa SDL_GetWindowMaximumSize()
+    ///  \sa SDL_SetWindowMinimumSize()
     pub fn SDL_SetWindowMaximumSize(
         window: *mut SDL_Window,
         max_w: ::std::os::raw::c_int,
@@ -7711,14 +7793,14 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Get the maximum size of a window's client area.
+    ///  \brief Get the maximum size of a window's client area.
     ///
-    /// \param window   The window to query.
-    /// \param w        Pointer to variable for storing the maximum width, may be NULL
-    /// \param h        Pointer to variable for storing the maximum height, may be NULL
+    ///  \param window   The window to query.
+    ///  \param w        Pointer to variable for storing the maximum width, may be NULL
+    ///  \param h        Pointer to variable for storing the maximum height, may be NULL
     ///
-    /// \sa SDL_GetWindowMinimumSize()
-    /// \sa SDL_SetWindowMaximumSize()
+    ///  \sa SDL_GetWindowMinimumSize()
+    ///  \sa SDL_SetWindowMaximumSize()
     pub fn SDL_GetWindowMaximumSize(
         window: *mut SDL_Window,
         w: *mut ::std::os::raw::c_int,
@@ -7726,110 +7808,110 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Set the border state of a window.
+    ///  \brief Set the border state of a window.
     ///
-    /// This will add or remove the window's SDL_WINDOW_BORDERLESS flag and
-    /// add or remove the border from the actual window. This is a no-op if the
-    /// window's border already matches the requested state.
+    ///  This will add or remove the window's SDL_WINDOW_BORDERLESS flag and
+    ///  add or remove the border from the actual window. This is a no-op if the
+    ///  window's border already matches the requested state.
     ///
-    /// \param window The window of which to change the border state.
-    /// \param bordered SDL_FALSE to remove border, SDL_TRUE to add border.
+    ///  \param window The window of which to change the border state.
+    ///  \param bordered SDL_FALSE to remove border, SDL_TRUE to add border.
     ///
-    /// \note You can't change the border state of a fullscreen window.
+    ///  \note You can't change the border state of a fullscreen window.
     ///
-    /// \sa SDL_GetWindowFlags()
+    ///  \sa SDL_GetWindowFlags()
     pub fn SDL_SetWindowBordered(window: *mut SDL_Window, bordered: SDL_bool);
 }
 extern "C" {
-    /// \brief Set the user-resizable state of a window.
+    ///  \brief Set the user-resizable state of a window.
     ///
-    /// This will add or remove the window's SDL_WINDOW_RESIZABLE flag and
-    /// allow/disallow user resizing of the window. This is a no-op if the
-    /// window's resizable state already matches the requested state.
+    ///  This will add or remove the window's SDL_WINDOW_RESIZABLE flag and
+    ///  allow/disallow user resizing of the window. This is a no-op if the
+    ///  window's resizable state already matches the requested state.
     ///
-    /// \param window The window of which to change the resizable state.
-    /// \param resizable SDL_TRUE to allow resizing, SDL_FALSE to disallow.
+    ///  \param window The window of which to change the resizable state.
+    ///  \param resizable SDL_TRUE to allow resizing, SDL_FALSE to disallow.
     ///
-    /// \note You can't change the resizable state of a fullscreen window.
+    ///  \note You can't change the resizable state of a fullscreen window.
     ///
-    /// \sa SDL_GetWindowFlags()
+    ///  \sa SDL_GetWindowFlags()
     pub fn SDL_SetWindowResizable(window: *mut SDL_Window, resizable: SDL_bool);
 }
 extern "C" {
-    /// \brief Show a window.
+    ///  \brief Show a window.
     ///
-    /// \sa SDL_HideWindow()
+    ///  \sa SDL_HideWindow()
     pub fn SDL_ShowWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Hide a window.
+    ///  \brief Hide a window.
     ///
-    /// \sa SDL_ShowWindow()
+    ///  \sa SDL_ShowWindow()
     pub fn SDL_HideWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Raise a window above other windows and set the input focus.
+    ///  \brief Raise a window above other windows and set the input focus.
     pub fn SDL_RaiseWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Make a window as large as possible.
+    ///  \brief Make a window as large as possible.
     ///
-    /// \sa SDL_RestoreWindow()
+    ///  \sa SDL_RestoreWindow()
     pub fn SDL_MaximizeWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Minimize a window to an iconic representation.
+    ///  \brief Minimize a window to an iconic representation.
     ///
-    /// \sa SDL_RestoreWindow()
+    ///  \sa SDL_RestoreWindow()
     pub fn SDL_MinimizeWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Restore the size and position of a minimized or maximized window.
+    ///  \brief Restore the size and position of a minimized or maximized window.
     ///
-    /// \sa SDL_MaximizeWindow()
-    /// \sa SDL_MinimizeWindow()
+    ///  \sa SDL_MaximizeWindow()
+    ///  \sa SDL_MinimizeWindow()
     pub fn SDL_RestoreWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Set a window's fullscreen state.
+    ///  \brief Set a window's fullscreen state.
     ///
-    /// \return 0 on success, or -1 if setting the display mode failed.
+    ///  \return 0 on success, or -1 if setting the display mode failed.
     ///
-    /// \sa SDL_SetWindowDisplayMode()
-    /// \sa SDL_GetWindowDisplayMode()
+    ///  \sa SDL_SetWindowDisplayMode()
+    ///  \sa SDL_GetWindowDisplayMode()
     pub fn SDL_SetWindowFullscreen(window: *mut SDL_Window, flags: Uint32)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the SDL surface associated with the window.
+    ///  \brief Get the SDL surface associated with the window.
     ///
-    /// \return The window's framebuffer surface, or NULL on error.
+    ///  \return The window's framebuffer surface, or NULL on error.
     ///
-    /// A new surface will be created with the optimal format for the window,
-    /// if necessary. This surface will be freed when the window is destroyed.
+    ///  A new surface will be created with the optimal format for the window,
+    ///  if necessary. This surface will be freed when the window is destroyed.
     ///
-    /// \note You may not combine this with 3D or the rendering API on this window.
+    ///  \note You may not combine this with 3D or the rendering API on this window.
     ///
-    /// \sa SDL_UpdateWindowSurface()
-    /// \sa SDL_UpdateWindowSurfaceRects()
+    ///  \sa SDL_UpdateWindowSurface()
+    ///  \sa SDL_UpdateWindowSurfaceRects()
     pub fn SDL_GetWindowSurface(window: *mut SDL_Window) -> *mut SDL_Surface;
 }
 extern "C" {
-    /// \brief Copy the window surface to the screen.
+    ///  \brief Copy the window surface to the screen.
     ///
-    /// \return 0 on success, or -1 on error.
+    ///  \return 0 on success, or -1 on error.
     ///
-    /// \sa SDL_GetWindowSurface()
-    /// \sa SDL_UpdateWindowSurfaceRects()
+    ///  \sa SDL_GetWindowSurface()
+    ///  \sa SDL_UpdateWindowSurfaceRects()
     pub fn SDL_UpdateWindowSurface(window: *mut SDL_Window) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Copy a number of rectangles on the window surface to the screen.
+    ///  \brief Copy a number of rectangles on the window surface to the screen.
     ///
-    /// \return 0 on success, or -1 on error.
+    ///  \return 0 on success, or -1 on error.
     ///
-    /// \sa SDL_GetWindowSurface()
-    /// \sa SDL_UpdateWindowSurface()
+    ///  \sa SDL_GetWindowSurface()
+    ///  \sa SDL_UpdateWindowSurface()
     pub fn SDL_UpdateWindowSurfaceRects(
         window: *mut SDL_Window,
         rects: *const SDL_Rect,
@@ -7837,124 +7919,124 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set a window's input grab mode.
+    ///  \brief Set a window's input grab mode.
     ///
-    /// \param window The window for which the input grab mode should be set.
-    /// \param grabbed This is SDL_TRUE to grab input, and SDL_FALSE to release input.
+    ///  \param window The window for which the input grab mode should be set.
+    ///  \param grabbed This is SDL_TRUE to grab input, and SDL_FALSE to release input.
     ///
-    /// If the caller enables a grab while another window is currently grabbed,
-    /// the other window loses its grab in favor of the caller's window.
+    ///  If the caller enables a grab while another window is currently grabbed,
+    ///  the other window loses its grab in favor of the caller's window.
     ///
-    /// \sa SDL_GetWindowGrab()
+    ///  \sa SDL_GetWindowGrab()
     pub fn SDL_SetWindowGrab(window: *mut SDL_Window, grabbed: SDL_bool);
 }
 extern "C" {
-    /// \brief Get a window's input grab mode.
+    ///  \brief Get a window's input grab mode.
     ///
-    /// \return This returns SDL_TRUE if input is grabbed, and SDL_FALSE otherwise.
+    ///  \return This returns SDL_TRUE if input is grabbed, and SDL_FALSE otherwise.
     ///
-    /// \sa SDL_SetWindowGrab()
+    ///  \sa SDL_SetWindowGrab()
     pub fn SDL_GetWindowGrab(window: *mut SDL_Window) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Get the window that currently has an input grab enabled.
+    ///  \brief Get the window that currently has an input grab enabled.
     ///
-    /// \return This returns the window if input is grabbed, and NULL otherwise.
+    ///  \return This returns the window if input is grabbed, and NULL otherwise.
     ///
-    /// \sa SDL_SetWindowGrab()
+    ///  \sa SDL_SetWindowGrab()
     pub fn SDL_GetGrabbedWindow() -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Set the brightness (gamma correction) for a window.
+    ///  \brief Set the brightness (gamma correction) for a window.
     ///
-    /// \return 0 on success, or -1 if setting the brightness isn't supported.
+    ///  \return 0 on success, or -1 if setting the brightness isn't supported.
     ///
-    /// \sa SDL_GetWindowBrightness()
-    /// \sa SDL_SetWindowGammaRamp()
+    ///  \sa SDL_GetWindowBrightness()
+    ///  \sa SDL_SetWindowGammaRamp()
     pub fn SDL_SetWindowBrightness(
         window: *mut SDL_Window,
         brightness: f32,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the brightness (gamma correction) for a window.
+    ///  \brief Get the brightness (gamma correction) for a window.
     ///
-    /// \return The last brightness value passed to SDL_SetWindowBrightness()
+    ///  \return The last brightness value passed to SDL_SetWindowBrightness()
     ///
-    /// \sa SDL_SetWindowBrightness()
+    ///  \sa SDL_SetWindowBrightness()
     pub fn SDL_GetWindowBrightness(window: *mut SDL_Window) -> f32;
 }
 extern "C" {
-    /// \brief Set the opacity for a window
+    ///  \brief Set the opacity for a window
     ///
-    /// \param window The window which will be made transparent or opaque
-    /// \param opacity Opacity (0.0f - transparent, 1.0f - opaque) This will be
-    /// clamped internally between 0.0f and 1.0f.
+    ///  \param window The window which will be made transparent or opaque
+    ///  \param opacity Opacity (0.0f - transparent, 1.0f - opaque) This will be
+    ///                 clamped internally between 0.0f and 1.0f.
     ///
-    /// \return 0 on success, or -1 if setting the opacity isn't supported.
+    ///  \return 0 on success, or -1 if setting the opacity isn't supported.
     ///
-    /// \sa SDL_GetWindowOpacity()
+    ///  \sa SDL_GetWindowOpacity()
     pub fn SDL_SetWindowOpacity(window: *mut SDL_Window, opacity: f32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the opacity of a window.
+    ///  \brief Get the opacity of a window.
     ///
-    /// If transparency isn't supported on this platform, opacity will be reported
-    /// as 1.0f without error.
+    ///  If transparency isn't supported on this platform, opacity will be reported
+    ///  as 1.0f without error.
     ///
-    /// \param window The window in question.
-    /// \param out_opacity Opacity (0.0f - transparent, 1.0f - opaque)
+    ///  \param window The window in question.
+    ///  \param out_opacity Opacity (0.0f - transparent, 1.0f - opaque)
     ///
-    /// \return 0 on success, or -1 on error (invalid window, etc).
+    ///  \return 0 on success, or -1 on error (invalid window, etc).
     ///
-    /// \sa SDL_SetWindowOpacity()
+    ///  \sa SDL_SetWindowOpacity()
     pub fn SDL_GetWindowOpacity(
         window: *mut SDL_Window,
         out_opacity: *mut f32,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets the window as a modal for another window (TODO: reconsider this function and/or its name)
+    ///  \brief Sets the window as a modal for another window (TODO: reconsider this function and/or its name)
     ///
-    /// \param modal_window The window that should be modal
-    /// \param parent_window The parent window
+    ///  \param modal_window The window that should be modal
+    ///  \param parent_window The parent window
     ///
-    /// \return 0 on success, or -1 otherwise.
+    ///  \return 0 on success, or -1 otherwise.
     pub fn SDL_SetWindowModalFor(
         modal_window: *mut SDL_Window,
         parent_window: *mut SDL_Window,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Explicitly sets input focus to the window.
+    ///  \brief Explicitly sets input focus to the window.
     ///
-    /// You almost certainly want SDL_RaiseWindow() instead of this function. Use
-    /// this with caution, as you might give focus to a window that's completely
-    /// obscured by other windows.
+    ///  You almost certainly want SDL_RaiseWindow() instead of this function. Use
+    ///  this with caution, as you might give focus to a window that's completely
+    ///  obscured by other windows.
     ///
-    /// \param window The window that should get the input focus
+    ///  \param window The window that should get the input focus
     ///
-    /// \return 0 on success, or -1 otherwise.
-    /// \sa SDL_RaiseWindow()
+    ///  \return 0 on success, or -1 otherwise.
+    ///  \sa SDL_RaiseWindow()
     pub fn SDL_SetWindowInputFocus(window: *mut SDL_Window) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the gamma ramp for a window.
+    ///  \brief Set the gamma ramp for a window.
     ///
-    /// \param window The window for which the gamma ramp should be set.
-    /// \param red The translation table for the red channel, or NULL.
-    /// \param green The translation table for the green channel, or NULL.
-    /// \param blue The translation table for the blue channel, or NULL.
+    ///  \param window The window for which the gamma ramp should be set.
+    ///  \param red The translation table for the red channel, or NULL.
+    ///  \param green The translation table for the green channel, or NULL.
+    ///  \param blue The translation table for the blue channel, or NULL.
     ///
-    /// \return 0 on success, or -1 if gamma ramps are unsupported.
+    ///  \return 0 on success, or -1 if gamma ramps are unsupported.
     ///
-    /// Set the gamma translation table for the red, green, and blue channels
-    /// of the video hardware.  Each table is an array of 256 16-bit quantities,
-    /// representing a mapping between the input and output for that channel.
-    /// The input is the index into the array, and the output is the 16-bit
-    /// gamma value at that index, scaled to the output color precision.
+    ///  Set the gamma translation table for the red, green, and blue channels
+    ///  of the video hardware.  Each table is an array of 256 16-bit quantities,
+    ///  representing a mapping between the input and output for that channel.
+    ///  The input is the index into the array, and the output is the 16-bit
+    ///  gamma value at that index, scaled to the output color precision.
     ///
-    /// \sa SDL_GetWindowGammaRamp()
+    ///  \sa SDL_GetWindowGammaRamp()
     pub fn SDL_SetWindowGammaRamp(
         window: *mut SDL_Window,
         red: *const Uint16,
@@ -7963,19 +8045,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the gamma ramp for a window.
+    ///  \brief Get the gamma ramp for a window.
     ///
-    /// \param window The window from which the gamma ramp should be queried.
-    /// \param red   A pointer to a 256 element array of 16-bit quantities to hold
-    /// the translation table for the red channel, or NULL.
-    /// \param green A pointer to a 256 element array of 16-bit quantities to hold
-    /// the translation table for the green channel, or NULL.
-    /// \param blue  A pointer to a 256 element array of 16-bit quantities to hold
-    /// the translation table for the blue channel, or NULL.
+    ///  \param window The window from which the gamma ramp should be queried.
+    ///  \param red   A pointer to a 256 element array of 16-bit quantities to hold
+    ///               the translation table for the red channel, or NULL.
+    ///  \param green A pointer to a 256 element array of 16-bit quantities to hold
+    ///               the translation table for the green channel, or NULL.
+    ///  \param blue  A pointer to a 256 element array of 16-bit quantities to hold
+    ///               the translation table for the blue channel, or NULL.
     ///
-    /// \return 0 on success, or -1 if gamma ramps are unsupported.
+    ///  \return 0 on success, or -1 if gamma ramps are unsupported.
     ///
-    /// \sa SDL_SetWindowGammaRamp()
+    ///  \sa SDL_SetWindowGammaRamp()
     pub fn SDL_GetWindowGammaRamp(
         window: *mut SDL_Window,
         red: *mut Uint16,
@@ -7984,14 +8066,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
-/// \brief Possible return values from the SDL_HitTest callback.
+///  \brief Possible return values from the SDL_HitTest callback.
 ///
-/// \sa SDL_HitTest
+///  \sa SDL_HitTest
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_HitTestResult {
-    /// < Region is normal. No special properties.
+    ///< Region is normal. No special properties.
     SDL_HITTEST_NORMAL = 0,
-    /// < Region can drag entire window.
+    ///< Region can drag entire window.
     SDL_HITTEST_DRAGGABLE = 1,
     SDL_HITTEST_RESIZE_TOPLEFT = 2,
     SDL_HITTEST_RESIZE_TOP = 3,
@@ -8002,9 +8084,9 @@ pub enum SDL_HitTestResult {
     SDL_HITTEST_RESIZE_BOTTOMLEFT = 8,
     SDL_HITTEST_RESIZE_LEFT = 9,
 }
-/// \brief Callback used for hit-testing.
+///  \brief Callback used for hit-testing.
 ///
-/// \sa SDL_SetWindowHitTest
+///  \sa SDL_SetWindowHitTest
 pub type SDL_HitTest = ::std::option::Option<
     unsafe extern "C" fn(
         win: *mut SDL_Window,
@@ -8013,41 +8095,41 @@ pub type SDL_HitTest = ::std::option::Option<
     ) -> SDL_HitTestResult,
 >;
 extern "C" {
-    /// \brief Provide a callback that decides if a window region has special properties.
+    ///  \brief Provide a callback that decides if a window region has special properties.
     ///
-    /// Normally windows are dragged and resized by decorations provided by the
-    /// system window manager (a title bar, borders, etc), but for some apps, it
-    /// makes sense to drag them from somewhere else inside the window itself; for
-    /// example, one might have a borderless window that wants to be draggable
-    /// from any part, or simulate its own title bar, etc.
+    ///  Normally windows are dragged and resized by decorations provided by the
+    ///  system window manager (a title bar, borders, etc), but for some apps, it
+    ///  makes sense to drag them from somewhere else inside the window itself; for
+    ///  example, one might have a borderless window that wants to be draggable
+    ///  from any part, or simulate its own title bar, etc.
     ///
-    /// This function lets the app provide a callback that designates pieces of
-    /// a given window as special. This callback is run during event processing
-    /// if we need to tell the OS to treat a region of the window specially; the
-    /// use of this callback is known as "hit testing."
+    ///  This function lets the app provide a callback that designates pieces of
+    ///  a given window as special. This callback is run during event processing
+    ///  if we need to tell the OS to treat a region of the window specially; the
+    ///  use of this callback is known as "hit testing."
     ///
-    /// Mouse input may not be delivered to your application if it is within
-    /// a special area; the OS will often apply that input to moving the window or
-    /// resizing the window and not deliver it to the application.
+    ///  Mouse input may not be delivered to your application if it is within
+    ///  a special area; the OS will often apply that input to moving the window or
+    ///  resizing the window and not deliver it to the application.
     ///
-    /// Specifying NULL for a callback disables hit-testing. Hit-testing is
-    /// disabled by default.
+    ///  Specifying NULL for a callback disables hit-testing. Hit-testing is
+    ///  disabled by default.
     ///
-    /// Platforms that don't support this functionality will return -1
-    /// unconditionally, even if you're attempting to disable hit-testing.
+    ///  Platforms that don't support this functionality will return -1
+    ///  unconditionally, even if you're attempting to disable hit-testing.
     ///
-    /// Your callback may fire at any time, and its firing does not indicate any
-    /// specific behavior (for example, on Windows, this certainly might fire
-    /// when the OS is deciding whether to drag your window, but it fires for lots
-    /// of other reasons, too, some unrelated to anything you probably care about
-    /// _and when the mouse isn't actually at the location it is testing_).
-    /// Since this can fire at any time, you should try to keep your callback
-    /// efficient, devoid of allocations, etc.
+    ///  Your callback may fire at any time, and its firing does not indicate any
+    ///  specific behavior (for example, on Windows, this certainly might fire
+    ///  when the OS is deciding whether to drag your window, but it fires for lots
+    ///  of other reasons, too, some unrelated to anything you probably care about
+    ///  _and when the mouse isn't actually at the location it is testing_).
+    ///  Since this can fire at any time, you should try to keep your callback
+    ///  efficient, devoid of allocations, etc.
     ///
-    /// \param window The window to set hit-testing on.
-    /// \param callback The callback to call when doing a hit-test.
-    /// \param callback_data An app-defined void pointer passed to the callback.
-    /// \return 0 on success, -1 on error (including unsupported).
+    ///  \param window The window to set hit-testing on.
+    ///  \param callback The callback to call when doing a hit-test.
+    ///  \param callback_data An app-defined void pointer passed to the callback.
+    ///  \return 0 on success, -1 on error (including unsupported).
     pub fn SDL_SetWindowHitTest(
         window: *mut SDL_Window,
         callback: SDL_HitTest,
@@ -8055,128 +8137,128 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Destroy a window.
+    ///  \brief Destroy a window.
     pub fn SDL_DestroyWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Returns whether the screensaver is currently enabled (default off).
+    ///  \brief Returns whether the screensaver is currently enabled (default off).
     ///
-    /// \sa SDL_EnableScreenSaver()
-    /// \sa SDL_DisableScreenSaver()
+    ///  \sa SDL_EnableScreenSaver()
+    ///  \sa SDL_DisableScreenSaver()
     pub fn SDL_IsScreenSaverEnabled() -> SDL_bool;
 }
 extern "C" {
-    /// \brief Allow the screen to be blanked by a screensaver
+    ///  \brief Allow the screen to be blanked by a screensaver
     ///
-    /// \sa SDL_IsScreenSaverEnabled()
-    /// \sa SDL_DisableScreenSaver()
+    ///  \sa SDL_IsScreenSaverEnabled()
+    ///  \sa SDL_DisableScreenSaver()
     pub fn SDL_EnableScreenSaver();
 }
 extern "C" {
-    /// \brief Prevent the screen from being blanked by a screensaver
+    ///  \brief Prevent the screen from being blanked by a screensaver
     ///
-    /// \sa SDL_IsScreenSaverEnabled()
-    /// \sa SDL_EnableScreenSaver()
+    ///  \sa SDL_IsScreenSaverEnabled()
+    ///  \sa SDL_EnableScreenSaver()
     pub fn SDL_DisableScreenSaver();
 }
 extern "C" {
-    /// \brief Dynamically load an OpenGL library.
+    ///  \brief Dynamically load an OpenGL library.
     ///
-    /// \param path The platform dependent OpenGL library name, or NULL to open the
-    /// default OpenGL library.
+    ///  \param path The platform dependent OpenGL library name, or NULL to open the
+    ///              default OpenGL library.
     ///
-    /// \return 0 on success, or -1 if the library couldn't be loaded.
+    ///  \return 0 on success, or -1 if the library couldn't be loaded.
     ///
-    /// This should be done after initializing the video driver, but before
-    /// creating any OpenGL windows.  If no OpenGL library is loaded, the default
-    /// library will be loaded upon creation of the first OpenGL window.
+    ///  This should be done after initializing the video driver, but before
+    ///  creating any OpenGL windows.  If no OpenGL library is loaded, the default
+    ///  library will be loaded upon creation of the first OpenGL window.
     ///
-    /// \note If you do this, you need to retrieve all of the GL functions used in
-    /// your program from the dynamic library using SDL_GL_GetProcAddress().
+    ///  \note If you do this, you need to retrieve all of the GL functions used in
+    ///        your program from the dynamic library using SDL_GL_GetProcAddress().
     ///
-    /// \sa SDL_GL_GetProcAddress()
-    /// \sa SDL_GL_UnloadLibrary()
+    ///  \sa SDL_GL_GetProcAddress()
+    ///  \sa SDL_GL_UnloadLibrary()
     pub fn SDL_GL_LoadLibrary(path: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the address of an OpenGL function.
+    ///  \brief Get the address of an OpenGL function.
     pub fn SDL_GL_GetProcAddress(
         proc_: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Unload the OpenGL library previously loaded by SDL_GL_LoadLibrary().
+    ///  \brief Unload the OpenGL library previously loaded by SDL_GL_LoadLibrary().
     ///
-    /// \sa SDL_GL_LoadLibrary()
+    ///  \sa SDL_GL_LoadLibrary()
     pub fn SDL_GL_UnloadLibrary();
 }
 extern "C" {
-    /// \brief Return true if an OpenGL extension is supported for the current
-    /// context.
+    ///  \brief Return true if an OpenGL extension is supported for the current
+    ///         context.
     pub fn SDL_GL_ExtensionSupported(extension: *const ::std::os::raw::c_char) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Reset all previously set OpenGL context attributes to their default values
+    ///  \brief Reset all previously set OpenGL context attributes to their default values
     pub fn SDL_GL_ResetAttributes();
 }
 extern "C" {
-    /// \brief Set an OpenGL window attribute before window creation.
+    ///  \brief Set an OpenGL window attribute before window creation.
     ///
-    /// \return 0 on success, or -1 if the attribute could not be set.
+    ///  \return 0 on success, or -1 if the attribute could not be set.
     pub fn SDL_GL_SetAttribute(
         attr: SDL_GLattr,
         value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the actual value for an attribute from the current context.
+    ///  \brief Get the actual value for an attribute from the current context.
     ///
-    /// \return 0 on success, or -1 if the attribute could not be retrieved.
-    /// The integer at \c value will be modified in either case.
+    ///  \return 0 on success, or -1 if the attribute could not be retrieved.
+    ///          The integer at \c value will be modified in either case.
     pub fn SDL_GL_GetAttribute(
         attr: SDL_GLattr,
         value: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Create an OpenGL context for use with an OpenGL window, and make it
-    /// current.
+    ///  \brief Create an OpenGL context for use with an OpenGL window, and make it
+    ///         current.
     ///
-    /// \sa SDL_GL_DeleteContext()
+    ///  \sa SDL_GL_DeleteContext()
     pub fn SDL_GL_CreateContext(window: *mut SDL_Window) -> SDL_GLContext;
 }
 extern "C" {
-    /// \brief Set up an OpenGL context for rendering into an OpenGL window.
+    ///  \brief Set up an OpenGL context for rendering into an OpenGL window.
     ///
-    /// \note The context must have been created with a compatible window.
+    ///  \note The context must have been created with a compatible window.
     pub fn SDL_GL_MakeCurrent(
         window: *mut SDL_Window,
         context: SDL_GLContext,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the currently active OpenGL window.
+    ///  \brief Get the currently active OpenGL window.
     pub fn SDL_GL_GetCurrentWindow() -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Get the currently active OpenGL context.
+    ///  \brief Get the currently active OpenGL context.
     pub fn SDL_GL_GetCurrentContext() -> SDL_GLContext;
 }
 extern "C" {
-    /// \brief Get the size of a window's underlying drawable in pixels (for use
-    /// with glViewport).
+    ///  \brief Get the size of a window's underlying drawable in pixels (for use
+    ///         with glViewport).
     ///
-    /// \param window   Window from which the drawable size should be queried
-    /// \param w        Pointer to variable for storing the width in pixels, may be NULL
-    /// \param h        Pointer to variable for storing the height in pixels, may be NULL
+    ///  \param window   Window from which the drawable size should be queried
+    ///  \param w        Pointer to variable for storing the width in pixels, may be NULL
+    ///  \param h        Pointer to variable for storing the height in pixels, may be NULL
     ///
     /// This may differ from SDL_GetWindowSize() if we're rendering to a high-DPI
     /// drawable, i.e. the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a
     /// platform with high-DPI support (Apple calls this "Retina"), and not disabled
     /// by the SDL_HINT_VIDEO_HIGHDPI_DISABLED hint.
     ///
-    /// \sa SDL_GetWindowSize()
-    /// \sa SDL_CreateWindow()
+    ///  \sa SDL_GetWindowSize()
+    ///  \sa SDL_CreateWindow()
     pub fn SDL_GL_GetDrawableSize(
         window: *mut SDL_Window,
         w: *mut ::std::os::raw::c_int,
@@ -8184,50 +8266,50 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Set the swap interval for the current OpenGL context.
+    ///  \brief Set the swap interval for the current OpenGL context.
     ///
-    /// \param interval 0 for immediate updates, 1 for updates synchronized with the
-    /// vertical retrace. If the system supports it, you may
-    /// specify -1 to allow late swaps to happen immediately
-    /// instead of waiting for the next retrace.
+    ///  \param interval 0 for immediate updates, 1 for updates synchronized with the
+    ///                  vertical retrace. If the system supports it, you may
+    ///                  specify -1 to allow late swaps to happen immediately
+    ///                  instead of waiting for the next retrace.
     ///
-    /// \return 0 on success, or -1 if setting the swap interval is not supported.
+    ///  \return 0 on success, or -1 if setting the swap interval is not supported.
     ///
-    /// \sa SDL_GL_GetSwapInterval()
+    ///  \sa SDL_GL_GetSwapInterval()
     pub fn SDL_GL_SetSwapInterval(interval: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the swap interval for the current OpenGL context.
+    ///  \brief Get the swap interval for the current OpenGL context.
     ///
-    /// \return 0 if there is no vertical retrace synchronization, 1 if the buffer
-    /// swap is synchronized with the vertical retrace, and -1 if late
-    /// swaps happen immediately instead of waiting for the next retrace.
-    /// If the system can't determine the swap interval, or there isn't a
-    /// valid current context, this will return 0 as a safe default.
+    ///  \return 0 if there is no vertical retrace synchronization, 1 if the buffer
+    ///          swap is synchronized with the vertical retrace, and -1 if late
+    ///          swaps happen immediately instead of waiting for the next retrace.
+    ///          If the system can't determine the swap interval, or there isn't a
+    ///          valid current context, this will return 0 as a safe default.
     ///
-    /// \sa SDL_GL_SetSwapInterval()
+    ///  \sa SDL_GL_SetSwapInterval()
     pub fn SDL_GL_GetSwapInterval() -> ::std::os::raw::c_int;
 }
 extern "C" {
     /// \brief Swap the OpenGL buffers for a window, if double-buffering is
-    /// supported.
+    ///        supported.
     pub fn SDL_GL_SwapWindow(window: *mut SDL_Window);
 }
 extern "C" {
-    /// \brief Delete an OpenGL context.
+    ///  \brief Delete an OpenGL context.
     ///
-    /// \sa SDL_GL_CreateContext()
+    ///  \sa SDL_GL_CreateContext()
     pub fn SDL_GL_DeleteContext(context: SDL_GLContext);
 }
 #[repr(u32)]
-/// \brief The SDL keyboard scancode representation.
+///  \brief The SDL keyboard scancode representation.
 ///
-/// Values of this type are used to represent keyboard keys, among other places
-/// in the \link SDL_Keysym::scancode key.keysym.scancode \endlink field of the
-/// SDL_Event structure.
+///  Values of this type are used to represent keyboard keys, among other places
+///  in the \link SDL_Keysym::scancode key.keysym.scancode \endlink field of the
+///  SDL_Event structure.
 ///
-/// The values in this enumeration are based on the USB usage page standard:
-/// http://www.usb.org/developers/hidpage/Hut1_12v2.pdf
+///  The values in this enumeration are based on the USB usage page standard:
+///  http://www.usb.org/developers/hidpage/Hut1_12v2.pdf
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_Scancode {
     SDL_SCANCODE_UNKNOWN = 0,
@@ -8276,50 +8358,50 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_EQUALS = 46,
     SDL_SCANCODE_LEFTBRACKET = 47,
     SDL_SCANCODE_RIGHTBRACKET = 48,
-    /// < Located at the lower left of the return
-    /// key on ISO keyboards and at the right end
-    /// of the QWERTY row on ANSI keyboards.
-    /// Produces REVERSE SOLIDUS (backslash) and
-    /// VERTICAL LINE in a US layout, REVERSE
-    /// SOLIDUS and VERTICAL LINE in a UK Mac
-    /// layout, NUMBER SIGN and TILDE in a UK
-    /// Windows layout, DOLLAR SIGN and POUND SIGN
-    /// in a Swiss German layout, NUMBER SIGN and
-    /// APOSTROPHE in a German layout, GRAVE
-    /// ACCENT and POUND SIGN in a French Mac
-    /// layout, and ASTERISK and MICRO SIGN in a
-    /// French Windows layout.
+    ///< Located at the lower left of the return
+    ///   key on ISO keyboards and at the right end
+    ///   of the QWERTY row on ANSI keyboards.
+    ///   Produces REVERSE SOLIDUS (backslash) and
+    ///   VERTICAL LINE in a US layout, REVERSE
+    ///   SOLIDUS and VERTICAL LINE in a UK Mac
+    ///   layout, NUMBER SIGN and TILDE in a UK
+    ///   Windows layout, DOLLAR SIGN and POUND SIGN
+    ///   in a Swiss German layout, NUMBER SIGN and
+    ///   APOSTROPHE in a German layout, GRAVE
+    ///   ACCENT and POUND SIGN in a French Mac
+    ///   layout, and ASTERISK and MICRO SIGN in a
+    ///   French Windows layout.
     SDL_SCANCODE_BACKSLASH = 49,
-    /// < ISO USB keyboards actually use this code
-    /// instead of 49 for the same key, but all
-    /// OSes I've seen treat the two codes
-    /// identically. So, as an implementor, unless
-    /// your keyboard generates both of those
-    /// codes and your OS treats them differently,
-    /// you should generate SDL_SCANCODE_BACKSLASH
-    /// instead of this code. As a user, you
-    /// should not rely on this code because SDL
-    /// will never generate it with most (all?)
-    /// keyboards.
+    ///< ISO USB keyboards actually use this code
+    ///   instead of 49 for the same key, but all
+    ///   OSes I've seen treat the two codes
+    ///   identically. So, as an implementor, unless
+    ///   your keyboard generates both of those
+    ///   codes and your OS treats them differently,
+    ///   you should generate SDL_SCANCODE_BACKSLASH
+    ///   instead of this code. As a user, you
+    ///   should not rely on this code because SDL
+    ///   will never generate it with most (all?)
+    ///   keyboards.
     SDL_SCANCODE_NONUSHASH = 50,
     SDL_SCANCODE_SEMICOLON = 51,
     SDL_SCANCODE_APOSTROPHE = 52,
-    /// < Located in the top left corner (on both ANSI
-    /// and ISO keyboards). Produces GRAVE ACCENT and
-    /// TILDE in a US Windows layout and in US and UK
-    /// Mac layouts on ANSI keyboards, GRAVE ACCENT
-    /// and NOT SIGN in a UK Windows layout, SECTION
-    /// SIGN and PLUS-MINUS SIGN in US and UK Mac
-    /// layouts on ISO keyboards, SECTION SIGN and
-    /// DEGREE SIGN in a Swiss German layout (Mac:
-    /// only on ISO keyboards), CIRCUMFLEX ACCENT and
-    /// DEGREE SIGN in a German layout (Mac: only on
-    /// ISO keyboards), SUPERSCRIPT TWO and TILDE in a
-    /// French Windows layout, COMMERCIAL AT and
-    /// NUMBER SIGN in a French Mac layout on ISO
-    /// keyboards, and LESS-THAN SIGN and GREATER-THAN
-    /// SIGN in a Swiss German, German, or French Mac
-    /// layout on ANSI keyboards.
+    ///< Located in the top left corner (on both ANSI
+    ///   and ISO keyboards). Produces GRAVE ACCENT and
+    ///   TILDE in a US Windows layout and in US and UK
+    ///   Mac layouts on ANSI keyboards, GRAVE ACCENT
+    ///   and NOT SIGN in a UK Windows layout, SECTION
+    ///   SIGN and PLUS-MINUS SIGN in US and UK Mac
+    ///   layouts on ISO keyboards, SECTION SIGN and
+    ///   DEGREE SIGN in a Swiss German layout (Mac:
+    ///   only on ISO keyboards), CIRCUMFLEX ACCENT and
+    ///   DEGREE SIGN in a German layout (Mac: only on
+    ///   ISO keyboards), SUPERSCRIPT TWO and TILDE in a
+    ///   French Windows layout, COMMERCIAL AT and
+    ///   NUMBER SIGN in a French Mac layout on ISO
+    ///   keyboards, and LESS-THAN SIGN and GREATER-THAN
+    ///   SIGN in a Swiss German, German, or French Mac
+    ///   layout on ANSI keyboards.
     SDL_SCANCODE_GRAVE = 53,
     SDL_SCANCODE_COMMA = 54,
     SDL_SCANCODE_PERIOD = 55,
@@ -8340,8 +8422,8 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_PRINTSCREEN = 70,
     SDL_SCANCODE_SCROLLLOCK = 71,
     SDL_SCANCODE_PAUSE = 72,
-    /// < insert on PC, help on some Mac keyboards (but
-    /// does send code 73, not 117)
+    ///< insert on PC, help on some Mac keyboards (but
+    ///does send code 73, not 117)
     SDL_SCANCODE_INSERT = 73,
     SDL_SCANCODE_HOME = 74,
     SDL_SCANCODE_PAGEUP = 75,
@@ -8352,7 +8434,7 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_LEFT = 80,
     SDL_SCANCODE_DOWN = 81,
     SDL_SCANCODE_UP = 82,
-    /// < num lock on PC, clear on Mac keyboards
+    ///< num lock on PC, clear on Mac keyboards
     SDL_SCANCODE_NUMLOCKCLEAR = 83,
     SDL_SCANCODE_KP_DIVIDE = 84,
     SDL_SCANCODE_KP_MULTIPLY = 85,
@@ -8370,22 +8452,22 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_KP_9 = 97,
     SDL_SCANCODE_KP_0 = 98,
     SDL_SCANCODE_KP_PERIOD = 99,
-    /// < This is the additional key that ISO
-    /// keyboards have over ANSI ones,
-    /// located between left shift and Y.
-    /// Produces GRAVE ACCENT and TILDE in a
-    /// US or UK Mac layout, REVERSE SOLIDUS
-    /// (backslash) and VERTICAL LINE in a
-    /// US or UK Windows layout, and
-    /// LESS-THAN SIGN and GREATER-THAN SIGN
-    /// in a Swiss German, German, or French
-    /// layout.
+    ///< This is the additional key that ISO
+    ///   keyboards have over ANSI ones,
+    ///   located between left shift and Y.
+    ///   Produces GRAVE ACCENT and TILDE in a
+    ///   US or UK Mac layout, REVERSE SOLIDUS
+    ///   (backslash) and VERTICAL LINE in a
+    ///   US or UK Windows layout, and
+    ///   LESS-THAN SIGN and GREATER-THAN SIGN
+    ///   in a Swiss German, German, or French
+    ///   layout.
     SDL_SCANCODE_NONUSBACKSLASH = 100,
-    /// < windows contextual menu, compose
+    ///< windows contextual menu, compose
     SDL_SCANCODE_APPLICATION = 101,
-    /// < The USB document says this is a status flag,
-    /// not a physical key - but some Mac keyboards
-    /// do have a power key.
+    ///< The USB document says this is a status flag,
+    ///   not a physical key - but some Mac keyboards
+    ///   do have a power key.
     SDL_SCANCODE_POWER = 102,
     SDL_SCANCODE_KP_EQUALS = 103,
     SDL_SCANCODE_F13 = 104,
@@ -8405,7 +8487,7 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_MENU = 118,
     SDL_SCANCODE_SELECT = 119,
     SDL_SCANCODE_STOP = 120,
-    /// < redo
+    ///< redo
     SDL_SCANCODE_AGAIN = 121,
     SDL_SCANCODE_UNDO = 122,
     SDL_SCANCODE_CUT = 123,
@@ -8417,11 +8499,11 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_VOLUMEDOWN = 129,
     SDL_SCANCODE_KP_COMMA = 133,
     SDL_SCANCODE_KP_EQUALSAS400 = 134,
-    /// < used on Asian keyboards, see
-    /// footnotes in USB doc
+    ///< used on Asian keyboards, see
+    ///footnotes in USB doc
     SDL_SCANCODE_INTERNATIONAL1 = 135,
     SDL_SCANCODE_INTERNATIONAL2 = 136,
-    /// < Yen
+    ///< Yen
     SDL_SCANCODE_INTERNATIONAL3 = 137,
     SDL_SCANCODE_INTERNATIONAL4 = 138,
     SDL_SCANCODE_INTERNATIONAL5 = 139,
@@ -8429,25 +8511,25 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_INTERNATIONAL7 = 141,
     SDL_SCANCODE_INTERNATIONAL8 = 142,
     SDL_SCANCODE_INTERNATIONAL9 = 143,
-    /// < Hangul/English toggle
+    ///< Hangul/English toggle
     SDL_SCANCODE_LANG1 = 144,
-    /// < Hanja conversion
+    ///< Hanja conversion
     SDL_SCANCODE_LANG2 = 145,
-    /// < Katakana
+    ///< Katakana
     SDL_SCANCODE_LANG3 = 146,
-    /// < Hiragana
+    ///< Hiragana
     SDL_SCANCODE_LANG4 = 147,
-    /// < Zenkaku/Hankaku
+    ///< Zenkaku/Hankaku
     SDL_SCANCODE_LANG5 = 148,
-    /// < reserved
+    ///< reserved
     SDL_SCANCODE_LANG6 = 149,
-    /// < reserved
+    ///< reserved
     SDL_SCANCODE_LANG7 = 150,
-    /// < reserved
+    ///< reserved
     SDL_SCANCODE_LANG8 = 151,
-    /// < reserved
+    ///< reserved
     SDL_SCANCODE_LANG9 = 152,
-    /// < Erase-Eaze
+    ///< Erase-Eaze
     SDL_SCANCODE_ALTERASE = 153,
     SDL_SCANCODE_SYSREQ = 154,
     SDL_SCANCODE_CANCEL = 155,
@@ -8508,19 +8590,19 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_KP_HEXADECIMAL = 221,
     SDL_SCANCODE_LCTRL = 224,
     SDL_SCANCODE_LSHIFT = 225,
-    /// < alt, option
+    ///< alt, option
     SDL_SCANCODE_LALT = 226,
-    /// < windows, command (apple), meta
+    ///< windows, command (apple), meta
     SDL_SCANCODE_LGUI = 227,
     SDL_SCANCODE_RCTRL = 228,
     SDL_SCANCODE_RSHIFT = 229,
-    /// < alt gr, option
+    ///< alt gr, option
     SDL_SCANCODE_RALT = 230,
-    /// < windows, command (apple), meta
+    ///< windows, command (apple), meta
     SDL_SCANCODE_RGUI = 231,
-    /// < I'm not sure if this is really not covered
-    /// by any of the above, but since there's a
-    /// special KMOD_MODE for it I'm adding it here
+    ///< I'm not sure if this is really not covered
+    ///   by any of the above, but since there's a
+    ///   special KMOD_MODE for it I'm adding it here
     SDL_SCANCODE_MODE = 257,
     SDL_SCANCODE_AUDIONEXT = 258,
     SDL_SCANCODE_AUDIOPREV = 259,
@@ -8541,8 +8623,8 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_AC_BOOKMARKS = 274,
     SDL_SCANCODE_BRIGHTNESSDOWN = 275,
     SDL_SCANCODE_BRIGHTNESSUP = 276,
-    /// < display mirroring/dual display
-    /// switch, video mode switch
+    ///< display mirroring/dual display
+    ///switch, video mode switch
     SDL_SCANCODE_DISPLAYSWITCH = 277,
     SDL_SCANCODE_KBDILLUMTOGGLE = 278,
     SDL_SCANCODE_KBDILLUMDOWN = 279,
@@ -8553,19 +8635,19 @@ pub enum SDL_Scancode {
     SDL_SCANCODE_APP2 = 284,
     SDL_SCANCODE_AUDIOREWIND = 285,
     SDL_SCANCODE_AUDIOFASTFORWARD = 286,
-    /// < not a key, just marks the number of scancodes
-    /// for array bounds
+    ///< not a key, just marks the number of scancodes
+    ///for array bounds
     SDL_NUM_SCANCODES = 512,
 }
-/// \brief The SDL virtual key representation.
+///  \brief The SDL virtual key representation.
 ///
-/// Values of this type are used to represent keyboard keys using the current
-/// layout of the keyboard.  These values include Unicode values representing
-/// the unmodified character that would be generated by pressing the key, or
-/// an SDLK_* constant for those keys that do not generate characters.
+///  Values of this type are used to represent keyboard keys using the current
+///  layout of the keyboard.  These values include Unicode values representing
+///  the unmodified character that would be generated by pressing the key, or
+///  an SDLK_* constant for those keys that do not generate characters.
 ///
-/// A special exception is the number keys at the top of the keyboard which
-/// always map to SDLK_0...SDLK_9, regardless of layout.
+///  A special exception is the number keys at the top of the keyboard which
+///  always map to SDLK_0...SDLK_9, regardless of layout.
 pub type SDL_Keycode = Sint32;
 pub const SDLK_UNKNOWN: _bindgen_ty_7 = _bindgen_ty_7::SDLK_UNKNOWN;
 pub const SDLK_RETURN: _bindgen_ty_7 = _bindgen_ty_7::SDLK_RETURN;
@@ -9069,17 +9151,17 @@ pub enum SDL_Keymod {
     KMOD_MODE = 16384,
     KMOD_RESERVED = 32768,
 }
-/// \brief The SDL keysym structure, used in key events.
+///  \brief The SDL keysym structure, used in key events.
 ///
-/// \note  If you are looking for translated character input, see the ::SDL_TEXTINPUT event.
+///  \note  If you are looking for translated character input, see the ::SDL_TEXTINPUT event.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Keysym {
-    /// < SDL physical key code - see ::SDL_Scancode for details
+    ///< SDL physical key code - see ::SDL_Scancode for details
     pub scancode: SDL_Scancode,
-    /// < SDL virtual key code - see ::SDL_Keycode for details
+    ///< SDL virtual key code - see ::SDL_Keycode for details
     pub sym: SDL_Keycode,
-    /// < current key modifiers
+    ///< current key modifiers
     pub mod_: Uint16,
     pub unused: Uint32,
 }
@@ -9137,139 +9219,139 @@ fn bindgen_test_layout_SDL_Keysym() {
     );
 }
 extern "C" {
-    /// \brief Get the window which currently has keyboard focus.
+    ///  \brief Get the window which currently has keyboard focus.
     pub fn SDL_GetKeyboardFocus() -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Get a snapshot of the current state of the keyboard.
+    ///  \brief Get a snapshot of the current state of the keyboard.
     ///
-    /// \param numkeys if non-NULL, receives the length of the returned array.
+    ///  \param numkeys if non-NULL, receives the length of the returned array.
     ///
-    /// \return An array of key states. Indexes into this array are obtained by using ::SDL_Scancode values.
+    ///  \return An array of key states. Indexes into this array are obtained by using ::SDL_Scancode values.
     ///
-    /// \b Example:
-    /// \code
-    /// const Uint8 *state = SDL_GetKeyboardState(NULL);
-    /// if ( state[SDL_SCANCODE_RETURN] )   {
-    /// printf("<RETURN> is pressed.\n");
-    /// }
-    /// \endcode
+    ///  \b Example:
+    ///  \code
+    ///  const Uint8 *state = SDL_GetKeyboardState(NULL);
+    ///  if ( state[SDL_SCANCODE_RETURN] )   {
+    ///      printf("<RETURN> is pressed.\n");
+    ///  }
+    ///  \endcode
     pub fn SDL_GetKeyboardState(numkeys: *mut ::std::os::raw::c_int) -> *const Uint8;
 }
 extern "C" {
-    /// \brief Get the current key modifier state for the keyboard.
+    ///  \brief Get the current key modifier state for the keyboard.
     pub fn SDL_GetModState() -> SDL_Keymod;
 }
 extern "C" {
-    /// \brief Set the current key modifier state for the keyboard.
+    ///  \brief Set the current key modifier state for the keyboard.
     ///
-    /// \note This does not change the keyboard state, only the key modifier flags.
+    ///  \note This does not change the keyboard state, only the key modifier flags.
     pub fn SDL_SetModState(modstate: SDL_Keymod);
 }
 extern "C" {
-    /// \brief Get the key code corresponding to the given scancode according
-    /// to the current keyboard layout.
+    ///  \brief Get the key code corresponding to the given scancode according
+    ///         to the current keyboard layout.
     ///
-    /// See ::SDL_Keycode for details.
+    ///  See ::SDL_Keycode for details.
     ///
-    /// \sa SDL_GetKeyName()
+    ///  \sa SDL_GetKeyName()
     pub fn SDL_GetKeyFromScancode(scancode: SDL_Scancode) -> SDL_Keycode;
 }
 extern "C" {
-    /// \brief Get the scancode corresponding to the given key code according to the
-    /// current keyboard layout.
+    ///  \brief Get the scancode corresponding to the given key code according to the
+    ///         current keyboard layout.
     ///
-    /// See ::SDL_Scancode for details.
+    ///  See ::SDL_Scancode for details.
     ///
-    /// \sa SDL_GetScancodeName()
+    ///  \sa SDL_GetScancodeName()
     pub fn SDL_GetScancodeFromKey(key: SDL_Keycode) -> SDL_Scancode;
 }
 extern "C" {
-    /// \brief Get a human-readable name for a scancode.
+    ///  \brief Get a human-readable name for a scancode.
     ///
-    /// \return A pointer to the name for the scancode.
-    /// If the scancode doesn't have a name, this function returns
-    /// an empty string ("").
+    ///  \return A pointer to the name for the scancode.
+    ///          If the scancode doesn't have a name, this function returns
+    ///          an empty string ("").
     ///
-    /// \sa SDL_Scancode
+    ///  \sa SDL_Scancode
     pub fn SDL_GetScancodeName(scancode: SDL_Scancode) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Get a scancode from a human-readable name
+    ///  \brief Get a scancode from a human-readable name
     ///
-    /// \return scancode, or SDL_SCANCODE_UNKNOWN if the name wasn't recognized
+    ///  \return scancode, or SDL_SCANCODE_UNKNOWN if the name wasn't recognized
     ///
-    /// \sa SDL_Scancode
+    ///  \sa SDL_Scancode
     pub fn SDL_GetScancodeFromName(name: *const ::std::os::raw::c_char) -> SDL_Scancode;
 }
 extern "C" {
-    /// \brief Get a human-readable name for a key.
+    ///  \brief Get a human-readable name for a key.
     ///
-    /// \return A pointer to a UTF-8 string that stays valid at least until the next
-    /// call to this function. If you need it around any longer, you must
-    /// copy it.  If the key doesn't have a name, this function returns an
-    /// empty string ("").
+    ///  \return A pointer to a UTF-8 string that stays valid at least until the next
+    ///          call to this function. If you need it around any longer, you must
+    ///          copy it.  If the key doesn't have a name, this function returns an
+    ///          empty string ("").
     ///
-    /// \sa SDL_Keycode
+    ///  \sa SDL_Keycode
     pub fn SDL_GetKeyName(key: SDL_Keycode) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Get a key code from a human-readable name
+    ///  \brief Get a key code from a human-readable name
     ///
-    /// \return key code, or SDLK_UNKNOWN if the name wasn't recognized
+    ///  \return key code, or SDLK_UNKNOWN if the name wasn't recognized
     ///
-    /// \sa SDL_Keycode
+    ///  \sa SDL_Keycode
     pub fn SDL_GetKeyFromName(name: *const ::std::os::raw::c_char) -> SDL_Keycode;
 }
 extern "C" {
-    /// \brief Start accepting Unicode text input events.
-    /// This function will show the on-screen keyboard if supported.
+    ///  \brief Start accepting Unicode text input events.
+    ///         This function will show the on-screen keyboard if supported.
     ///
-    /// \sa SDL_StopTextInput()
-    /// \sa SDL_SetTextInputRect()
-    /// \sa SDL_HasScreenKeyboardSupport()
+    ///  \sa SDL_StopTextInput()
+    ///  \sa SDL_SetTextInputRect()
+    ///  \sa SDL_HasScreenKeyboardSupport()
     pub fn SDL_StartTextInput();
 }
 extern "C" {
-    /// \brief Return whether or not Unicode text input events are enabled.
+    ///  \brief Return whether or not Unicode text input events are enabled.
     ///
-    /// \sa SDL_StartTextInput()
-    /// \sa SDL_StopTextInput()
+    ///  \sa SDL_StartTextInput()
+    ///  \sa SDL_StopTextInput()
     pub fn SDL_IsTextInputActive() -> SDL_bool;
 }
 extern "C" {
-    /// \brief Stop receiving any text input events.
-    /// This function will hide the on-screen keyboard if supported.
+    ///  \brief Stop receiving any text input events.
+    ///         This function will hide the on-screen keyboard if supported.
     ///
-    /// \sa SDL_StartTextInput()
-    /// \sa SDL_HasScreenKeyboardSupport()
+    ///  \sa SDL_StartTextInput()
+    ///  \sa SDL_HasScreenKeyboardSupport()
     pub fn SDL_StopTextInput();
 }
 extern "C" {
-    /// \brief Set the rectangle used to type Unicode text inputs.
-    /// This is used as a hint for IME and on-screen keyboard placement.
+    ///  \brief Set the rectangle used to type Unicode text inputs.
+    ///         This is used as a hint for IME and on-screen keyboard placement.
     ///
-    /// \sa SDL_StartTextInput()
+    ///  \sa SDL_StartTextInput()
     pub fn SDL_SetTextInputRect(rect: *mut SDL_Rect);
 }
 extern "C" {
-    /// \brief Returns whether the platform has some screen keyboard support.
+    ///  \brief Returns whether the platform has some screen keyboard support.
     ///
-    /// \return SDL_TRUE if some keyboard support is available else SDL_FALSE.
+    ///  \return SDL_TRUE if some keyboard support is available else SDL_FALSE.
     ///
-    /// \note Not all screen keyboard functions are supported on all platforms.
+    ///  \note Not all screen keyboard functions are supported on all platforms.
     ///
-    /// \sa SDL_IsScreenKeyboardShown()
+    ///  \sa SDL_IsScreenKeyboardShown()
     pub fn SDL_HasScreenKeyboardSupport() -> SDL_bool;
 }
 extern "C" {
-    /// \brief Returns whether the screen keyboard is shown for given window.
+    ///  \brief Returns whether the screen keyboard is shown for given window.
     ///
-    /// \param window The window for which screen keyboard should be queried.
+    ///  \param window The window for which screen keyboard should be queried.
     ///
-    /// \return SDL_TRUE if screen keyboard is shown else SDL_FALSE.
+    ///  \return SDL_TRUE if screen keyboard is shown else SDL_FALSE.
     ///
-    /// \sa SDL_HasScreenKeyboardSupport()
+    ///  \sa SDL_HasScreenKeyboardSupport()
     pub fn SDL_IsScreenKeyboardShown(window: *mut SDL_Window) -> SDL_bool;
 }
 #[repr(C)]
@@ -9281,29 +9363,29 @@ pub struct SDL_Cursor {
 /// \brief Cursor types for SDL_CreateSystemCursor().
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_SystemCursor {
-    /// < Arrow
+    ///< Arrow
     SDL_SYSTEM_CURSOR_ARROW = 0,
-    /// < I-beam
+    ///< I-beam
     SDL_SYSTEM_CURSOR_IBEAM = 1,
-    /// < Wait
+    ///< Wait
     SDL_SYSTEM_CURSOR_WAIT = 2,
-    /// < Crosshair
+    ///< Crosshair
     SDL_SYSTEM_CURSOR_CROSSHAIR = 3,
-    /// < Small wait cursor (or Wait if not available)
+    ///< Small wait cursor (or Wait if not available)
     SDL_SYSTEM_CURSOR_WAITARROW = 4,
-    /// < Double arrow pointing northwest and southeast
+    ///< Double arrow pointing northwest and southeast
     SDL_SYSTEM_CURSOR_SIZENWSE = 5,
-    /// < Double arrow pointing northeast and southwest
+    ///< Double arrow pointing northeast and southwest
     SDL_SYSTEM_CURSOR_SIZENESW = 6,
-    /// < Double arrow pointing west and east
+    ///< Double arrow pointing west and east
     SDL_SYSTEM_CURSOR_SIZEWE = 7,
-    /// < Double arrow pointing north and south
+    ///< Double arrow pointing north and south
     SDL_SYSTEM_CURSOR_SIZENS = 8,
-    /// < Four pointed arrow pointing north, south, east, and west
+    ///< Four pointed arrow pointing north, south, east, and west
     SDL_SYSTEM_CURSOR_SIZEALL = 9,
-    /// < Slashed circle or crossbones
+    ///< Slashed circle or crossbones
     SDL_SYSTEM_CURSOR_NO = 10,
-    /// < Hand
+    ///< Hand
     SDL_SYSTEM_CURSOR_HAND = 11,
     SDL_NUM_SYSTEM_CURSORS = 12,
 }
@@ -9311,73 +9393,73 @@ pub enum SDL_SystemCursor {
 /// \brief Scroll direction types for the Scroll event
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_MouseWheelDirection {
-    /// < The scroll direction is normal
+    ///< The scroll direction is normal
     SDL_MOUSEWHEEL_NORMAL = 0,
-    /// < The scroll direction is flipped / natural
+    ///< The scroll direction is flipped / natural
     SDL_MOUSEWHEEL_FLIPPED = 1,
 }
 extern "C" {
-    /// \brief Get the window which currently has mouse focus.
+    ///  \brief Get the window which currently has mouse focus.
     pub fn SDL_GetMouseFocus() -> *mut SDL_Window;
 }
 extern "C" {
-    /// \brief Retrieve the current state of the mouse.
+    ///  \brief Retrieve the current state of the mouse.
     ///
-    /// The current button state is returned as a button bitmask, which can
-    /// be tested using the SDL_BUTTON(X) macros, and x and y are set to the
-    /// mouse cursor position relative to the focus window for the currently
-    /// selected mouse.  You can pass NULL for either x or y.
+    ///  The current button state is returned as a button bitmask, which can
+    ///  be tested using the SDL_BUTTON(X) macros, and x and y are set to the
+    ///  mouse cursor position relative to the focus window for the currently
+    ///  selected mouse.  You can pass NULL for either x or y.
     pub fn SDL_GetMouseState(
         x: *mut ::std::os::raw::c_int,
         y: *mut ::std::os::raw::c_int,
     ) -> Uint32;
 }
 extern "C" {
-    /// \brief Get the current state of the mouse, in relation to the desktop
+    ///  \brief Get the current state of the mouse, in relation to the desktop
     ///
-    /// This works just like SDL_GetMouseState(), but the coordinates will be
-    /// reported relative to the top-left of the desktop. This can be useful if
-    /// you need to track the mouse outside of a specific window and
-    /// SDL_CaptureMouse() doesn't fit your needs. For example, it could be
-    /// useful if you need to track the mouse while dragging a window, where
-    /// coordinates relative to a window might not be in sync at all times.
+    ///  This works just like SDL_GetMouseState(), but the coordinates will be
+    ///  reported relative to the top-left of the desktop. This can be useful if
+    ///  you need to track the mouse outside of a specific window and
+    ///  SDL_CaptureMouse() doesn't fit your needs. For example, it could be
+    ///  useful if you need to track the mouse while dragging a window, where
+    ///  coordinates relative to a window might not be in sync at all times.
     ///
-    /// \note SDL_GetMouseState() returns the mouse position as SDL understands
-    /// it from the last pump of the event queue. This function, however,
-    /// queries the OS for the current mouse position, and as such, might
-    /// be a slightly less efficient function. Unless you know what you're
-    /// doing and have a good reason to use this function, you probably want
-    /// SDL_GetMouseState() instead.
+    ///  \note SDL_GetMouseState() returns the mouse position as SDL understands
+    ///        it from the last pump of the event queue. This function, however,
+    ///        queries the OS for the current mouse position, and as such, might
+    ///        be a slightly less efficient function. Unless you know what you're
+    ///        doing and have a good reason to use this function, you probably want
+    ///        SDL_GetMouseState() instead.
     ///
-    /// \param x Returns the current X coord, relative to the desktop. Can be NULL.
-    /// \param y Returns the current Y coord, relative to the desktop. Can be NULL.
-    /// \return The current button state as a bitmask, which can be tested using the SDL_BUTTON(X) macros.
+    ///  \param x Returns the current X coord, relative to the desktop. Can be NULL.
+    ///  \param y Returns the current Y coord, relative to the desktop. Can be NULL.
+    ///  \return The current button state as a bitmask, which can be tested using the SDL_BUTTON(X) macros.
     ///
-    /// \sa SDL_GetMouseState
+    ///  \sa SDL_GetMouseState
     pub fn SDL_GetGlobalMouseState(
         x: *mut ::std::os::raw::c_int,
         y: *mut ::std::os::raw::c_int,
     ) -> Uint32;
 }
 extern "C" {
-    /// \brief Retrieve the relative state of the mouse.
+    ///  \brief Retrieve the relative state of the mouse.
     ///
-    /// The current button state is returned as a button bitmask, which can
-    /// be tested using the SDL_BUTTON(X) macros, and x and y are set to the
-    /// mouse deltas since the last call to SDL_GetRelativeMouseState().
+    ///  The current button state is returned as a button bitmask, which can
+    ///  be tested using the SDL_BUTTON(X) macros, and x and y are set to the
+    ///  mouse deltas since the last call to SDL_GetRelativeMouseState().
     pub fn SDL_GetRelativeMouseState(
         x: *mut ::std::os::raw::c_int,
         y: *mut ::std::os::raw::c_int,
     ) -> Uint32;
 }
 extern "C" {
-    /// \brief Moves the mouse to the given position within the window.
+    ///  \brief Moves the mouse to the given position within the window.
     ///
-    /// \param window The window to move the mouse into, or NULL for the current mouse focus
-    /// \param x The x coordinate within the window
-    /// \param y The y coordinate within the window
+    ///  \param window The window to move the mouse into, or NULL for the current mouse focus
+    ///  \param x The x coordinate within the window
+    ///  \param y The y coordinate within the window
     ///
-    /// \note This function generates a mouse motion event
+    ///  \note This function generates a mouse motion event
     pub fn SDL_WarpMouseInWindow(
         window: *mut SDL_Window,
         x: ::std::os::raw::c_int,
@@ -9385,88 +9467,88 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Moves the mouse to the given position in global screen space.
+    ///  \brief Moves the mouse to the given position in global screen space.
     ///
-    /// \param x The x coordinate
-    /// \param y The y coordinate
-    /// \return 0 on success, -1 on error (usually: unsupported by a platform).
+    ///  \param x The x coordinate
+    ///  \param y The y coordinate
+    ///  \return 0 on success, -1 on error (usually: unsupported by a platform).
     ///
-    /// \note This function generates a mouse motion event
+    ///  \note This function generates a mouse motion event
     pub fn SDL_WarpMouseGlobal(
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set relative mouse mode.
+    ///  \brief Set relative mouse mode.
     ///
-    /// \param enabled Whether or not to enable relative mode
+    ///  \param enabled Whether or not to enable relative mode
     ///
-    /// \return 0 on success, or -1 if relative mode is not supported.
+    ///  \return 0 on success, or -1 if relative mode is not supported.
     ///
-    /// While the mouse is in relative mode, the cursor is hidden, and the
-    /// driver will try to report continuous motion in the current window.
-    /// Only relative motion events will be delivered, the mouse position
-    /// will not change.
+    ///  While the mouse is in relative mode, the cursor is hidden, and the
+    ///  driver will try to report continuous motion in the current window.
+    ///  Only relative motion events will be delivered, the mouse position
+    ///  will not change.
     ///
-    /// \note This function will flush any pending mouse motion.
+    ///  \note This function will flush any pending mouse motion.
     ///
-    /// \sa SDL_GetRelativeMouseMode()
+    ///  \sa SDL_GetRelativeMouseMode()
     pub fn SDL_SetRelativeMouseMode(enabled: SDL_bool) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Capture the mouse, to track input outside an SDL window.
+    ///  \brief Capture the mouse, to track input outside an SDL window.
     ///
-    /// \param enabled Whether or not to enable capturing
+    ///  \param enabled Whether or not to enable capturing
     ///
-    /// Capturing enables your app to obtain mouse events globally, instead of
-    /// just within your window. Not all video targets support this function.
-    /// When capturing is enabled, the current window will get all mouse events,
-    /// but unlike relative mode, no change is made to the cursor and it is
-    /// not restrained to your window.
+    ///  Capturing enables your app to obtain mouse events globally, instead of
+    ///  just within your window. Not all video targets support this function.
+    ///  When capturing is enabled, the current window will get all mouse events,
+    ///  but unlike relative mode, no change is made to the cursor and it is
+    ///  not restrained to your window.
     ///
-    /// This function may also deny mouse input to other windows--both those in
-    /// your application and others on the system--so you should use this
-    /// function sparingly, and in small bursts. For example, you might want to
-    /// track the mouse while the user is dragging something, until the user
-    /// releases a mouse button. It is not recommended that you capture the mouse
-    /// for long periods of time, such as the entire time your app is running.
+    ///  This function may also deny mouse input to other windows--both those in
+    ///  your application and others on the system--so you should use this
+    ///  function sparingly, and in small bursts. For example, you might want to
+    ///  track the mouse while the user is dragging something, until the user
+    ///  releases a mouse button. It is not recommended that you capture the mouse
+    ///  for long periods of time, such as the entire time your app is running.
     ///
-    /// While captured, mouse events still report coordinates relative to the
-    /// current (foreground) window, but those coordinates may be outside the
-    /// bounds of the window (including negative values). Capturing is only
-    /// allowed for the foreground window. If the window loses focus while
-    /// capturing, the capture will be disabled automatically.
+    ///  While captured, mouse events still report coordinates relative to the
+    ///  current (foreground) window, but those coordinates may be outside the
+    ///  bounds of the window (including negative values). Capturing is only
+    ///  allowed for the foreground window. If the window loses focus while
+    ///  capturing, the capture will be disabled automatically.
     ///
-    /// While capturing is enabled, the current window will have the
-    /// SDL_WINDOW_MOUSE_CAPTURE flag set.
+    ///  While capturing is enabled, the current window will have the
+    ///  SDL_WINDOW_MOUSE_CAPTURE flag set.
     ///
-    /// \return 0 on success, or -1 if not supported.
+    ///  \return 0 on success, or -1 if not supported.
     pub fn SDL_CaptureMouse(enabled: SDL_bool) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Query whether relative mouse mode is enabled.
+    ///  \brief Query whether relative mouse mode is enabled.
     ///
-    /// \sa SDL_SetRelativeMouseMode()
+    ///  \sa SDL_SetRelativeMouseMode()
     pub fn SDL_GetRelativeMouseMode() -> SDL_bool;
 }
 extern "C" {
-    /// \brief Create a cursor, using the specified bitmap data and
-    /// mask (in MSB format).
+    ///  \brief Create a cursor, using the specified bitmap data and
+    ///         mask (in MSB format).
     ///
-    /// The cursor width must be a multiple of 8 bits.
+    ///  The cursor width must be a multiple of 8 bits.
     ///
-    /// The cursor is created in black and white according to the following:
-    /// <table>
-    /// <tr><td> data </td><td> mask </td><td> resulting pixel on screen </td></tr>
-    /// <tr><td>  0   </td><td>  1   </td><td> White </td></tr>
-    /// <tr><td>  1   </td><td>  1   </td><td> Black </td></tr>
-    /// <tr><td>  0   </td><td>  0   </td><td> Transparent </td></tr>
-    /// <tr><td>  1   </td><td>  0   </td><td> Inverted color if possible, black
-    /// if not. </td></tr>
-    /// </table>
+    ///  The cursor is created in black and white according to the following:
+    ///  <table>
+    ///  <tr><td> data </td><td> mask </td><td> resulting pixel on screen </td></tr>
+    ///  <tr><td>  0   </td><td>  1   </td><td> White </td></tr>
+    ///  <tr><td>  1   </td><td>  1   </td><td> Black </td></tr>
+    ///  <tr><td>  0   </td><td>  0   </td><td> Transparent </td></tr>
+    ///  <tr><td>  1   </td><td>  0   </td><td> Inverted color if possible, black
+    ///                                         if not. </td></tr>
+    ///  </table>
     ///
-    /// \sa SDL_FreeCursor()
+    ///  \sa SDL_FreeCursor()
     pub fn SDL_CreateCursor(
         data: *const Uint8,
         mask: *const Uint8,
@@ -9477,9 +9559,9 @@ extern "C" {
     ) -> *mut SDL_Cursor;
 }
 extern "C" {
-    /// \brief Create a color cursor.
+    ///  \brief Create a color cursor.
     ///
-    /// \sa SDL_FreeCursor()
+    ///  \sa SDL_FreeCursor()
     pub fn SDL_CreateColorCursor(
         surface: *mut SDL_Surface,
         hot_x: ::std::os::raw::c_int,
@@ -9487,38 +9569,38 @@ extern "C" {
     ) -> *mut SDL_Cursor;
 }
 extern "C" {
-    /// \brief Create a system cursor.
+    ///  \brief Create a system cursor.
     ///
-    /// \sa SDL_FreeCursor()
+    ///  \sa SDL_FreeCursor()
     pub fn SDL_CreateSystemCursor(id: SDL_SystemCursor) -> *mut SDL_Cursor;
 }
 extern "C" {
-    /// \brief Set the active cursor.
+    ///  \brief Set the active cursor.
     pub fn SDL_SetCursor(cursor: *mut SDL_Cursor);
 }
 extern "C" {
-    /// \brief Return the active cursor.
+    ///  \brief Return the active cursor.
     pub fn SDL_GetCursor() -> *mut SDL_Cursor;
 }
 extern "C" {
-    /// \brief Return the default cursor.
+    ///  \brief Return the default cursor.
     pub fn SDL_GetDefaultCursor() -> *mut SDL_Cursor;
 }
 extern "C" {
-    /// \brief Frees a cursor created with SDL_CreateCursor() or similar functions.
+    ///  \brief Frees a cursor created with SDL_CreateCursor() or similar functions.
     ///
-    /// \sa SDL_CreateCursor()
-    /// \sa SDL_CreateColorCursor()
-    /// \sa SDL_CreateSystemCursor()
+    ///  \sa SDL_CreateCursor()
+    ///  \sa SDL_CreateColorCursor()
+    ///  \sa SDL_CreateSystemCursor()
     pub fn SDL_FreeCursor(cursor: *mut SDL_Cursor);
 }
 extern "C" {
-    /// \brief Toggle whether or not the cursor is shown.
+    ///  \brief Toggle whether or not the cursor is shown.
     ///
-    /// \param toggle 1 to show the cursor, 0 to hide it, -1 to query the current
-    /// state.
+    ///  \param toggle 1 to show the cursor, 0 to hide it, -1 to query the current
+    ///                state.
     ///
-    /// \return 1 if the cursor is shown, or 0 if the cursor is hidden.
+    ///  \return 1 if the cursor is shown, or 0 if the cursor is hidden.
     pub fn SDL_ShowCursor(toggle: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 /// The joystick structure used to identify an SDL joystick
@@ -9602,59 +9684,66 @@ extern "C" {
     pub fn SDL_UnlockJoysticks();
 }
 extern "C" {
-    /// Count the number of joysticks attached to the system right now
+    ///  Count the number of joysticks attached to the system right now
     pub fn SDL_NumJoysticks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the implementation dependent name of a joystick.
-    /// This can be called before any joysticks are opened.
-    /// If no name can be found, this function returns NULL.
+    ///  Get the implementation dependent name of a joystick.
+    ///  This can be called before any joysticks are opened.
+    ///  If no name can be found, this function returns NULL.
     pub fn SDL_JoystickNameForIndex(
         device_index: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Return the GUID for the joystick at this index
-    /// This can be called before any joysticks are opened.
+    ///  Get the player index of a joystick, or -1 if it's not available
+    ///  This can be called before any joysticks are opened.
+    pub fn SDL_JoystickGetDevicePlayerIndex(
+        device_index: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Return the GUID for the joystick at this index
+    ///  This can be called before any joysticks are opened.
     pub fn SDL_JoystickGetDeviceGUID(device_index: ::std::os::raw::c_int) -> SDL_JoystickGUID;
 }
 extern "C" {
-    /// Get the USB vendor ID of a joystick, if available.
-    /// This can be called before any joysticks are opened.
-    /// If the vendor ID isn't available this function returns 0.
+    ///  Get the USB vendor ID of a joystick, if available.
+    ///  This can be called before any joysticks are opened.
+    ///  If the vendor ID isn't available this function returns 0.
     pub fn SDL_JoystickGetDeviceVendor(device_index: ::std::os::raw::c_int) -> Uint16;
 }
 extern "C" {
-    /// Get the USB product ID of a joystick, if available.
-    /// This can be called before any joysticks are opened.
-    /// If the product ID isn't available this function returns 0.
+    ///  Get the USB product ID of a joystick, if available.
+    ///  This can be called before any joysticks are opened.
+    ///  If the product ID isn't available this function returns 0.
     pub fn SDL_JoystickGetDeviceProduct(device_index: ::std::os::raw::c_int) -> Uint16;
 }
 extern "C" {
-    /// Get the product version of a joystick, if available.
-    /// This can be called before any joysticks are opened.
-    /// If the product version isn't available this function returns 0.
+    ///  Get the product version of a joystick, if available.
+    ///  This can be called before any joysticks are opened.
+    ///  If the product version isn't available this function returns 0.
     pub fn SDL_JoystickGetDeviceProductVersion(device_index: ::std::os::raw::c_int) -> Uint16;
 }
 extern "C" {
-    /// Get the type of a joystick, if available.
-    /// This can be called before any joysticks are opened.
+    ///  Get the type of a joystick, if available.
+    ///  This can be called before any joysticks are opened.
     pub fn SDL_JoystickGetDeviceType(device_index: ::std::os::raw::c_int) -> SDL_JoystickType;
 }
 extern "C" {
-    /// Get the instance ID of a joystick.
-    /// This can be called before any joysticks are opened.
-    /// If the index is out of range, this function will return -1.
+    ///  Get the instance ID of a joystick.
+    ///  This can be called before any joysticks are opened.
+    ///  If the index is out of range, this function will return -1.
     pub fn SDL_JoystickGetDeviceInstanceID(device_index: ::std::os::raw::c_int) -> SDL_JoystickID;
 }
 extern "C" {
-    /// Open a joystick for use.
-    /// The index passed as an argument refers to the N'th joystick on the system.
-    /// This index is not the value which will identify this joystick in future
-    /// joystick events.  The joystick's instance id (::SDL_JoystickID) will be used
-    /// there instead.
+    ///  Open a joystick for use.
+    ///  The index passed as an argument refers to the N'th joystick on the system.
+    ///  This index is not the value which will identify this joystick in future
+    ///  joystick events.  The joystick's instance id (::SDL_JoystickID) will be used
+    ///  there instead.
     ///
-    /// \return A joystick identifier, or NULL if an error occurred.
+    ///  \return A joystick identifier, or NULL if an error occurred.
     pub fn SDL_JoystickOpen(device_index: ::std::os::raw::c_int) -> *mut SDL_Joystick;
 }
 extern "C" {
@@ -9662,36 +9751,42 @@ extern "C" {
     pub fn SDL_JoystickFromInstanceID(joyid: SDL_JoystickID) -> *mut SDL_Joystick;
 }
 extern "C" {
-    /// Return the name for this currently opened joystick.
-    /// If no name can be found, this function returns NULL.
+    ///  Return the name for this currently opened joystick.
+    ///  If no name can be found, this function returns NULL.
     pub fn SDL_JoystickName(joystick: *mut SDL_Joystick) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Return the GUID for this opened joystick
+    ///  Get the player index of an opened joystick, or -1 if it's not available
+    ///
+    ///  For XInput controllers this returns the XInput user index.
+    pub fn SDL_JoystickGetPlayerIndex(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Return the GUID for this opened joystick
     pub fn SDL_JoystickGetGUID(joystick: *mut SDL_Joystick) -> SDL_JoystickGUID;
 }
 extern "C" {
-    /// Get the USB vendor ID of an opened joystick, if available.
-    /// If the vendor ID isn't available this function returns 0.
+    ///  Get the USB vendor ID of an opened joystick, if available.
+    ///  If the vendor ID isn't available this function returns 0.
     pub fn SDL_JoystickGetVendor(joystick: *mut SDL_Joystick) -> Uint16;
 }
 extern "C" {
-    /// Get the USB product ID of an opened joystick, if available.
-    /// If the product ID isn't available this function returns 0.
+    ///  Get the USB product ID of an opened joystick, if available.
+    ///  If the product ID isn't available this function returns 0.
     pub fn SDL_JoystickGetProduct(joystick: *mut SDL_Joystick) -> Uint16;
 }
 extern "C" {
-    /// Get the product version of an opened joystick, if available.
-    /// If the product version isn't available this function returns 0.
+    ///  Get the product version of an opened joystick, if available.
+    ///  If the product version isn't available this function returns 0.
     pub fn SDL_JoystickGetProductVersion(joystick: *mut SDL_Joystick) -> Uint16;
 }
 extern "C" {
-    /// Get the type of an opened joystick.
+    ///  Get the type of an opened joystick.
     pub fn SDL_JoystickGetType(joystick: *mut SDL_Joystick) -> SDL_JoystickType;
 }
 extern "C" {
-    /// Return a string representation for this guid. pszGUID must point to at least 33 bytes
-    /// (32 for the string plus a NULL terminator).
+    ///  Return a string representation for this guid. pszGUID must point to at least 33 bytes
+    ///  (32 for the string plus a NULL terminator).
     pub fn SDL_JoystickGetGUIDString(
         guid: SDL_JoystickGUID,
         pszGUID: *mut ::std::os::raw::c_char,
@@ -9699,71 +9794,71 @@ extern "C" {
     );
 }
 extern "C" {
-    /// Convert a string into a joystick guid
+    ///  Convert a string into a joystick guid
     pub fn SDL_JoystickGetGUIDFromString(
         pchGUID: *const ::std::os::raw::c_char,
     ) -> SDL_JoystickGUID;
 }
 extern "C" {
-    /// Returns SDL_TRUE if the joystick has been opened and currently connected, or SDL_FALSE if it has not.
+    ///  Returns SDL_TRUE if the joystick has been opened and currently connected, or SDL_FALSE if it has not.
     pub fn SDL_JoystickGetAttached(joystick: *mut SDL_Joystick) -> SDL_bool;
 }
 extern "C" {
-    /// Get the instance ID of an opened joystick or -1 if the joystick is invalid.
+    ///  Get the instance ID of an opened joystick or -1 if the joystick is invalid.
     pub fn SDL_JoystickInstanceID(joystick: *mut SDL_Joystick) -> SDL_JoystickID;
 }
 extern "C" {
-    /// Get the number of general axis controls on a joystick.
+    ///  Get the number of general axis controls on a joystick.
     pub fn SDL_JoystickNumAxes(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the number of trackballs on a joystick.
+    ///  Get the number of trackballs on a joystick.
     ///
-    /// Joystick trackballs have only relative motion events associated
-    /// with them and their state cannot be polled.
+    ///  Joystick trackballs have only relative motion events associated
+    ///  with them and their state cannot be polled.
     pub fn SDL_JoystickNumBalls(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the number of POV hats on a joystick.
+    ///  Get the number of POV hats on a joystick.
     pub fn SDL_JoystickNumHats(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the number of buttons on a joystick.
+    ///  Get the number of buttons on a joystick.
     pub fn SDL_JoystickNumButtons(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Update the current state of the open joysticks.
+    ///  Update the current state of the open joysticks.
     ///
-    /// This is called automatically by the event loop if any joystick
-    /// events are enabled.
+    ///  This is called automatically by the event loop if any joystick
+    ///  events are enabled.
     pub fn SDL_JoystickUpdate();
 }
 extern "C" {
-    /// Enable/disable joystick event polling.
+    ///  Enable/disable joystick event polling.
     ///
-    /// If joystick events are disabled, you must call SDL_JoystickUpdate()
-    /// yourself and check the state of the joystick when you want joystick
-    /// information.
+    ///  If joystick events are disabled, you must call SDL_JoystickUpdate()
+    ///  yourself and check the state of the joystick when you want joystick
+    ///  information.
     ///
-    /// The state can be one of ::SDL_QUERY, ::SDL_ENABLE or ::SDL_IGNORE.
+    ///  The state can be one of ::SDL_QUERY, ::SDL_ENABLE or ::SDL_IGNORE.
     pub fn SDL_JoystickEventState(state: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the current state of an axis control on a joystick.
+    ///  Get the current state of an axis control on a joystick.
     ///
-    /// The state is a value ranging from -32768 to 32767.
+    ///  The state is a value ranging from -32768 to 32767.
     ///
-    /// The axis indices start at index 0.
+    ///  The axis indices start at index 0.
     pub fn SDL_JoystickGetAxis(joystick: *mut SDL_Joystick, axis: ::std::os::raw::c_int) -> Sint16;
 }
 extern "C" {
-    /// Get the initial state of an axis control on a joystick.
+    ///  Get the initial state of an axis control on a joystick.
     ///
-    /// The state is a value ranging from -32768 to 32767.
+    ///  The state is a value ranging from -32768 to 32767.
     ///
-    /// The axis indices start at index 0.
+    ///  The axis indices start at index 0.
     ///
-    /// \return SDL_TRUE if this axis has any initial value, or SDL_FALSE if not.
+    ///  \return SDL_TRUE if this axis has any initial value, or SDL_FALSE if not.
     pub fn SDL_JoystickGetAxisInitialState(
         joystick: *mut SDL_Joystick,
         axis: ::std::os::raw::c_int,
@@ -9771,28 +9866,28 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// Get the current state of a POV hat on a joystick.
+    ///  Get the current state of a POV hat on a joystick.
     ///
-    /// The hat indices start at index 0.
+    ///  The hat indices start at index 0.
     ///
-    /// \return The return value is one of the following positions:
-    /// - ::SDL_HAT_CENTERED
-    /// - ::SDL_HAT_UP
-    /// - ::SDL_HAT_RIGHT
-    /// - ::SDL_HAT_DOWN
-    /// - ::SDL_HAT_LEFT
-    /// - ::SDL_HAT_RIGHTUP
-    /// - ::SDL_HAT_RIGHTDOWN
-    /// - ::SDL_HAT_LEFTUP
-    /// - ::SDL_HAT_LEFTDOWN
+    ///  \return The return value is one of the following positions:
+    ///           - ::SDL_HAT_CENTERED
+    ///           - ::SDL_HAT_UP
+    ///           - ::SDL_HAT_RIGHT
+    ///           - ::SDL_HAT_DOWN
+    ///           - ::SDL_HAT_LEFT
+    ///           - ::SDL_HAT_RIGHTUP
+    ///           - ::SDL_HAT_RIGHTDOWN
+    ///           - ::SDL_HAT_LEFTUP
+    ///           - ::SDL_HAT_LEFTDOWN
     pub fn SDL_JoystickGetHat(joystick: *mut SDL_Joystick, hat: ::std::os::raw::c_int) -> Uint8;
 }
 extern "C" {
-    /// Get the ball axis change since the last poll.
+    ///  Get the ball axis change since the last poll.
     ///
-    /// \return 0, or -1 if you passed it invalid parameters.
+    ///  \return 0, or -1 if you passed it invalid parameters.
     ///
-    /// The ball indices start at index 0.
+    ///  The ball indices start at index 0.
     pub fn SDL_JoystickGetBall(
         joystick: *mut SDL_Joystick,
         ball: ::std::os::raw::c_int,
@@ -9801,20 +9896,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the current state of a button on a joystick.
+    ///  Get the current state of a button on a joystick.
     ///
-    /// The button indices start at index 0.
+    ///  The button indices start at index 0.
     pub fn SDL_JoystickGetButton(
         joystick: *mut SDL_Joystick,
         button: ::std::os::raw::c_int,
     ) -> Uint8;
 }
 extern "C" {
-    /// Close a joystick previously opened with SDL_JoystickOpen().
+    ///  Trigger a rumble effect
+    ///  Each call to this function cancels any previous rumble effect, and calling it with 0 intensity stops any rumbling.
+    ///
+    ///  \param joystick The joystick to vibrate
+    ///  \param low_frequency_rumble The intensity of the low frequency (left) rumble motor, from 0 to 0xFFFF
+    ///  \param high_frequency_rumble The intensity of the high frequency (right) rumble motor, from 0 to 0xFFFF
+    ///  \param duration_ms The duration of the rumble effect, in milliseconds
+    ///
+    ///  \return 0, or -1 if rumble isn't supported on this joystick
+    pub fn SDL_JoystickRumble(
+        joystick: *mut SDL_Joystick,
+        low_frequency_rumble: Uint16,
+        high_frequency_rumble: Uint16,
+        duration_ms: Uint32,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Close a joystick previously opened with SDL_JoystickOpen().
     pub fn SDL_JoystickClose(joystick: *mut SDL_Joystick);
 }
 extern "C" {
-    /// Return the battery level of this joystick
+    ///  Return the battery level of this joystick
     pub fn SDL_JoystickCurrentPowerLevel(joystick: *mut SDL_Joystick) -> SDL_JoystickPowerLevel;
 }
 /// The gamecontroller structure used to identify an SDL game controller
@@ -9832,7 +9944,7 @@ pub enum SDL_GameControllerBindType {
     SDL_CONTROLLER_BINDTYPE_AXIS = 2,
     SDL_CONTROLLER_BINDTYPE_HAT = 3,
 }
-/// Get the SDL joystick layer binding for this controller button/axis mapping
+///  Get the SDL joystick layer binding for this controller button/axis mapping
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct SDL_GameControllerButtonBind {
@@ -9994,10 +10106,10 @@ fn bindgen_test_layout_SDL_GameControllerButtonBind() {
     );
 }
 extern "C" {
-    /// Load a set of mappings from a seekable SDL data stream (memory or file), filtered by the current SDL_GetPlatform()
-    /// A community sourced database of controllers is available at https://raw.github.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
+    ///  Load a set of mappings from a seekable SDL data stream (memory or file), filtered by the current SDL_GetPlatform()
+    ///  A community sourced database of controllers is available at https://raw.github.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
     ///
-    /// If \c freerw is non-zero, the stream will be closed after being read.
+    ///  If \c freerw is non-zero, the stream will be closed after being read.
     ///
     /// \return number of mappings added, -1 on error
     pub fn SDL_GameControllerAddMappingsFromRW(
@@ -10006,7 +10118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Add or update an existing mapping configuration
+    ///  Add or update an existing mapping configuration
     ///
     /// \return 1 if mapping is added, 0 if updated, -1 on error
     pub fn SDL_GameControllerAddMapping(
@@ -10014,53 +10126,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the number of mappings installed
+    ///  Get the number of mappings installed
     ///
-    /// \return the number of mappings
+    ///  \return the number of mappings
     pub fn SDL_GameControllerNumMappings() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Get the mapping at a particular index.
+    ///  Get the mapping at a particular index.
     ///
-    /// \return the mapping string.  Must be freed with SDL_free().  Returns NULL if the index is out of range.
+    ///  \return the mapping string.  Must be freed with SDL_free().  Returns NULL if the index is out of range.
     pub fn SDL_GameControllerMappingForIndex(
         mapping_index: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get a mapping string for a GUID
+    ///  Get a mapping string for a GUID
     ///
-    /// \return the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
+    ///  \return the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
     pub fn SDL_GameControllerMappingForGUID(guid: SDL_JoystickGUID) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get a mapping string for an open GameController
+    ///  Get a mapping string for an open GameController
     ///
-    /// \return the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
+    ///  \return the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
     pub fn SDL_GameControllerMapping(
         gamecontroller: *mut SDL_GameController,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Is the joystick on this index supported by the game controller interface?
+    ///  Is the joystick on this index supported by the game controller interface?
     pub fn SDL_IsGameController(joystick_index: ::std::os::raw::c_int) -> SDL_bool;
 }
 extern "C" {
-    /// Get the implementation dependent name of a game controller.
-    /// This can be called before any controllers are opened.
-    /// If no name can be found, this function returns NULL.
+    ///  Get the implementation dependent name of a game controller.
+    ///  This can be called before any controllers are opened.
+    ///  If no name can be found, this function returns NULL.
     pub fn SDL_GameControllerNameForIndex(
         joystick_index: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Open a game controller for use.
-    /// The index passed as an argument refers to the N'th game controller on the system.
-    /// This index is not the value which will identify this controller in future
-    /// controller events.  The joystick's instance id (::SDL_JoystickID) will be
-    /// used there instead.
+    ///  Get the mapping of a game controller.
+    ///  This can be called before any controllers are opened.
     ///
-    /// \return A controller identifier, or NULL if an error occurred.
+    ///  \return the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
+    pub fn SDL_GameControllerMappingForDeviceIndex(
+        joystick_index: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    ///  Open a game controller for use.
+    ///  The index passed as an argument refers to the N'th game controller on the system.
+    ///  This index is not the value which will identify this controller in future
+    ///  controller events.  The joystick's instance id (::SDL_JoystickID) will be
+    ///  used there instead.
+    ///
+    ///  \return A controller identifier, or NULL if an error occurred.
     pub fn SDL_GameControllerOpen(joystick_index: ::std::os::raw::c_int)
         -> *mut SDL_GameController;
 }
@@ -10069,62 +10190,70 @@ extern "C" {
     pub fn SDL_GameControllerFromInstanceID(joyid: SDL_JoystickID) -> *mut SDL_GameController;
 }
 extern "C" {
-    /// Return the name for this currently opened controller
+    ///  Return the name for this currently opened controller
     pub fn SDL_GameControllerName(
         gamecontroller: *mut SDL_GameController,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get the USB vendor ID of an opened controller, if available.
-    /// If the vendor ID isn't available this function returns 0.
+    ///  Get the player index of an opened game controller, or -1 if it's not available
+    ///
+    ///  For XInput controllers this returns the XInput user index.
+    pub fn SDL_GameControllerGetPlayerIndex(
+        gamecontroller: *mut SDL_GameController,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Get the USB vendor ID of an opened controller, if available.
+    ///  If the vendor ID isn't available this function returns 0.
     pub fn SDL_GameControllerGetVendor(gamecontroller: *mut SDL_GameController) -> Uint16;
 }
 extern "C" {
-    /// Get the USB product ID of an opened controller, if available.
-    /// If the product ID isn't available this function returns 0.
+    ///  Get the USB product ID of an opened controller, if available.
+    ///  If the product ID isn't available this function returns 0.
     pub fn SDL_GameControllerGetProduct(gamecontroller: *mut SDL_GameController) -> Uint16;
 }
 extern "C" {
-    /// Get the product version of an opened controller, if available.
-    /// If the product version isn't available this function returns 0.
+    ///  Get the product version of an opened controller, if available.
+    ///  If the product version isn't available this function returns 0.
     pub fn SDL_GameControllerGetProductVersion(gamecontroller: *mut SDL_GameController) -> Uint16;
 }
 extern "C" {
-    /// Returns SDL_TRUE if the controller has been opened and currently connected,
-    /// or SDL_FALSE if it has not.
+    ///  Returns SDL_TRUE if the controller has been opened and currently connected,
+    ///  or SDL_FALSE if it has not.
     pub fn SDL_GameControllerGetAttached(gamecontroller: *mut SDL_GameController) -> SDL_bool;
 }
 extern "C" {
-    /// Get the underlying joystick object used by a controller
+    ///  Get the underlying joystick object used by a controller
     pub fn SDL_GameControllerGetJoystick(
         gamecontroller: *mut SDL_GameController,
     ) -> *mut SDL_Joystick;
 }
 extern "C" {
-    /// Enable/disable controller event polling.
+    ///  Enable/disable controller event polling.
     ///
-    /// If controller events are disabled, you must call SDL_GameControllerUpdate()
-    /// yourself and check the state of the controller when you want controller
-    /// information.
+    ///  If controller events are disabled, you must call SDL_GameControllerUpdate()
+    ///  yourself and check the state of the controller when you want controller
+    ///  information.
     ///
-    /// The state can be one of ::SDL_QUERY, ::SDL_ENABLE or ::SDL_IGNORE.
+    ///  The state can be one of ::SDL_QUERY, ::SDL_ENABLE or ::SDL_IGNORE.
     pub fn SDL_GameControllerEventState(state: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Update the current state of the open game controllers.
+    ///  Update the current state of the open game controllers.
     ///
-    /// This is called automatically by the event loop if any game controller
-    /// events are enabled.
+    ///  This is called automatically by the event loop if any game controller
+    ///  events are enabled.
     pub fn SDL_GameControllerUpdate();
 }
 #[repr(i32)]
-/// The list of axes available from a controller
+///  The list of axes available from a controller
 ///
-/// Thumbstick axis values range from SDL_JOYSTICK_AXIS_MIN to SDL_JOYSTICK_AXIS_MAX,
-/// and are centered within ~8000 of zero, though advanced UI will allow users to set
-/// or autodetect the dead zone, which varies between controllers.
+///  Thumbstick axis values range from SDL_JOYSTICK_AXIS_MIN to SDL_JOYSTICK_AXIS_MAX,
+///  and are centered within ~8000 of zero, though advanced UI will allow users to set
+///  or autodetect the dead zone, which varies between controllers.
 ///
-/// Trigger axis values range from 0 to SDL_JOYSTICK_AXIS_MAX.
+///  Trigger axis values range from 0 to SDL_JOYSTICK_AXIS_MAX.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_GameControllerAxis {
     SDL_CONTROLLER_AXIS_INVALID = -1,
@@ -10137,38 +10266,38 @@ pub enum SDL_GameControllerAxis {
     SDL_CONTROLLER_AXIS_MAX = 6,
 }
 extern "C" {
-    /// turn this string into a axis mapping
+    ///  turn this string into a axis mapping
     pub fn SDL_GameControllerGetAxisFromString(
         pchString: *const ::std::os::raw::c_char,
     ) -> SDL_GameControllerAxis;
 }
 extern "C" {
-    /// turn this axis enum into a string mapping
+    ///  turn this axis enum into a string mapping
     pub fn SDL_GameControllerGetStringForAxis(
         axis: SDL_GameControllerAxis,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get the SDL joystick layer binding for this controller button mapping
+    ///  Get the SDL joystick layer binding for this controller button mapping
     pub fn SDL_GameControllerGetBindForAxis(
         gamecontroller: *mut SDL_GameController,
         axis: SDL_GameControllerAxis,
     ) -> SDL_GameControllerButtonBind;
 }
 extern "C" {
-    /// Get the current state of an axis control on a game controller.
+    ///  Get the current state of an axis control on a game controller.
     ///
-    /// The state is a value ranging from -32768 to 32767 (except for the triggers,
-    /// which range from 0 to 32767).
+    ///  The state is a value ranging from -32768 to 32767 (except for the triggers,
+    ///  which range from 0 to 32767).
     ///
-    /// The axis indices start at index 0.
+    ///  The axis indices start at index 0.
     pub fn SDL_GameControllerGetAxis(
         gamecontroller: *mut SDL_GameController,
         axis: SDL_GameControllerAxis,
     ) -> Sint16;
 }
 #[repr(i32)]
-/// The list of buttons available from a controller
+///  The list of buttons available from a controller
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_GameControllerButton {
     SDL_CONTROLLER_BUTTON_INVALID = -1,
@@ -10190,35 +10319,52 @@ pub enum SDL_GameControllerButton {
     SDL_CONTROLLER_BUTTON_MAX = 15,
 }
 extern "C" {
-    /// turn this string into a button mapping
+    ///  turn this string into a button mapping
     pub fn SDL_GameControllerGetButtonFromString(
         pchString: *const ::std::os::raw::c_char,
     ) -> SDL_GameControllerButton;
 }
 extern "C" {
-    /// turn this button enum into a string mapping
+    ///  turn this button enum into a string mapping
     pub fn SDL_GameControllerGetStringForButton(
         button: SDL_GameControllerButton,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// Get the SDL joystick layer binding for this controller button mapping
+    ///  Get the SDL joystick layer binding for this controller button mapping
     pub fn SDL_GameControllerGetBindForButton(
         gamecontroller: *mut SDL_GameController,
         button: SDL_GameControllerButton,
     ) -> SDL_GameControllerButtonBind;
 }
 extern "C" {
-    /// Get the current state of a button on a game controller.
+    ///  Get the current state of a button on a game controller.
     ///
-    /// The button indices start at index 0.
+    ///  The button indices start at index 0.
     pub fn SDL_GameControllerGetButton(
         gamecontroller: *mut SDL_GameController,
         button: SDL_GameControllerButton,
     ) -> Uint8;
 }
 extern "C" {
-    /// Close a controller previously opened with SDL_GameControllerOpen().
+    ///  Trigger a rumble effect
+    ///  Each call to this function cancels any previous rumble effect, and calling it with 0 intensity stops any rumbling.
+    ///
+    ///  \param gamecontroller The controller to vibrate
+    ///  \param low_frequency_rumble The intensity of the low frequency (left) rumble motor, from 0 to 0xFFFF
+    ///  \param high_frequency_rumble The intensity of the high frequency (right) rumble motor, from 0 to 0xFFFF
+    ///  \param duration_ms The duration of the rumble effect, in milliseconds
+    ///
+    ///  \return 0, or -1 if rumble isn't supported on this joystick
+    pub fn SDL_GameControllerRumble(
+        gamecontroller: *mut SDL_GameController,
+        low_frequency_rumble: Uint16,
+        high_frequency_rumble: Uint16,
+        duration_ms: Uint32,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Close a controller previously opened with SDL_GameControllerOpen().
     pub fn SDL_GameControllerClose(gamecontroller: *mut SDL_GameController);
 }
 pub type SDL_TouchID = Sint64;
@@ -10285,19 +10431,19 @@ fn bindgen_test_layout_SDL_Finger() {
     );
 }
 extern "C" {
-    /// \brief Get the number of registered touch devices.
+    ///  \brief Get the number of registered touch devices.
     pub fn SDL_GetNumTouchDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the touch ID with the given index, or 0 if the index is invalid.
+    ///  \brief Get the touch ID with the given index, or 0 if the index is invalid.
     pub fn SDL_GetTouchDevice(index: ::std::os::raw::c_int) -> SDL_TouchID;
 }
 extern "C" {
-    /// \brief Get the number of active fingers for a given touch device.
+    ///  \brief Get the number of active fingers for a given touch device.
     pub fn SDL_GetNumTouchFingers(touchID: SDL_TouchID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the finger object of the given touch, with the given index.
+    ///  \brief Get the finger object of the given touch, with the given index.
     pub fn SDL_GetTouchFinger(
         touchID: SDL_TouchID,
         index: ::std::os::raw::c_int,
@@ -10305,19 +10451,19 @@ extern "C" {
 }
 pub type SDL_GestureID = Sint64;
 extern "C" {
-    /// \brief Begin Recording a gesture on the specified touch, or all touches (-1)
+    ///  \brief Begin Recording a gesture on the specified touch, or all touches (-1)
     ///
     ///
     pub fn SDL_RecordGesture(touchId: SDL_TouchID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Save all currently loaded Dollar Gesture templates
+    ///  \brief Save all currently loaded Dollar Gesture templates
     ///
     ///
     pub fn SDL_SaveAllDollarTemplates(dst: *mut SDL_RWops) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Save a currently loaded Dollar Gesture template
+    ///  \brief Save a currently loaded Dollar Gesture template
     ///
     ///
     pub fn SDL_SaveDollarTemplate(
@@ -10326,7 +10472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Load Dollar Gesture templates from a file
+    ///  \brief Load Dollar Gesture templates from a file
     ///
     ///
     pub fn SDL_LoadDollarTemplates(
@@ -10338,82 +10484,84 @@ extern "C" {
 /// \brief The types of events that can be delivered.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_EventType {
-    /// < Unused (do not remove)
+    ///< Unused (do not remove)
     SDL_FIRSTEVENT = 0,
-    /// < User-requested quit
+    ///< User-requested quit
     SDL_QUIT = 256,
-    /// < The application is being terminated by the OS
-    /// Called on iOS in applicationWillTerminate()
-    /// Called on Android in onDestroy()
+    ///< The application is being terminated by the OS
+    ///Called on iOS in applicationWillTerminate()
+    ///Called on Android in onDestroy()
     SDL_APP_TERMINATING = 257,
-    /// < The application is low on memory, free memory if possible.
-    /// Called on iOS in applicationDidReceiveMemoryWarning()
-    /// Called on Android in onLowMemory()
+    ///< The application is low on memory, free memory if possible.
+    ///Called on iOS in applicationDidReceiveMemoryWarning()
+    ///Called on Android in onLowMemory()
     SDL_APP_LOWMEMORY = 258,
-    /// < The application is about to enter the background
-    /// Called on iOS in applicationWillResignActive()
-    /// Called on Android in onPause()
+    ///< The application is about to enter the background
+    ///Called on iOS in applicationWillResignActive()
+    ///Called on Android in onPause()
     SDL_APP_WILLENTERBACKGROUND = 259,
-    /// < The application did enter the background and may not get CPU for some time
-    /// Called on iOS in applicationDidEnterBackground()
-    /// Called on Android in onPause()
+    ///< The application did enter the background and may not get CPU for some time
+    ///Called on iOS in applicationDidEnterBackground()
+    ///Called on Android in onPause()
     SDL_APP_DIDENTERBACKGROUND = 260,
-    /// < The application is about to enter the foreground
-    /// Called on iOS in applicationWillEnterForeground()
-    /// Called on Android in onResume()
+    ///< The application is about to enter the foreground
+    ///Called on iOS in applicationWillEnterForeground()
+    ///Called on Android in onResume()
     SDL_APP_WILLENTERFOREGROUND = 261,
-    /// < The application is now interactive
-    /// Called on iOS in applicationDidBecomeActive()
-    /// Called on Android in onResume()
+    ///< The application is now interactive
+    ///Called on iOS in applicationDidBecomeActive()
+    ///Called on Android in onResume()
     SDL_APP_DIDENTERFOREGROUND = 262,
-    /// < Window state change
+    ///< Display state change
+    SDL_DISPLAYEVENT = 336,
+    ///< Window state change
     SDL_WINDOWEVENT = 512,
-    /// < System specific event
+    ///< System specific event
     SDL_SYSWMEVENT = 513,
-    /// < Key pressed
+    ///< Key pressed
     SDL_KEYDOWN = 768,
-    /// < Key released
+    ///< Key released
     SDL_KEYUP = 769,
-    /// < Keyboard text editing (composition)
+    ///< Keyboard text editing (composition)
     SDL_TEXTEDITING = 770,
-    /// < Keyboard text input
+    ///< Keyboard text input
     SDL_TEXTINPUT = 771,
-    /// < Keymap changed due to a system event such as an
-    /// input language or keyboard layout change.
+    ///< Keymap changed due to a system event such as an
+    ///input language or keyboard layout change.
     SDL_KEYMAPCHANGED = 772,
-    /// < Mouse moved
+    ///< Mouse moved
     SDL_MOUSEMOTION = 1024,
-    /// < Mouse button pressed
+    ///< Mouse button pressed
     SDL_MOUSEBUTTONDOWN = 1025,
-    /// < Mouse button released
+    ///< Mouse button released
     SDL_MOUSEBUTTONUP = 1026,
-    /// < Mouse wheel motion
+    ///< Mouse wheel motion
     SDL_MOUSEWHEEL = 1027,
-    /// < Joystick axis motion
+    ///< Joystick axis motion
     SDL_JOYAXISMOTION = 1536,
-    /// < Joystick trackball motion
+    ///< Joystick trackball motion
     SDL_JOYBALLMOTION = 1537,
-    /// < Joystick hat position change
+    ///< Joystick hat position change
     SDL_JOYHATMOTION = 1538,
-    /// < Joystick button pressed
+    ///< Joystick button pressed
     SDL_JOYBUTTONDOWN = 1539,
-    /// < Joystick button released
+    ///< Joystick button released
     SDL_JOYBUTTONUP = 1540,
-    /// < A new joystick has been inserted into the system
+    ///< A new joystick has been inserted into the system
     SDL_JOYDEVICEADDED = 1541,
-    /// < An opened joystick has been removed
+    ///< An opened joystick has been removed
     SDL_JOYDEVICEREMOVED = 1542,
-    /// < Game controller axis motion
+    ///< Game controller axis motion
     SDL_CONTROLLERAXISMOTION = 1616,
-    /// < Game controller button pressed
+    ///< Game controller button pressed
     SDL_CONTROLLERBUTTONDOWN = 1617,
-    /// < Game controller button released
+    ///< Game controller button released
     SDL_CONTROLLERBUTTONUP = 1618,
-    /// < A new Game controller has been inserted into the system
+    ///< A new Game controller has been inserted into the system
     SDL_CONTROLLERDEVICEADDED = 1619,
-    /// < An opened Game controller has been removed
+    ///< An opened Game controller has been removed
     SDL_CONTROLLERDEVICEREMOVED = 1620,
-    /// < The controller mapping was updated
+    ///< The controller mapping was updated
     SDL_CONTROLLERDEVICEREMAPPED = 1621,
     SDL_FINGERDOWN = 1792,
     SDL_FINGERUP = 1793,
@@ -10421,36 +10569,38 @@ pub enum SDL_EventType {
     SDL_DOLLARGESTURE = 2048,
     SDL_DOLLARRECORD = 2049,
     SDL_MULTIGESTURE = 2050,
-    /// < The clipboard changed
+    ///< The clipboard changed
     SDL_CLIPBOARDUPDATE = 2304,
-    /// < The system requests a file open
+    ///< The system requests a file open
     SDL_DROPFILE = 4096,
-    /// < text/plain drag-and-drop event
+    ///< text/plain drag-and-drop event
     SDL_DROPTEXT = 4097,
-    /// < A new set of drops is beginning (NULL filename)
+    ///< A new set of drops is beginning (NULL filename)
     SDL_DROPBEGIN = 4098,
-    /// < Current set of drops is now complete (NULL filename)
+    ///< Current set of drops is now complete (NULL filename)
     SDL_DROPCOMPLETE = 4099,
-    /// < A new audio device is available
+    ///< A new audio device is available
     SDL_AUDIODEVICEADDED = 4352,
-    /// < An audio device has been removed.
+    ///< An audio device has been removed.
     SDL_AUDIODEVICEREMOVED = 4353,
-    /// < The render targets have been reset and their contents need to be updated
+    ///< A sensor was updated
+    SDL_SENSORUPDATE = 4608,
+    ///< The render targets have been reset and their contents need to be updated
     SDL_RENDER_TARGETS_RESET = 8192,
-    /// < The device has been reset and all textures need to be recreated
+    ///< The device has been reset and all textures need to be recreated
     SDL_RENDER_DEVICE_RESET = 8193,
     /// Events ::SDL_USEREVENT through ::SDL_LASTEVENT are for your use,
-    /// and should be allocated with SDL_RegisterEvents()
+    ///  and should be allocated with SDL_RegisterEvents()
     SDL_USEREVENT = 32768,
-    /// This last event is only for bounding internal arrays
+    ///  This last event is only for bounding internal arrays
     SDL_LASTEVENT = 65535,
 }
-/// \brief Fields shared by every event
+///  \brief Fields shared by every event
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_CommonEvent {
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
 }
 #[test]
@@ -10486,24 +10636,135 @@ fn bindgen_test_layout_SDL_CommonEvent() {
         )
     );
 }
-/// \brief Window state change event data (event.window.*)
+///  \brief Display state change event data (event.display.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct SDL_WindowEvent {
-    /// < ::SDL_WINDOWEVENT
+pub struct SDL_DisplayEvent {
+    ///< ::SDL_DISPLAYEVENT
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The associated window
-    pub windowID: Uint32,
-    /// < ::SDL_WindowEventID
+    ///< The associated display index
+    pub display: Uint32,
+    ///< ::SDL_DisplayEventID
     pub event: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
     pub padding3: Uint8,
-    /// < event dependent data
+    ///< event dependent data
     pub data1: Sint32,
-    /// < event dependent data
+}
+#[test]
+fn bindgen_test_layout_SDL_DisplayEvent() {
+    assert_eq!(
+        ::std::mem::size_of::<SDL_DisplayEvent>(),
+        20usize,
+        concat!("Size of: ", stringify!(SDL_DisplayEvent))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SDL_DisplayEvent>(),
+        4usize,
+        concat!("Alignment of ", stringify!(SDL_DisplayEvent))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).type_ as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).timestamp as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(timestamp)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).display as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(display)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).event as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(event)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).padding1 as *const _ as usize },
+        13usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(padding1)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).padding2 as *const _ as usize },
+        14usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(padding2)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).padding3 as *const _ as usize },
+        15usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(padding3)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_DisplayEvent>())).data1 as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_DisplayEvent),
+            "::",
+            stringify!(data1)
+        )
+    );
+}
+///  \brief Window state change event data (event.window.*)
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SDL_WindowEvent {
+    ///< ::SDL_WINDOWEVENT
+    pub type_: Uint32,
+    ///< In milliseconds, populated using SDL_GetTicks()
+    pub timestamp: Uint32,
+    ///< The associated window
+    pub windowID: Uint32,
+    ///< ::SDL_WindowEventID
+    pub event: Uint8,
+    pub padding1: Uint8,
+    pub padding2: Uint8,
+    pub padding3: Uint8,
+    ///< event dependent data
+    pub data1: Sint32,
+    ///< event dependent data
     pub data2: Sint32,
 }
 #[test]
@@ -10609,23 +10870,23 @@ fn bindgen_test_layout_SDL_WindowEvent() {
         )
     );
 }
-/// \brief Keyboard button event structure (event.key.*)
+///  \brief Keyboard button event structure (event.key.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_KeyboardEvent {
-    /// < ::SDL_KEYDOWN or ::SDL_KEYUP
+    ///< ::SDL_KEYDOWN or ::SDL_KEYUP
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with keyboard focus, if any
+    ///< The window with keyboard focus, if any
     pub windowID: Uint32,
-    /// < ::SDL_PRESSED or ::SDL_RELEASED
+    ///< ::SDL_PRESSED or ::SDL_RELEASED
     pub state: Uint8,
-    /// < Non-zero if this is a key repeat
+    ///< Non-zero if this is a key repeat
     pub repeat: Uint8,
     pub padding2: Uint8,
     pub padding3: Uint8,
-    /// < The key that was pressed or released
+    ///< The key that was pressed or released
     pub keysym: SDL_Keysym,
 }
 #[test]
@@ -10721,21 +10982,21 @@ fn bindgen_test_layout_SDL_KeyboardEvent() {
         )
     );
 }
-/// \brief Keyboard text editing event structure (event.edit.*)
+///  \brief Keyboard text editing event structure (event.edit.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_TextEditingEvent {
-    /// < ::SDL_TEXTEDITING
+    ///< ::SDL_TEXTEDITING
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with keyboard focus, if any
+    ///< The window with keyboard focus, if any
     pub windowID: Uint32,
-    /// < The editing text
+    ///< The editing text
     pub text: [::std::os::raw::c_char; 32usize],
-    /// < The start cursor of selected editing text
+    ///< The start cursor of selected editing text
     pub start: Sint32,
-    /// < The length of selected editing text
+    ///< The length of selected editing text
     pub length: Sint32,
 }
 #[test]
@@ -10811,17 +11072,17 @@ fn bindgen_test_layout_SDL_TextEditingEvent() {
         )
     );
 }
-/// \brief Keyboard text input event structure (event.text.*)
+///  \brief Keyboard text input event structure (event.text.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_TextInputEvent {
-    /// < ::SDL_TEXTINPUT
+    ///< ::SDL_TEXTINPUT
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with keyboard focus, if any
+    ///< The window with keyboard focus, if any
     pub windowID: Uint32,
-    /// < The input text
+    ///< The input text
     pub text: [::std::os::raw::c_char; 32usize],
 }
 #[test]
@@ -10877,27 +11138,27 @@ fn bindgen_test_layout_SDL_TextInputEvent() {
         )
     );
 }
-/// \brief Mouse motion event structure (event.motion.*)
+///  \brief Mouse motion event structure (event.motion.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MouseMotionEvent {
-    /// < ::SDL_MOUSEMOTION
+    ///< ::SDL_MOUSEMOTION
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with mouse focus, if any
+    ///< The window with mouse focus, if any
     pub windowID: Uint32,
-    /// < The mouse instance id, or SDL_TOUCH_MOUSEID
+    ///< The mouse instance id, or SDL_TOUCH_MOUSEID
     pub which: Uint32,
-    /// < The current button state
+    ///< The current button state
     pub state: Uint32,
-    /// < X coordinate, relative to window
+    ///< X coordinate, relative to window
     pub x: Sint32,
-    /// < Y coordinate, relative to window
+    ///< Y coordinate, relative to window
     pub y: Sint32,
-    /// < The relative motion in the X direction
+    ///< The relative motion in the X direction
     pub xrel: Sint32,
-    /// < The relative motion in the Y direction
+    ///< The relative motion in the Y direction
     pub yrel: Sint32,
 }
 #[test]
@@ -11003,28 +11264,28 @@ fn bindgen_test_layout_SDL_MouseMotionEvent() {
         )
     );
 }
-/// \brief Mouse button event structure (event.button.*)
+///  \brief Mouse button event structure (event.button.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MouseButtonEvent {
-    /// < ::SDL_MOUSEBUTTONDOWN or ::SDL_MOUSEBUTTONUP
+    ///< ::SDL_MOUSEBUTTONDOWN or ::SDL_MOUSEBUTTONUP
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with mouse focus, if any
+    ///< The window with mouse focus, if any
     pub windowID: Uint32,
-    /// < The mouse instance id, or SDL_TOUCH_MOUSEID
+    ///< The mouse instance id, or SDL_TOUCH_MOUSEID
     pub which: Uint32,
-    /// < The mouse button index
+    ///< The mouse button index
     pub button: Uint8,
-    /// < ::SDL_PRESSED or ::SDL_RELEASED
+    ///< ::SDL_PRESSED or ::SDL_RELEASED
     pub state: Uint8,
-    /// < 1 for single-click, 2 for double-click, etc.
+    ///< 1 for single-click, 2 for double-click, etc.
     pub clicks: Uint8,
     pub padding1: Uint8,
-    /// < X coordinate, relative to window
+    ///< X coordinate, relative to window
     pub x: Sint32,
-    /// < Y coordinate, relative to window
+    ///< Y coordinate, relative to window
     pub y: Sint32,
 }
 #[test]
@@ -11140,23 +11401,23 @@ fn bindgen_test_layout_SDL_MouseButtonEvent() {
         )
     );
 }
-/// \brief Mouse wheel event structure (event.wheel.*)
+///  \brief Mouse wheel event structure (event.wheel.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MouseWheelEvent {
-    /// < ::SDL_MOUSEWHEEL
+    ///< ::SDL_MOUSEWHEEL
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The window with mouse focus, if any
+    ///< The window with mouse focus, if any
     pub windowID: Uint32,
-    /// < The mouse instance id, or SDL_TOUCH_MOUSEID
+    ///< The mouse instance id, or SDL_TOUCH_MOUSEID
     pub which: Uint32,
-    /// < The amount scrolled horizontally, positive to the right and negative to the left
+    ///< The amount scrolled horizontally, positive to the right and negative to the left
     pub x: Sint32,
-    /// < The amount scrolled vertically, positive away from the user and negative toward the user
+    ///< The amount scrolled vertically, positive away from the user and negative toward the user
     pub y: Sint32,
-    /// < Set to one of the SDL_MOUSEWHEEL_* defines. When FLIPPED the values in X and Y will be opposite. Multiply by -1 to change them back
+    ///< Set to one of the SDL_MOUSEWHEEL_* defines. When FLIPPED the values in X and Y will be opposite. Multiply by -1 to change them back
     pub direction: Uint32,
 }
 #[test]
@@ -11242,22 +11503,22 @@ fn bindgen_test_layout_SDL_MouseWheelEvent() {
         )
     );
 }
-/// \brief Joystick axis motion event structure (event.jaxis.*)
+///  \brief Joystick axis motion event structure (event.jaxis.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_JoyAxisEvent {
-    /// < ::SDL_JOYAXISMOTION
+    ///< ::SDL_JOYAXISMOTION
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The joystick axis index
+    ///< The joystick axis index
     pub axis: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
     pub padding3: Uint8,
-    /// < The axis value (range: -32768 to 32767)
+    ///< The axis value (range: -32768 to 32767)
     pub value: Sint16,
     pub padding4: Uint16,
 }
@@ -11364,24 +11625,24 @@ fn bindgen_test_layout_SDL_JoyAxisEvent() {
         )
     );
 }
-/// \brief Joystick trackball motion event structure (event.jball.*)
+///  \brief Joystick trackball motion event structure (event.jball.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_JoyBallEvent {
-    /// < ::SDL_JOYBALLMOTION
+    ///< ::SDL_JOYBALLMOTION
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The joystick trackball index
+    ///< The joystick trackball index
     pub ball: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
     pub padding3: Uint8,
-    /// < The relative motion in the X direction
+    ///< The relative motion in the X direction
     pub xrel: Sint16,
-    /// < The relative motion in the Y direction
+    ///< The relative motion in the Y direction
     pub yrel: Sint16,
 }
 #[test]
@@ -11487,24 +11748,24 @@ fn bindgen_test_layout_SDL_JoyBallEvent() {
         )
     );
 }
-/// \brief Joystick hat position change event structure (event.jhat.*)
+///  \brief Joystick hat position change event structure (event.jhat.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_JoyHatEvent {
-    /// < ::SDL_JOYHATMOTION
+    ///< ::SDL_JOYHATMOTION
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The joystick hat index
+    ///< The joystick hat index
     pub hat: Uint8,
-    /// < The hat position value.
-    /// \sa ::SDL_HAT_LEFTUP ::SDL_HAT_UP ::SDL_HAT_RIGHTUP
-    /// \sa ::SDL_HAT_LEFT ::SDL_HAT_CENTERED ::SDL_HAT_RIGHT
-    /// \sa ::SDL_HAT_LEFTDOWN ::SDL_HAT_DOWN ::SDL_HAT_RIGHTDOWN
+    ///< The hat position value.
+    ///   \sa ::SDL_HAT_LEFTUP ::SDL_HAT_UP ::SDL_HAT_RIGHTUP
+    ///   \sa ::SDL_HAT_LEFT ::SDL_HAT_CENTERED ::SDL_HAT_RIGHT
+    ///   \sa ::SDL_HAT_LEFTDOWN ::SDL_HAT_DOWN ::SDL_HAT_RIGHTDOWN
     ///
-    /// Note that zero means the POV is centered.
+    ///   Note that zero means the POV is centered.
     pub value: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
@@ -11592,19 +11853,19 @@ fn bindgen_test_layout_SDL_JoyHatEvent() {
         )
     );
 }
-/// \brief Joystick button event structure (event.jbutton.*)
+///  \brief Joystick button event structure (event.jbutton.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_JoyButtonEvent {
-    /// < ::SDL_JOYBUTTONDOWN or ::SDL_JOYBUTTONUP
+    ///< ::SDL_JOYBUTTONDOWN or ::SDL_JOYBUTTONUP
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The joystick button index
+    ///< The joystick button index
     pub button: Uint8,
-    /// < ::SDL_PRESSED or ::SDL_RELEASED
+    ///< ::SDL_PRESSED or ::SDL_RELEASED
     pub state: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
@@ -11692,15 +11953,15 @@ fn bindgen_test_layout_SDL_JoyButtonEvent() {
         )
     );
 }
-/// \brief Joystick device event structure (event.jdevice.*)
+///  \brief Joystick device event structure (event.jdevice.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_JoyDeviceEvent {
-    /// < ::SDL_JOYDEVICEADDED or ::SDL_JOYDEVICEREMOVED
+    ///< ::SDL_JOYDEVICEADDED or ::SDL_JOYDEVICEREMOVED
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick device index for the ADDED event, instance id for the REMOVED event
+    ///< The joystick device index for the ADDED event, instance id for the REMOVED event
     pub which: Sint32,
 }
 #[test]
@@ -11746,22 +12007,22 @@ fn bindgen_test_layout_SDL_JoyDeviceEvent() {
         )
     );
 }
-/// \brief Game controller axis motion event structure (event.caxis.*)
+///  \brief Game controller axis motion event structure (event.caxis.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_ControllerAxisEvent {
-    /// < ::SDL_CONTROLLERAXISMOTION
+    ///< ::SDL_CONTROLLERAXISMOTION
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The controller axis (SDL_GameControllerAxis)
+    ///< The controller axis (SDL_GameControllerAxis)
     pub axis: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
     pub padding3: Uint8,
-    /// < The axis value (range: -32768 to 32767)
+    ///< The axis value (range: -32768 to 32767)
     pub value: Sint16,
     pub padding4: Uint16,
 }
@@ -11878,19 +12139,19 @@ fn bindgen_test_layout_SDL_ControllerAxisEvent() {
         )
     );
 }
-/// \brief Game controller button event structure (event.cbutton.*)
+///  \brief Game controller button event structure (event.cbutton.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_ControllerButtonEvent {
-    /// < ::SDL_CONTROLLERBUTTONDOWN or ::SDL_CONTROLLERBUTTONUP
+    ///< ::SDL_CONTROLLERBUTTONDOWN or ::SDL_CONTROLLERBUTTONUP
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick instance id
+    ///< The joystick instance id
     pub which: SDL_JoystickID,
-    /// < The controller button (SDL_GameControllerButton)
+    ///< The controller button (SDL_GameControllerButton)
     pub button: Uint8,
-    /// < ::SDL_PRESSED or ::SDL_RELEASED
+    ///< ::SDL_PRESSED or ::SDL_RELEASED
     pub state: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
@@ -11986,15 +12247,15 @@ fn bindgen_test_layout_SDL_ControllerButtonEvent() {
         )
     );
 }
-/// \brief Controller device event structure (event.cdevice.*)
+///  \brief Controller device event structure (event.cdevice.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_ControllerDeviceEvent {
-    /// < ::SDL_CONTROLLERDEVICEADDED, ::SDL_CONTROLLERDEVICEREMOVED, or ::SDL_CONTROLLERDEVICEREMAPPED
+    ///< ::SDL_CONTROLLERDEVICEADDED, ::SDL_CONTROLLERDEVICEREMOVED, or ::SDL_CONTROLLERDEVICEREMAPPED
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The joystick device index for the ADDED event, instance id for the REMOVED or REMAPPED event
+    ///< The joystick device index for the ADDED event, instance id for the REMOVED or REMAPPED event
     pub which: Sint32,
 }
 #[test]
@@ -12042,17 +12303,17 @@ fn bindgen_test_layout_SDL_ControllerDeviceEvent() {
         )
     );
 }
-/// \brief Audio device event structure (event.adevice.*)
+///  \brief Audio device event structure (event.adevice.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_AudioDeviceEvent {
-    /// < ::SDL_AUDIODEVICEADDED, or ::SDL_AUDIODEVICEREMOVED
+    ///< ::SDL_AUDIODEVICEADDED, or ::SDL_AUDIODEVICEREMOVED
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The audio device index for the ADDED event (valid until next SDL_GetNumAudioDevices() call), SDL_AudioDeviceID for the REMOVED event
+    ///< The audio device index for the ADDED event (valid until next SDL_GetNumAudioDevices() call), SDL_AudioDeviceID for the REMOVED event
     pub which: Uint32,
-    /// < zero if an output device, non-zero if a capture device.
+    ///< zero if an output device, non-zero if a capture device.
     pub iscapture: Uint8,
     pub padding1: Uint8,
     pub padding2: Uint8,
@@ -12141,26 +12402,26 @@ fn bindgen_test_layout_SDL_AudioDeviceEvent() {
         )
     );
 }
-/// \brief Touch finger event structure (event.tfinger.*)
+///  \brief Touch finger event structure (event.tfinger.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_TouchFingerEvent {
-    /// < ::SDL_FINGERMOTION or ::SDL_FINGERDOWN or ::SDL_FINGERUP
+    ///< ::SDL_FINGERMOTION or ::SDL_FINGERDOWN or ::SDL_FINGERUP
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The touch device id
+    ///< The touch device id
     pub touchId: SDL_TouchID,
     pub fingerId: SDL_FingerID,
-    /// < Normalized in the range 0...1
+    ///< Normalized in the range 0...1
     pub x: f32,
-    /// < Normalized in the range 0...1
+    ///< Normalized in the range 0...1
     pub y: f32,
-    /// < Normalized in the range -1...1
+    ///< Normalized in the range -1...1
     pub dx: f32,
-    /// < Normalized in the range -1...1
+    ///< Normalized in the range -1...1
     pub dy: f32,
-    /// < Normalized in the range 0...1
+    ///< Normalized in the range 0...1
     pub pressure: f32,
 }
 #[test]
@@ -12266,15 +12527,15 @@ fn bindgen_test_layout_SDL_TouchFingerEvent() {
         )
     );
 }
-/// \brief Multiple Finger Gesture Event (event.mgesture.*)
+///  \brief Multiple Finger Gesture Event (event.mgesture.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MultiGestureEvent {
-    /// < ::SDL_MULTIGESTURE
+    ///< ::SDL_MULTIGESTURE
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The touch device id
+    ///< The touch device id
     pub touchId: SDL_TouchID,
     pub dTheta: f32,
     pub dDist: f32,
@@ -12392,18 +12653,18 @@ fn bindgen_test_layout_SDL_MultiGestureEvent() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_DollarGestureEvent {
-    /// < ::SDL_DOLLARGESTURE or ::SDL_DOLLARRECORD
+    ///< ::SDL_DOLLARGESTURE or ::SDL_DOLLARRECORD
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The touch device id
+    ///< The touch device id
     pub touchId: SDL_TouchID,
     pub gestureId: SDL_GestureID,
     pub numFingers: Uint32,
     pub error: f32,
-    /// < Normalized center of gesture
+    ///< Normalized center of gesture
     pub x: f32,
-    /// < Normalized center of gesture
+    ///< Normalized center of gesture
     pub y: f32,
 }
 #[test]
@@ -12505,19 +12766,19 @@ fn bindgen_test_layout_SDL_DollarGestureEvent() {
         )
     );
 }
-/// \brief An event used to request a file open by the system (event.drop.*)
-/// This event is enabled by default, you can disable it with SDL_EventState().
-/// \note If this event is enabled, you must free the filename in the event.
+///  \brief An event used to request a file open by the system (event.drop.*)
+///         This event is enabled by default, you can disable it with SDL_EventState().
+///  \note If this event is enabled, you must free the filename in the event.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_DropEvent {
-    /// < ::SDL_DROPBEGIN or ::SDL_DROPFILE or ::SDL_DROPTEXT or ::SDL_DROPCOMPLETE
+    ///< ::SDL_DROPBEGIN or ::SDL_DROPFILE or ::SDL_DROPTEXT or ::SDL_DROPCOMPLETE
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The file name, which should be freed with SDL_free(), is NULL on begin/complete
+    ///< The file name, which should be freed with SDL_free(), is NULL on begin/complete
     pub file: *mut ::std::os::raw::c_char,
-    /// < The window that was dropped on, if any
+    ///< The window that was dropped on, if any
     pub windowID: Uint32,
 }
 #[test]
@@ -12573,13 +12834,79 @@ fn bindgen_test_layout_SDL_DropEvent() {
         )
     );
 }
-/// \brief The "quit requested" event
+///  \brief Sensor event structure (event.sensor.*)
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SDL_SensorEvent {
+    ///< ::SDL_SENSORUPDATE
+    pub type_: Uint32,
+    ///< In milliseconds, populated using SDL_GetTicks()
+    pub timestamp: Uint32,
+    ///< The instance ID of the sensor
+    pub which: Sint32,
+    ///< Up to 6 values from the sensor - additional values can be queried using SDL_SensorGetData()
+    pub data: [f32; 6usize],
+}
+#[test]
+fn bindgen_test_layout_SDL_SensorEvent() {
+    assert_eq!(
+        ::std::mem::size_of::<SDL_SensorEvent>(),
+        36usize,
+        concat!("Size of: ", stringify!(SDL_SensorEvent))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SDL_SensorEvent>(),
+        4usize,
+        concat!("Alignment of ", stringify!(SDL_SensorEvent))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_SensorEvent>())).type_ as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_SensorEvent),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_SensorEvent>())).timestamp as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_SensorEvent),
+            "::",
+            stringify!(timestamp)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_SensorEvent>())).which as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_SensorEvent),
+            "::",
+            stringify!(which)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_SensorEvent>())).data as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_SensorEvent),
+            "::",
+            stringify!(data)
+        )
+    );
+}
+///  \brief The "quit requested" event
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_QuitEvent {
-    /// < ::SDL_QUIT
+    ///< ::SDL_QUIT
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
 }
 #[test]
@@ -12615,13 +12942,13 @@ fn bindgen_test_layout_SDL_QuitEvent() {
         )
     );
 }
-/// \brief OS Specific event
+///  \brief OS Specific event
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_OSEvent {
-    /// < ::SDL_QUIT
+    ///< ::SDL_QUIT
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
 }
 #[test]
@@ -12657,21 +12984,21 @@ fn bindgen_test_layout_SDL_OSEvent() {
         )
     );
 }
-/// \brief A user-defined event type (event.user.*)
+///  \brief A user-defined event type (event.user.*)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_UserEvent {
-    /// < ::SDL_USEREVENT through ::SDL_LASTEVENT-1
+    ///< ::SDL_USEREVENT through ::SDL_LASTEVENT-1
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < The associated window if any
+    ///< The associated window if any
     pub windowID: Uint32,
-    /// < User defined event code
+    ///< User defined event code
     pub code: Sint32,
-    /// < User defined data pointer
+    ///< User defined data pointer
     pub data1: *mut ::std::os::raw::c_void,
-    /// < User defined data pointer
+    ///< User defined data pointer
     pub data2: *mut ::std::os::raw::c_void,
 }
 #[test]
@@ -12747,18 +13074,18 @@ fn bindgen_test_layout_SDL_UserEvent() {
         )
     );
 }
-/// \brief A video driver dependent system event (event.syswm.*)
-/// This event is disabled by default, you can enable it with SDL_EventState()
+///  \brief A video driver dependent system event (event.syswm.*)
+///         This event is disabled by default, you can enable it with SDL_EventState()
 ///
-/// \note If you want to use this event, you should include SDL_syswm.h.
+///  \note If you want to use this event, you should include SDL_syswm.h.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_SysWMEvent {
-    /// < ::SDL_SYSWMEVENT
+    ///< ::SDL_SYSWMEVENT
     pub type_: Uint32,
-    /// < In milliseconds, populated using SDL_GetTicks()
+    ///< In milliseconds, populated using SDL_GetTicks()
     pub timestamp: Uint32,
-    /// < driver dependent data, defined in SDL_syswm.h
+    ///< driver dependent data, defined in SDL_syswm.h
     pub msg: *mut SDL_SysWMmsg,
 }
 #[test]
@@ -12804,59 +13131,63 @@ fn bindgen_test_layout_SDL_SysWMEvent() {
         )
     );
 }
-/// \brief General event structure
+///  \brief General event structure
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union SDL_Event {
-    /// < Event type, shared with all events
+    ///< Event type, shared with all events
     pub type_: Uint32,
-    /// < Common event data
+    ///< Common event data
     pub common: SDL_CommonEvent,
-    /// < Window event data
+    ///< Window event data
+    pub display: SDL_DisplayEvent,
+    ///< Window event data
     pub window: SDL_WindowEvent,
-    /// < Keyboard event data
+    ///< Keyboard event data
     pub key: SDL_KeyboardEvent,
-    /// < Text editing event data
+    ///< Text editing event data
     pub edit: SDL_TextEditingEvent,
-    /// < Text input event data
+    ///< Text input event data
     pub text: SDL_TextInputEvent,
-    /// < Mouse motion event data
+    ///< Mouse motion event data
     pub motion: SDL_MouseMotionEvent,
-    /// < Mouse button event data
+    ///< Mouse button event data
     pub button: SDL_MouseButtonEvent,
-    /// < Mouse wheel event data
+    ///< Mouse wheel event data
     pub wheel: SDL_MouseWheelEvent,
-    /// < Joystick axis event data
+    ///< Joystick axis event data
     pub jaxis: SDL_JoyAxisEvent,
-    /// < Joystick ball event data
+    ///< Joystick ball event data
     pub jball: SDL_JoyBallEvent,
-    /// < Joystick hat event data
+    ///< Joystick hat event data
     pub jhat: SDL_JoyHatEvent,
-    /// < Joystick button event data
+    ///< Joystick button event data
     pub jbutton: SDL_JoyButtonEvent,
-    /// < Joystick device change event data
+    ///< Joystick device change event data
     pub jdevice: SDL_JoyDeviceEvent,
-    /// < Game Controller axis event data
+    ///< Game Controller axis event data
     pub caxis: SDL_ControllerAxisEvent,
-    /// < Game Controller button event data
+    ///< Game Controller button event data
     pub cbutton: SDL_ControllerButtonEvent,
-    /// < Game Controller device event data
+    ///< Game Controller device event data
     pub cdevice: SDL_ControllerDeviceEvent,
-    /// < Audio device event data
+    ///< Audio device event data
     pub adevice: SDL_AudioDeviceEvent,
-    /// < Quit request event data
+    ///< Sensor event data
+    pub sensor: SDL_SensorEvent,
+    ///< Quit request event data
     pub quit: SDL_QuitEvent,
-    /// < Custom event data
+    ///< Custom event data
     pub user: SDL_UserEvent,
-    /// < System dependent window event data
+    ///< System dependent window event data
     pub syswm: SDL_SysWMEvent,
-    /// < Touch finger event data
+    ///< Touch finger event data
     pub tfinger: SDL_TouchFingerEvent,
-    /// < Gesture event data
+    ///< Gesture event data
     pub mgesture: SDL_MultiGestureEvent,
-    /// < Gesture event data
+    ///< Gesture event data
     pub dgesture: SDL_DollarGestureEvent,
-    /// < Drag and drop event data
+    ///< Drag and drop event data
     pub drop: SDL_DropEvent,
     pub padding: [Uint8; 56usize],
     _bindgen_union_align: [u64; 7usize],
@@ -12891,6 +13222,16 @@ fn bindgen_test_layout_SDL_Event() {
             stringify!(SDL_Event),
             "::",
             stringify!(common)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_Event>())).display as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_Event),
+            "::",
+            stringify!(display)
         )
     );
     assert_eq!(
@@ -13054,6 +13395,16 @@ fn bindgen_test_layout_SDL_Event() {
         )
     );
     assert_eq!(
+        unsafe { &(*(::std::ptr::null::<SDL_Event>())).sensor as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SDL_Event),
+            "::",
+            stringify!(sensor)
+        )
+    );
+    assert_eq!(
         unsafe { &(*(::std::ptr::null::<SDL_Event>())).quit as *const _ as usize },
         0usize,
         concat!(
@@ -13135,11 +13486,11 @@ fn bindgen_test_layout_SDL_Event() {
     );
 }
 extern "C" {
-    /// Pumps the event loop, gathering events from the input devices.
+    ///  Pumps the event loop, gathering events from the input devices.
     ///
-    /// This function updates the event queue and internal input device state.
+    ///  This function updates the event queue and internal input device state.
     ///
-    /// This should only be run in the thread that sets the video mode.
+    ///  This should only be run in the thread that sets the video mode.
     pub fn SDL_PumpEvents();
 }
 #[repr(u32)]
@@ -13150,22 +13501,22 @@ pub enum SDL_eventaction {
     SDL_GETEVENT = 2,
 }
 extern "C" {
-    /// Checks the event queue for messages and optionally returns them.
+    ///  Checks the event queue for messages and optionally returns them.
     ///
-    /// If \c action is ::SDL_ADDEVENT, up to \c numevents events will be added to
-    /// the back of the event queue.
+    ///  If \c action is ::SDL_ADDEVENT, up to \c numevents events will be added to
+    ///  the back of the event queue.
     ///
-    /// If \c action is ::SDL_PEEKEVENT, up to \c numevents events at the front
-    /// of the event queue, within the specified minimum and maximum type,
-    /// will be returned and will not be removed from the queue.
+    ///  If \c action is ::SDL_PEEKEVENT, up to \c numevents events at the front
+    ///  of the event queue, within the specified minimum and maximum type,
+    ///  will be returned and will not be removed from the queue.
     ///
-    /// If \c action is ::SDL_GETEVENT, up to \c numevents events at the front
-    /// of the event queue, within the specified minimum and maximum type,
-    /// will be returned and will be removed from the queue.
+    ///  If \c action is ::SDL_GETEVENT, up to \c numevents events at the front
+    ///  of the event queue, within the specified minimum and maximum type,
+    ///  will be returned and will be removed from the queue.
     ///
-    /// \return The number of events actually stored, or -1 if there was an error.
+    ///  \return The number of events actually stored, or -1 if there was an error.
     ///
-    /// This function is thread-safe.
+    ///  This function is thread-safe.
     pub fn SDL_PeepEvents(
         events: *mut SDL_Event,
         numevents: ::std::os::raw::c_int,
@@ -13175,150 +13526,152 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// Checks to see if certain event types are in the event queue.
+    ///  Checks to see if certain event types are in the event queue.
     pub fn SDL_HasEvent(type_: Uint32) -> SDL_bool;
 }
 extern "C" {
     pub fn SDL_HasEvents(minType: Uint32, maxType: Uint32) -> SDL_bool;
 }
 extern "C" {
-    /// This function clears events from the event queue
-    /// This function only affects currently queued events. If you want to make
-    /// sure that all pending OS events are flushed, you can call SDL_PumpEvents()
-    /// on the main thread immediately before the flush call.
+    ///  This function clears events from the event queue
+    ///  This function only affects currently queued events. If you want to make
+    ///  sure that all pending OS events are flushed, you can call SDL_PumpEvents()
+    ///  on the main thread immediately before the flush call.
     pub fn SDL_FlushEvent(type_: Uint32);
 }
 extern "C" {
     pub fn SDL_FlushEvents(minType: Uint32, maxType: Uint32);
 }
 extern "C" {
-    /// \brief Polls for currently pending events.
+    ///  \brief Polls for currently pending events.
     ///
-    /// \return 1 if there are any pending events, or 0 if there are none available.
+    ///  \return 1 if there are any pending events, or 0 if there are none available.
     ///
-    /// \param event If not NULL, the next event is removed from the queue and
-    /// stored in that area.
+    ///  \param event If not NULL, the next event is removed from the queue and
+    ///               stored in that area.
     pub fn SDL_PollEvent(event: *mut SDL_Event) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Waits indefinitely for the next available event.
+    ///  \brief Waits indefinitely for the next available event.
     ///
-    /// \return 1, or 0 if there was an error while waiting for events.
+    ///  \return 1, or 0 if there was an error while waiting for events.
     ///
-    /// \param event If not NULL, the next event is removed from the queue and
-    /// stored in that area.
+    ///  \param event If not NULL, the next event is removed from the queue and
+    ///               stored in that area.
     pub fn SDL_WaitEvent(event: *mut SDL_Event) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Waits until the specified timeout (in milliseconds) for the next
-    /// available event.
+    ///  \brief Waits until the specified timeout (in milliseconds) for the next
+    ///         available event.
     ///
-    /// \return 1, or 0 if there was an error while waiting for events.
+    ///  \return 1, or 0 if there was an error while waiting for events.
     ///
-    /// \param event If not NULL, the next event is removed from the queue and
-    /// stored in that area.
-    /// \param timeout The timeout (in milliseconds) to wait for next event.
+    ///  \param event If not NULL, the next event is removed from the queue and
+    ///               stored in that area.
+    ///  \param timeout The timeout (in milliseconds) to wait for next event.
     pub fn SDL_WaitEventTimeout(
         event: *mut SDL_Event,
         timeout: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Add an event to the event queue.
+    ///  \brief Add an event to the event queue.
     ///
-    /// \return 1 on success, 0 if the event was filtered, or -1 if the event queue
-    /// was full or there was some other error.
+    ///  \return 1 on success, 0 if the event was filtered, or -1 if the event queue
+    ///          was full or there was some other error.
     pub fn SDL_PushEvent(event: *mut SDL_Event) -> ::std::os::raw::c_int;
 }
 pub type SDL_EventFilter = ::std::option::Option<
-    unsafe extern "C" fn(userdata: *mut ::std::os::raw::c_void, event: *mut SDL_Event)
-        -> ::std::os::raw::c_int,
+    unsafe extern "C" fn(
+        userdata: *mut ::std::os::raw::c_void,
+        event: *mut SDL_Event,
+    ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    /// Sets up a filter to process all events before they change internal state and
-    /// are posted to the internal event queue.
+    ///  Sets up a filter to process all events before they change internal state and
+    ///  are posted to the internal event queue.
     ///
-    /// The filter is prototyped as:
-    /// \code
-    /// int SDL_EventFilter(void *userdata, SDL_Event * event);
-    /// \endcode
+    ///  The filter is prototyped as:
+    ///  \code
+    ///      int SDL_EventFilter(void *userdata, SDL_Event * event);
+    ///  \endcode
     ///
-    /// If the filter returns 1, then the event will be added to the internal queue.
-    /// If it returns 0, then the event will be dropped from the queue, but the
-    /// internal state will still be updated.  This allows selective filtering of
-    /// dynamically arriving events.
+    ///  If the filter returns 1, then the event will be added to the internal queue.
+    ///  If it returns 0, then the event will be dropped from the queue, but the
+    ///  internal state will still be updated.  This allows selective filtering of
+    ///  dynamically arriving events.
     ///
-    /// \warning  Be very careful of what you do in the event filter function, as
-    /// it may run in a different thread!
+    ///  \warning  Be very careful of what you do in the event filter function, as
+    ///            it may run in a different thread!
     ///
-    /// There is one caveat when dealing with the ::SDL_QuitEvent event type.  The
-    /// event filter is only called when the window manager desires to close the
-    /// application window.  If the event filter returns 1, then the window will
-    /// be closed, otherwise the window will remain open if possible.
+    ///  There is one caveat when dealing with the ::SDL_QuitEvent event type.  The
+    ///  event filter is only called when the window manager desires to close the
+    ///  application window.  If the event filter returns 1, then the window will
+    ///  be closed, otherwise the window will remain open if possible.
     ///
-    /// If the quit event is generated by an interrupt signal, it will bypass the
-    /// internal queue and be delivered to the application at the next event poll.
+    ///  If the quit event is generated by an interrupt signal, it will bypass the
+    ///  internal queue and be delivered to the application at the next event poll.
     pub fn SDL_SetEventFilter(filter: SDL_EventFilter, userdata: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    /// Return the current event filter - can be used to "chain" filters.
-    /// If there is no event filter set, this function returns SDL_FALSE.
+    ///  Return the current event filter - can be used to "chain" filters.
+    ///  If there is no event filter set, this function returns SDL_FALSE.
     pub fn SDL_GetEventFilter(
         filter: *mut SDL_EventFilter,
         userdata: *mut *mut ::std::os::raw::c_void,
     ) -> SDL_bool;
 }
 extern "C" {
-    /// Add a function which is called when an event is added to the queue.
+    ///  Add a function which is called when an event is added to the queue.
     pub fn SDL_AddEventWatch(filter: SDL_EventFilter, userdata: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    /// Remove an event watch function added with SDL_AddEventWatch()
+    ///  Remove an event watch function added with SDL_AddEventWatch()
     pub fn SDL_DelEventWatch(filter: SDL_EventFilter, userdata: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    /// Run the filter function on the current event queue, removing any
-    /// events for which the filter returns 0.
+    ///  Run the filter function on the current event queue, removing any
+    ///  events for which the filter returns 0.
     pub fn SDL_FilterEvents(filter: SDL_EventFilter, userdata: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    /// This function allows you to set the state of processing certain events.
-    /// - If \c state is set to ::SDL_IGNORE, that event will be automatically
-    /// dropped from the event queue and will not be filtered.
-    /// - If \c state is set to ::SDL_ENABLE, that event will be processed
-    /// normally.
-    /// - If \c state is set to ::SDL_QUERY, SDL_EventState() will return the
-    /// current processing state of the specified event.
+    ///  This function allows you to set the state of processing certain events.
+    ///   - If \c state is set to ::SDL_IGNORE, that event will be automatically
+    ///     dropped from the event queue and will not be filtered.
+    ///   - If \c state is set to ::SDL_ENABLE, that event will be processed
+    ///     normally.
+    ///   - If \c state is set to ::SDL_QUERY, SDL_EventState() will return the
+    ///     current processing state of the specified event.
     pub fn SDL_EventState(type_: Uint32, state: ::std::os::raw::c_int) -> Uint8;
 }
 extern "C" {
-    /// This function allocates a set of user-defined events, and returns
-    /// the beginning event number for that set of events.
+    ///  This function allocates a set of user-defined events, and returns
+    ///  the beginning event number for that set of events.
     ///
-    /// If there aren't enough user-defined events left, this function
-    /// returns (Uint32)-1
+    ///  If there aren't enough user-defined events left, this function
+    ///  returns (Uint32)-1
     pub fn SDL_RegisterEvents(numevents: ::std::os::raw::c_int) -> Uint32;
 }
 extern "C" {
     /// \brief Get the path where the application resides.
     ///
     /// Get the "base path". This is the directory where the application was run
-    /// from, which is probably the installation directory, and may or may not
-    /// be the process's current working directory.
+    ///  from, which is probably the installation directory, and may or may not
+    ///  be the process's current working directory.
     ///
     /// This returns an absolute path in UTF-8 encoding, and is guaranteed to
-    /// end with a path separator ('\\' on Windows, '/' most other places).
+    ///  end with a path separator ('\\' on Windows, '/' most other places).
     ///
     /// The pointer returned by this function is owned by you. Please call
-    /// SDL_free() on the pointer when you are done with it, or it will be a
-    /// memory leak. This is not necessarily a fast call, though, so you should
-    /// call this once near startup and save the string if you need it.
+    ///  SDL_free() on the pointer when you are done with it, or it will be a
+    ///  memory leak. This is not necessarily a fast call, though, so you should
+    ///  call this once near startup and save the string if you need it.
     ///
     /// Some platforms can't determine the application's path, and on other
-    /// platforms, this might be meaningless. In such cases, this function will
-    /// return NULL.
+    ///  platforms, this might be meaningless. In such cases, this function will
+    ///  return NULL.
     ///
-    /// \return String of base dir in UTF-8 encoding, or NULL on error.
+    ///  \return String of base dir in UTF-8 encoding, or NULL on error.
     ///
     /// \sa SDL_GetPrefPath
     pub fn SDL_GetBasePath() -> *mut ::std::os::raw::c_char;
@@ -13327,60 +13680,60 @@ extern "C" {
     /// \brief Get the user-and-app-specific path where files can be written.
     ///
     /// Get the "pref dir". This is meant to be where users can write personal
-    /// files (preferences and save games, etc) that are specific to your
-    /// application. This directory is unique per user, per application.
+    ///  files (preferences and save games, etc) that are specific to your
+    ///  application. This directory is unique per user, per application.
     ///
     /// This function will decide the appropriate location in the native filesystem,
-    /// create the directory if necessary, and return a string of the absolute
-    /// path to the directory in UTF-8 encoding.
+    ///  create the directory if necessary, and return a string of the absolute
+    ///  path to the directory in UTF-8 encoding.
     ///
     /// On Windows, the string might look like:
-    /// "C:\\Users\\bob\\AppData\\Roaming\\My Company\\My Program Name\\"
+    ///  "C:\\Users\\bob\\AppData\\Roaming\\My Company\\My Program Name\\"
     ///
     /// On Linux, the string might look like:
-    /// "/home/bob/.local/share/My Program Name/"
+    ///  "/home/bob/.local/share/My Program Name/"
     ///
     /// On Mac OS X, the string might look like:
-    /// "/Users/bob/Library/Application Support/My Program Name/"
+    ///  "/Users/bob/Library/Application Support/My Program Name/"
     ///
     /// (etc.)
     ///
     /// You specify the name of your organization (if it's not a real organization,
-    /// your name or an Internet domain you own might do) and the name of your
-    /// application. These should be untranslated proper names.
+    ///  your name or an Internet domain you own might do) and the name of your
+    ///  application. These should be untranslated proper names.
     ///
     /// Both the org and app strings may become part of a directory name, so
-    /// please follow these rules:
+    ///  please follow these rules:
     ///
-    /// - Try to use the same org string (including case-sensitivity) for
-    /// all your applications that use this function.
-    /// - Always use a unique app string for each one, and make sure it never
-    /// changes for an app once you've decided on it.
-    /// - Unicode characters are legal, as long as it's UTF-8 encoded, but...
-    /// - ...only use letters, numbers, and spaces. Avoid punctuation like
-    /// "Game Name 2: Bad Guy's Revenge!" ... "Game Name 2" is sufficient.
+    ///    - Try to use the same org string (including case-sensitivity) for
+    ///      all your applications that use this function.
+    ///    - Always use a unique app string for each one, and make sure it never
+    ///      changes for an app once you've decided on it.
+    ///    - Unicode characters are legal, as long as it's UTF-8 encoded, but...
+    ///    - ...only use letters, numbers, and spaces. Avoid punctuation like
+    ///      "Game Name 2: Bad Guy's Revenge!" ... "Game Name 2" is sufficient.
     ///
     /// This returns an absolute path in UTF-8 encoding, and is guaranteed to
-    /// end with a path separator ('\\' on Windows, '/' most other places).
+    ///  end with a path separator ('\\' on Windows, '/' most other places).
     ///
     /// The pointer returned by this function is owned by you. Please call
-    /// SDL_free() on the pointer when you are done with it, or it will be a
-    /// memory leak. This is not necessarily a fast call, though, so you should
-    /// call this once near startup and save the string if you need it.
+    ///  SDL_free() on the pointer when you are done with it, or it will be a
+    ///  memory leak. This is not necessarily a fast call, though, so you should
+    ///  call this once near startup and save the string if you need it.
     ///
     /// You should assume the path returned by this function is the only safe
-    /// place to write files (and that SDL_GetBasePath(), while it might be
-    /// writable, or even the parent of the returned path, aren't where you
-    /// should be writing things).
+    ///  place to write files (and that SDL_GetBasePath(), while it might be
+    ///  writable, or even the parent of the returned path, aren't where you
+    ///  should be writing things).
     ///
     /// Some platforms can't determine the pref path, and on other
-    /// platforms, this might be meaningless. In such cases, this function will
-    /// return NULL.
+    ///  platforms, this might be meaningless. In such cases, this function will
+    ///  return NULL.
     ///
-    /// \param org The name of your organization.
-    /// \param app The name of your application.
-    /// \return UTF-8 string of user dir in platform-dependent notation. NULL
-    /// if there's a problem (creating directory failed, etc).
+    ///   \param org The name of your organization.
+    ///   \param app The name of your application.
+    ///  \return UTF-8 string of user dir in platform-dependent notation. NULL
+    ///          if there's a problem (creating directory failed, etc).
     ///
     /// \sa SDL_GetBasePath
     pub fn SDL_GetPrefPath(
@@ -13388,118 +13741,118 @@ extern "C" {
         app: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-/// \typedef SDL_Haptic
+///  \typedef SDL_Haptic
 ///
-/// \brief The haptic structure used to identify an SDL haptic.
+///  \brief The haptic structure used to identify an SDL haptic.
 ///
-/// \sa SDL_HapticOpen
-/// \sa SDL_HapticOpenFromJoystick
-/// \sa SDL_HapticClose
+///  \sa SDL_HapticOpen
+///  \sa SDL_HapticOpenFromJoystick
+///  \sa SDL_HapticClose
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _SDL_Haptic {
     _unused: [u8; 0],
 }
 pub type SDL_Haptic = _SDL_Haptic;
-/// \brief Structure that represents a haptic direction.
+///  \brief Structure that represents a haptic direction.
 ///
-/// This is the direction where the force comes from,
-/// instead of the direction in which the force is exerted.
+///  This is the direction where the force comes from,
+///  instead of the direction in which the force is exerted.
 ///
-/// Directions can be specified by:
-/// - ::SDL_HAPTIC_POLAR : Specified by polar coordinates.
-/// - ::SDL_HAPTIC_CARTESIAN : Specified by cartesian coordinates.
-/// - ::SDL_HAPTIC_SPHERICAL : Specified by spherical coordinates.
+///  Directions can be specified by:
+///   - ::SDL_HAPTIC_POLAR : Specified by polar coordinates.
+///   - ::SDL_HAPTIC_CARTESIAN : Specified by cartesian coordinates.
+///   - ::SDL_HAPTIC_SPHERICAL : Specified by spherical coordinates.
 ///
-/// Cardinal directions of the haptic device are relative to the positioning
-/// of the device.  North is considered to be away from the user.
+///  Cardinal directions of the haptic device are relative to the positioning
+///  of the device.  North is considered to be away from the user.
 ///
-/// The following diagram represents the cardinal directions:
-/// \verbatim
-/// .--.
-/// |__| .-------.
-/// |=.| |.-----.|
-/// |--| ||     ||
-/// |  | |'-----'|
-/// |__|~')_____('
-/// [ COMPUTER ]
-///
-///
-/// North (0,-1)
-/// ^
-/// |
-/// |
-/// (-1,0)  West <----[ HAPTIC ]----> East (1,0)
-/// |
-/// |
-/// v
-/// South (0,1)
+///  The following diagram represents the cardinal directions:
+///  \verbatim
+///.--.
+///|__| .-------.
+///|=.| |.-----.|
+///|--| ||     ||
+///|  | |'-----'|
+///|__|~')_____('
+///[ COMPUTER ]
 ///
 ///
-/// [ USER ]
-/// \|||/
-/// (o o)
-/// ---ooO-(_)-Ooo---
-/// \endverbatim
-///
-/// If type is ::SDL_HAPTIC_POLAR, direction is encoded by hundredths of a
-/// degree starting north and turning clockwise.  ::SDL_HAPTIC_POLAR only uses
-/// the first \c dir parameter.  The cardinal directions would be:
-/// - North: 0 (0 degrees)
-/// - East: 9000 (90 degrees)
-/// - South: 18000 (180 degrees)
-/// - West: 27000 (270 degrees)
-///
-/// If type is ::SDL_HAPTIC_CARTESIAN, direction is encoded by three positions
-/// (X axis, Y axis and Z axis (with 3 axes)).  ::SDL_HAPTIC_CARTESIAN uses
-/// the first three \c dir parameters.  The cardinal directions would be:
-/// - North:  0,-1, 0
-/// - East:   1, 0, 0
-/// - South:  0, 1, 0
-/// - West:  -1, 0, 0
-///
-/// The Z axis represents the height of the effect if supported, otherwise
-/// it's unused.  In cartesian encoding (1, 2) would be the same as (2, 4), you
-/// can use any multiple you want, only the direction matters.
-///
-/// If type is ::SDL_HAPTIC_SPHERICAL, direction is encoded by two rotations.
-/// The first two \c dir parameters are used.  The \c dir parameters are as
-/// follows (all values are in hundredths of degrees):
-/// - Degrees from (1, 0) rotated towards (0, 1).
-/// - Degrees towards (0, 0, 1) (device needs at least 3 axes).
+///North (0,-1)
+///^
+///|
+///|
+///(-1,0)  West <----[ HAPTIC ]----> East (1,0)
+///|
+///|
+///v
+///South (0,1)
 ///
 ///
-/// Example of force coming from the south with all encodings (force coming
-/// from the south means the user will have to pull the stick to counteract):
-/// \code
-/// SDL_HapticDirection direction;
+///[ USER ]
+///\|||/
+///(o o)
+///---ooO-(_)-Ooo---
+///\endverbatim
 ///
-/// // Cartesian directions
-/// direction.type = SDL_HAPTIC_CARTESIAN; // Using cartesian direction encoding.
-/// direction.dir[0] = 0; // X position
-/// direction.dir[1] = 1; // Y position
-/// // Assuming the device has 2 axes, we don't need to specify third parameter.
+///  If type is ::SDL_HAPTIC_POLAR, direction is encoded by hundredths of a
+///  degree starting north and turning clockwise.  ::SDL_HAPTIC_POLAR only uses
+///  the first \c dir parameter.  The cardinal directions would be:
+///   - North: 0 (0 degrees)
+///   - East: 9000 (90 degrees)
+///   - South: 18000 (180 degrees)
+///   - West: 27000 (270 degrees)
 ///
-/// // Polar directions
-/// direction.type = SDL_HAPTIC_POLAR; // We'll be using polar direction encoding.
-/// direction.dir[0] = 18000; // Polar only uses first parameter
+///  If type is ::SDL_HAPTIC_CARTESIAN, direction is encoded by three positions
+///  (X axis, Y axis and Z axis (with 3 axes)).  ::SDL_HAPTIC_CARTESIAN uses
+///  the first three \c dir parameters.  The cardinal directions would be:
+///   - North:  0,-1, 0
+///   - East:   1, 0, 0
+///   - South:  0, 1, 0
+///   - West:  -1, 0, 0
 ///
-/// // Spherical coordinates
-/// direction.type = SDL_HAPTIC_SPHERICAL; // Spherical encoding
-/// direction.dir[0] = 9000; // Since we only have two axes we don't need more parameters.
-/// \endcode
+///  The Z axis represents the height of the effect if supported, otherwise
+///  it's unused.  In cartesian encoding (1, 2) would be the same as (2, 4), you
+///  can use any multiple you want, only the direction matters.
 ///
-/// \sa SDL_HAPTIC_POLAR
-/// \sa SDL_HAPTIC_CARTESIAN
-/// \sa SDL_HAPTIC_SPHERICAL
-/// \sa SDL_HapticEffect
-/// \sa SDL_HapticNumAxes
+///  If type is ::SDL_HAPTIC_SPHERICAL, direction is encoded by two rotations.
+///  The first two \c dir parameters are used.  The \c dir parameters are as
+///  follows (all values are in hundredths of degrees):
+///   - Degrees from (1, 0) rotated towards (0, 1).
+///   - Degrees towards (0, 0, 1) (device needs at least 3 axes).
+///
+///
+///  Example of force coming from the south with all encodings (force coming
+///  from the south means the user will have to pull the stick to counteract):
+///  \code
+///  SDL_HapticDirection direction;
+///
+///  // Cartesian directions
+///  direction.type = SDL_HAPTIC_CARTESIAN; // Using cartesian direction encoding.
+///  direction.dir[0] = 0; // X position
+///  direction.dir[1] = 1; // Y position
+///  // Assuming the device has 2 axes, we don't need to specify third parameter.
+///
+///  // Polar directions
+///  direction.type = SDL_HAPTIC_POLAR; // We'll be using polar direction encoding.
+///  direction.dir[0] = 18000; // Polar only uses first parameter
+///
+///  // Spherical coordinates
+///  direction.type = SDL_HAPTIC_SPHERICAL; // Spherical encoding
+///  direction.dir[0] = 9000; // Since we only have two axes we don't need more parameters.
+///  \endcode
+///
+///  \sa SDL_HAPTIC_POLAR
+///  \sa SDL_HAPTIC_CARTESIAN
+///  \sa SDL_HAPTIC_SPHERICAL
+///  \sa SDL_HapticEffect
+///  \sa SDL_HapticNumAxes
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticDirection {
-    /// < The type of encoding.
+    ///< The type of encoding.
     pub type_: Uint8,
-    /// < The encoded direction.
+    ///< The encoded direction.
     pub dir: [Sint32; 3usize],
 }
 #[test]
@@ -13535,39 +13888,39 @@ fn bindgen_test_layout_SDL_HapticDirection() {
         )
     );
 }
-/// \brief A structure containing a template for a Constant effect.
+///  \brief A structure containing a template for a Constant effect.
 ///
-/// This struct is exclusively for the ::SDL_HAPTIC_CONSTANT effect.
+///  This struct is exclusively for the ::SDL_HAPTIC_CONSTANT effect.
 ///
-/// A constant effect applies a constant force in the specified direction
-/// to the joystick.
+///  A constant effect applies a constant force in the specified direction
+///  to the joystick.
 ///
-/// \sa SDL_HAPTIC_CONSTANT
-/// \sa SDL_HapticEffect
+///  \sa SDL_HAPTIC_CONSTANT
+///  \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticConstant {
-    /// < ::SDL_HAPTIC_CONSTANT
+    ///< ::SDL_HAPTIC_CONSTANT
     pub type_: Uint16,
-    /// < Direction of the effect.
+    ///< Direction of the effect.
     pub direction: SDL_HapticDirection,
-    /// < Duration of the effect.
+    ///< Duration of the effect.
     pub length: Uint32,
-    /// < Delay before starting the effect.
+    ///< Delay before starting the effect.
     pub delay: Uint16,
-    /// < Button that triggers the effect.
+    ///< Button that triggers the effect.
     pub button: Uint16,
-    /// < How soon it can be triggered again after button.
+    ///< How soon it can be triggered again after button.
     pub interval: Uint16,
-    /// < Strength of the constant effect.
+    ///< Strength of the constant effect.
     pub level: Sint16,
-    /// < Duration of the attack.
+    ///< Duration of the attack.
     pub attack_length: Uint16,
-    /// < Level at the start of the attack.
+    ///< Level at the start of the attack.
     pub attack_level: Uint16,
-    /// < Duration of the fade.
+    ///< Duration of the fade.
     pub fade_length: Uint16,
-    /// < Level at the end of the fade.
+    ///< Level at the end of the fade.
     pub fade_level: Uint16,
 }
 #[test]
@@ -13695,93 +14048,93 @@ fn bindgen_test_layout_SDL_HapticConstant() {
         )
     );
 }
-/// \brief A structure containing a template for a Periodic effect.
+///  \brief A structure containing a template for a Periodic effect.
 ///
-/// The struct handles the following effects:
-/// - ::SDL_HAPTIC_SINE
-/// - ::SDL_HAPTIC_LEFTRIGHT
-/// - ::SDL_HAPTIC_TRIANGLE
-/// - ::SDL_HAPTIC_SAWTOOTHUP
-/// - ::SDL_HAPTIC_SAWTOOTHDOWN
+///  The struct handles the following effects:
+///   - ::SDL_HAPTIC_SINE
+///   - ::SDL_HAPTIC_LEFTRIGHT
+///   - ::SDL_HAPTIC_TRIANGLE
+///   - ::SDL_HAPTIC_SAWTOOTHUP
+///   - ::SDL_HAPTIC_SAWTOOTHDOWN
 ///
-/// A periodic effect consists in a wave-shaped effect that repeats itself
-/// over time.  The type determines the shape of the wave and the parameters
-/// determine the dimensions of the wave.
+///  A periodic effect consists in a wave-shaped effect that repeats itself
+///  over time.  The type determines the shape of the wave and the parameters
+///  determine the dimensions of the wave.
 ///
-/// Phase is given by hundredth of a degree meaning that giving the phase a value
-/// of 9000 will displace it 25% of its period.  Here are sample values:
-/// -     0: No phase displacement.
-/// -  9000: Displaced 25% of its period.
-/// - 18000: Displaced 50% of its period.
-/// - 27000: Displaced 75% of its period.
-/// - 36000: Displaced 100% of its period, same as 0, but 0 is preferred.
+///  Phase is given by hundredth of a degree meaning that giving the phase a value
+///  of 9000 will displace it 25% of its period.  Here are sample values:
+///   -     0: No phase displacement.
+///   -  9000: Displaced 25% of its period.
+///   - 18000: Displaced 50% of its period.
+///   - 27000: Displaced 75% of its period.
+///   - 36000: Displaced 100% of its period, same as 0, but 0 is preferred.
 ///
-/// Examples:
-/// \verbatim
-/// SDL_HAPTIC_SINE
-/// __      __      __      __
-/// /  \    /  \    /  \    /
-/// /    \__/    \__/    \__/
+///  Examples:
+///  \verbatim
+///SDL_HAPTIC_SINE
+///__      __      __      __
+////  \    /  \    /  \    /
+////    \__/    \__/    \__/
 ///
-/// SDL_HAPTIC_SQUARE
-/// __    __    __    __    __
-/// |  |  |  |  |  |  |  |  |  |
-/// |  |__|  |__|  |__|  |__|  |
+///SDL_HAPTIC_SQUARE
+///__    __    __    __    __
+///|  |  |  |  |  |  |  |  |  |
+///|  |__|  |__|  |__|  |__|  |
 ///
-/// SDL_HAPTIC_TRIANGLE
-/// /\    /\    /\    /\    /\
-/// /  \  /  \  /  \  /  \  /
-/// /    \/    \/    \/    \/
+///SDL_HAPTIC_TRIANGLE
+////\    /\    /\    /\    /\
+////  \  /  \  /  \  /  \  /
+////    \/    \/    \/    \/
 ///
-/// SDL_HAPTIC_SAWTOOTHUP
-/// /|  /|  /|  /|  /|  /|  /|
-/// / | / | / | / | / | / | / |
-/// /  |/  |/  |/  |/  |/  |/  |
+///SDL_HAPTIC_SAWTOOTHUP
+////|  /|  /|  /|  /|  /|  /|
+//// | / | / | / | / | / | / |
+////  |/  |/  |/  |/  |/  |/  |
 ///
-/// SDL_HAPTIC_SAWTOOTHDOWN
-/// \  |\  |\  |\  |\  |\  |\  |
-/// \ | \ | \ | \ | \ | \ | \ |
-/// \|  \|  \|  \|  \|  \|  \|
-/// \endverbatim
+///SDL_HAPTIC_SAWTOOTHDOWN
+///\  |\  |\  |\  |\  |\  |\  |
+///\ | \ | \ | \ | \ | \ | \ |
+///\|  \|  \|  \|  \|  \|  \|
+///\endverbatim
 ///
-/// \sa SDL_HAPTIC_SINE
-/// \sa SDL_HAPTIC_LEFTRIGHT
-/// \sa SDL_HAPTIC_TRIANGLE
-/// \sa SDL_HAPTIC_SAWTOOTHUP
-/// \sa SDL_HAPTIC_SAWTOOTHDOWN
-/// \sa SDL_HapticEffect
+///  \sa SDL_HAPTIC_SINE
+///  \sa SDL_HAPTIC_LEFTRIGHT
+///  \sa SDL_HAPTIC_TRIANGLE
+///  \sa SDL_HAPTIC_SAWTOOTHUP
+///  \sa SDL_HAPTIC_SAWTOOTHDOWN
+///  \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticPeriodic {
-    /// < ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT,
-    /// ::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or
-    /// ::SDL_HAPTIC_SAWTOOTHDOWN
+    ///< ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT,
+    ///::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or
+    ///::SDL_HAPTIC_SAWTOOTHDOWN
     pub type_: Uint16,
-    /// < Direction of the effect.
+    ///< Direction of the effect.
     pub direction: SDL_HapticDirection,
-    /// < Duration of the effect.
+    ///< Duration of the effect.
     pub length: Uint32,
-    /// < Delay before starting the effect.
+    ///< Delay before starting the effect.
     pub delay: Uint16,
-    /// < Button that triggers the effect.
+    ///< Button that triggers the effect.
     pub button: Uint16,
-    /// < How soon it can be triggered again after button.
+    ///< How soon it can be triggered again after button.
     pub interval: Uint16,
-    /// < Period of the wave.
+    ///< Period of the wave.
     pub period: Uint16,
-    /// < Peak value; if negative, equivalent to 180 degrees extra phase shift.
+    ///< Peak value; if negative, equivalent to 180 degrees extra phase shift.
     pub magnitude: Sint16,
-    /// < Mean value of the wave.
+    ///< Mean value of the wave.
     pub offset: Sint16,
-    /// < Positive phase shift given by hundredth of a degree.
+    ///< Positive phase shift given by hundredth of a degree.
     pub phase: Uint16,
-    /// < Duration of the attack.
+    ///< Duration of the attack.
     pub attack_length: Uint16,
-    /// < Level at the start of the attack.
+    ///< Level at the start of the attack.
     pub attack_level: Uint16,
-    /// < Duration of the fade.
+    ///< Duration of the fade.
     pub fade_length: Uint16,
-    /// < Level at the end of the fade.
+    ///< Level at the end of the fade.
     pub fade_level: Uint16,
 }
 #[test]
@@ -13939,55 +14292,55 @@ fn bindgen_test_layout_SDL_HapticPeriodic() {
         )
     );
 }
-/// \brief A structure containing a template for a Condition effect.
+///  \brief A structure containing a template for a Condition effect.
 ///
-/// The struct handles the following effects:
-/// - ::SDL_HAPTIC_SPRING: Effect based on axes position.
-/// - ::SDL_HAPTIC_DAMPER: Effect based on axes velocity.
-/// - ::SDL_HAPTIC_INERTIA: Effect based on axes acceleration.
-/// - ::SDL_HAPTIC_FRICTION: Effect based on axes movement.
+///  The struct handles the following effects:
+///   - ::SDL_HAPTIC_SPRING: Effect based on axes position.
+///   - ::SDL_HAPTIC_DAMPER: Effect based on axes velocity.
+///   - ::SDL_HAPTIC_INERTIA: Effect based on axes acceleration.
+///   - ::SDL_HAPTIC_FRICTION: Effect based on axes movement.
 ///
-/// Direction is handled by condition internals instead of a direction member.
-/// The condition effect specific members have three parameters.  The first
-/// refers to the X axis, the second refers to the Y axis and the third
-/// refers to the Z axis.  The right terms refer to the positive side of the
-/// axis and the left terms refer to the negative side of the axis.  Please
-/// refer to the ::SDL_HapticDirection diagram for which side is positive and
-/// which is negative.
+///  Direction is handled by condition internals instead of a direction member.
+///  The condition effect specific members have three parameters.  The first
+///  refers to the X axis, the second refers to the Y axis and the third
+///  refers to the Z axis.  The right terms refer to the positive side of the
+///  axis and the left terms refer to the negative side of the axis.  Please
+///  refer to the ::SDL_HapticDirection diagram for which side is positive and
+///  which is negative.
 ///
-/// \sa SDL_HapticDirection
-/// \sa SDL_HAPTIC_SPRING
-/// \sa SDL_HAPTIC_DAMPER
-/// \sa SDL_HAPTIC_INERTIA
-/// \sa SDL_HAPTIC_FRICTION
-/// \sa SDL_HapticEffect
+///  \sa SDL_HapticDirection
+///  \sa SDL_HAPTIC_SPRING
+///  \sa SDL_HAPTIC_DAMPER
+///  \sa SDL_HAPTIC_INERTIA
+///  \sa SDL_HAPTIC_FRICTION
+///  \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticCondition {
-    /// < ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,
-    /// ::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION
+    ///< ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,
+    ///::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION
     pub type_: Uint16,
-    /// < Direction of the effect - Not used ATM.
+    ///< Direction of the effect - Not used ATM.
     pub direction: SDL_HapticDirection,
-    /// < Duration of the effect.
+    ///< Duration of the effect.
     pub length: Uint32,
-    /// < Delay before starting the effect.
+    ///< Delay before starting the effect.
     pub delay: Uint16,
-    /// < Button that triggers the effect.
+    ///< Button that triggers the effect.
     pub button: Uint16,
-    /// < How soon it can be triggered again after button.
+    ///< How soon it can be triggered again after button.
     pub interval: Uint16,
-    /// < Level when joystick is to the positive side; max 0xFFFF.
+    ///< Level when joystick is to the positive side; max 0xFFFF.
     pub right_sat: [Uint16; 3usize],
-    /// < Level when joystick is to the negative side; max 0xFFFF.
+    ///< Level when joystick is to the negative side; max 0xFFFF.
     pub left_sat: [Uint16; 3usize],
-    /// < How fast to increase the force towards the positive side.
+    ///< How fast to increase the force towards the positive side.
     pub right_coeff: [Sint16; 3usize],
-    /// < How fast to increase the force towards the negative side.
+    ///< How fast to increase the force towards the negative side.
     pub left_coeff: [Sint16; 3usize],
-    /// < Size of the dead zone; max 0xFFFF: whole axis-range when 0-centered.
+    ///< Size of the dead zone; max 0xFFFF: whole axis-range when 0-centered.
     pub deadband: [Uint16; 3usize],
-    /// < Position of the dead zone.
+    ///< Position of the dead zone.
     pub center: [Sint16; 3usize],
 }
 #[test]
@@ -14123,43 +14476,43 @@ fn bindgen_test_layout_SDL_HapticCondition() {
         )
     );
 }
-/// \brief A structure containing a template for a Ramp effect.
+///  \brief A structure containing a template for a Ramp effect.
 ///
-/// This struct is exclusively for the ::SDL_HAPTIC_RAMP effect.
+///  This struct is exclusively for the ::SDL_HAPTIC_RAMP effect.
 ///
-/// The ramp effect starts at start strength and ends at end strength.
-/// It augments in linear fashion.  If you use attack and fade with a ramp
-/// the effects get added to the ramp effect making the effect become
-/// quadratic instead of linear.
+///  The ramp effect starts at start strength and ends at end strength.
+///  It augments in linear fashion.  If you use attack and fade with a ramp
+///  the effects get added to the ramp effect making the effect become
+///  quadratic instead of linear.
 ///
-/// \sa SDL_HAPTIC_RAMP
-/// \sa SDL_HapticEffect
+///  \sa SDL_HAPTIC_RAMP
+///  \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticRamp {
-    /// < ::SDL_HAPTIC_RAMP
+    ///< ::SDL_HAPTIC_RAMP
     pub type_: Uint16,
-    /// < Direction of the effect.
+    ///< Direction of the effect.
     pub direction: SDL_HapticDirection,
-    /// < Duration of the effect.
+    ///< Duration of the effect.
     pub length: Uint32,
-    /// < Delay before starting the effect.
+    ///< Delay before starting the effect.
     pub delay: Uint16,
-    /// < Button that triggers the effect.
+    ///< Button that triggers the effect.
     pub button: Uint16,
-    /// < How soon it can be triggered again after button.
+    ///< How soon it can be triggered again after button.
     pub interval: Uint16,
-    /// < Beginning strength level.
+    ///< Beginning strength level.
     pub start: Sint16,
-    /// < Ending strength level.
+    ///< Ending strength level.
     pub end: Sint16,
-    /// < Duration of the attack.
+    ///< Duration of the attack.
     pub attack_length: Uint16,
-    /// < Level at the start of the attack.
+    ///< Level at the start of the attack.
     pub attack_level: Uint16,
-    /// < Duration of the fade.
+    ///< Duration of the fade.
     pub fade_length: Uint16,
-    /// < Level at the end of the fade.
+    ///< Level at the end of the fade.
     pub fade_level: Uint16,
 }
 #[test]
@@ -14300,21 +14653,21 @@ fn bindgen_test_layout_SDL_HapticRamp() {
 /// This struct is exclusively for the ::SDL_HAPTIC_LEFTRIGHT effect.
 ///
 /// The Left/Right effect is used to explicitly control the large and small
-/// motors, commonly found in modern game controllers. One motor is high
-/// frequency, the other is low frequency.
+/// motors, commonly found in modern game controllers. The small (right) motor
+/// is high frequency, and the large (left) motor is low frequency.
 ///
 /// \sa SDL_HAPTIC_LEFTRIGHT
 /// \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticLeftRight {
-    /// < ::SDL_HAPTIC_LEFTRIGHT
+    ///< ::SDL_HAPTIC_LEFTRIGHT
     pub type_: Uint16,
-    /// < Duration of the effect.
+    ///< Duration of the effect in milliseconds.
     pub length: Uint32,
-    /// < Control of the large controller motor.
+    ///< Control of the large controller motor.
     pub large_magnitude: Uint16,
-    /// < Control of the small controller motor.
+    ///< Control of the small controller motor.
     pub small_magnitude: Uint16,
 }
 #[test]
@@ -14374,49 +14727,49 @@ fn bindgen_test_layout_SDL_HapticLeftRight() {
         )
     );
 }
-/// \brief A structure containing a template for the ::SDL_HAPTIC_CUSTOM effect.
+///  \brief A structure containing a template for the ::SDL_HAPTIC_CUSTOM effect.
 ///
-/// This struct is exclusively for the ::SDL_HAPTIC_CUSTOM effect.
+///  This struct is exclusively for the ::SDL_HAPTIC_CUSTOM effect.
 ///
-/// A custom force feedback effect is much like a periodic effect, where the
-/// application can define its exact shape.  You will have to allocate the
-/// data yourself.  Data should consist of channels * samples Uint16 samples.
+///  A custom force feedback effect is much like a periodic effect, where the
+///  application can define its exact shape.  You will have to allocate the
+///  data yourself.  Data should consist of channels * samples Uint16 samples.
 ///
-/// If channels is one, the effect is rotated using the defined direction.
-/// Otherwise it uses the samples in data for the different axes.
+///  If channels is one, the effect is rotated using the defined direction.
+///  Otherwise it uses the samples in data for the different axes.
 ///
-/// \sa SDL_HAPTIC_CUSTOM
-/// \sa SDL_HapticEffect
+///  \sa SDL_HAPTIC_CUSTOM
+///  \sa SDL_HapticEffect
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_HapticCustom {
-    /// < ::SDL_HAPTIC_CUSTOM
+    ///< ::SDL_HAPTIC_CUSTOM
     pub type_: Uint16,
-    /// < Direction of the effect.
+    ///< Direction of the effect.
     pub direction: SDL_HapticDirection,
-    /// < Duration of the effect.
+    ///< Duration of the effect.
     pub length: Uint32,
-    /// < Delay before starting the effect.
+    ///< Delay before starting the effect.
     pub delay: Uint16,
-    /// < Button that triggers the effect.
+    ///< Button that triggers the effect.
     pub button: Uint16,
-    /// < How soon it can be triggered again after button.
+    ///< How soon it can be triggered again after button.
     pub interval: Uint16,
-    /// < Axes to use, minimum of one.
+    ///< Axes to use, minimum of one.
     pub channels: Uint8,
-    /// < Sample periods.
+    ///< Sample periods.
     pub period: Uint16,
-    /// < Amount of samples.
+    ///< Amount of samples.
     pub samples: Uint16,
-    /// < Should contain channels*samples items.
+    ///< Should contain channels*samples items.
     pub data: *mut Uint16,
-    /// < Duration of the attack.
+    ///< Duration of the attack.
     pub attack_length: Uint16,
-    /// < Level at the start of the attack.
+    ///< Level at the start of the attack.
     pub attack_level: Uint16,
-    /// < Duration of the fade.
+    ///< Duration of the fade.
     pub fade_length: Uint16,
-    /// < Level at the end of the fade.
+    ///< Level at the end of the fade.
     pub fade_level: Uint16,
 }
 #[test]
@@ -14572,89 +14925,89 @@ fn bindgen_test_layout_SDL_HapticCustom() {
         )
     );
 }
-/// \brief The generic template for any haptic effect.
+///  \brief The generic template for any haptic effect.
 ///
-/// All values max at 32767 (0x7FFF).  Signed values also can be negative.
-/// Time values unless specified otherwise are in milliseconds.
+///  All values max at 32767 (0x7FFF).  Signed values also can be negative.
+///  Time values unless specified otherwise are in milliseconds.
 ///
-/// You can also pass ::SDL_HAPTIC_INFINITY to length instead of a 0-32767
-/// value.  Neither delay, interval, attack_length nor fade_length support
-/// ::SDL_HAPTIC_INFINITY.  Fade will also not be used since effect never ends.
+///  You can also pass ::SDL_HAPTIC_INFINITY to length instead of a 0-32767
+///  value.  Neither delay, interval, attack_length nor fade_length support
+///  ::SDL_HAPTIC_INFINITY.  Fade will also not be used since effect never ends.
 ///
-/// Additionally, the ::SDL_HAPTIC_RAMP effect does not support a duration of
-/// ::SDL_HAPTIC_INFINITY.
+///  Additionally, the ::SDL_HAPTIC_RAMP effect does not support a duration of
+///  ::SDL_HAPTIC_INFINITY.
 ///
-/// Button triggers may not be supported on all devices, it is advised to not
-/// use them if possible.  Buttons start at index 1 instead of index 0 like
-/// the joystick.
+///  Button triggers may not be supported on all devices, it is advised to not
+///  use them if possible.  Buttons start at index 1 instead of index 0 like
+///  the joystick.
 ///
-/// If both attack_length and fade_level are 0, the envelope is not used,
-/// otherwise both values are used.
+///  If both attack_length and fade_level are 0, the envelope is not used,
+///  otherwise both values are used.
 ///
-/// Common parts:
-/// \code
-/// // Replay - All effects have this
-/// Uint32 length;        // Duration of effect (ms).
-/// Uint16 delay;         // Delay before starting effect.
+///  Common parts:
+///  \code
+///  // Replay - All effects have this
+///  Uint32 length;        // Duration of effect (ms).
+///  Uint16 delay;         // Delay before starting effect.
 ///
-/// // Trigger - All effects have this
-/// Uint16 button;        // Button that triggers effect.
-/// Uint16 interval;      // How soon before effect can be triggered again.
+///  // Trigger - All effects have this
+///  Uint16 button;        // Button that triggers effect.
+///  Uint16 interval;      // How soon before effect can be triggered again.
 ///
-/// // Envelope - All effects except condition effects have this
-/// Uint16 attack_length; // Duration of the attack (ms).
-/// Uint16 attack_level;  // Level at the start of the attack.
-/// Uint16 fade_length;   // Duration of the fade out (ms).
-/// Uint16 fade_level;    // Level at the end of the fade.
-/// \endcode
+///  // Envelope - All effects except condition effects have this
+///  Uint16 attack_length; // Duration of the attack (ms).
+///  Uint16 attack_level;  // Level at the start of the attack.
+///  Uint16 fade_length;   // Duration of the fade out (ms).
+///  Uint16 fade_level;    // Level at the end of the fade.
+///  \endcode
 ///
 ///
-/// Here we have an example of a constant effect evolution in time:
-/// \verbatim
-/// Strength
-/// ^
-/// |
-/// |    effect level -->  _________________
-/// |                     /                 \
-/// |                    /                   \
-/// |                   /                     \
-/// |                  /                       \
-/// | attack_level --> |                        \
-/// |                  |                        |  <---  fade_level
-/// |
-/// +--------------------------------------------------> Time
-/// [--]                 [---]
-/// attack_length        fade_length
+///  Here we have an example of a constant effect evolution in time:
+///  \verbatim
+///Strength
+///^
+///|
+///|    effect level -->  _________________
+///|                     /                 \
+///|                    /                   \
+///|                   /                     \
+///|                  /                       \
+///| attack_level --> |                        \
+///|                  |                        |  <---  fade_level
+///|
+///+--------------------------------------------------> Time
+///[--]                 [---]
+///attack_length        fade_length
 ///
-/// [------------------][-----------------------]
-/// delay               length
-/// \endverbatim
+///[------------------][-----------------------]
+///delay               length
+///\endverbatim
 ///
-/// Note either the attack_level or the fade_level may be above the actual
-/// effect level.
+///  Note either the attack_level or the fade_level may be above the actual
+///  effect level.
 ///
-/// \sa SDL_HapticConstant
-/// \sa SDL_HapticPeriodic
-/// \sa SDL_HapticCondition
-/// \sa SDL_HapticRamp
-/// \sa SDL_HapticLeftRight
-/// \sa SDL_HapticCustom
+///  \sa SDL_HapticConstant
+///  \sa SDL_HapticPeriodic
+///  \sa SDL_HapticCondition
+///  \sa SDL_HapticRamp
+///  \sa SDL_HapticLeftRight
+///  \sa SDL_HapticCustom
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union SDL_HapticEffect {
-    /// < Effect type.
+    ///< Effect type.
     pub type_: Uint16,
-    /// < Constant effect.
+    ///< Constant effect.
     pub constant: SDL_HapticConstant,
-    /// < Periodic effect.
+    ///< Periodic effect.
     pub periodic: SDL_HapticPeriodic,
-    /// < Condition effect.
+    ///< Condition effect.
     pub condition: SDL_HapticCondition,
-    /// < Ramp effect.
+    ///< Ramp effect.
     pub ramp: SDL_HapticRamp,
-    /// < Left/Right effect.
+    ///< Left/Right effect.
     pub leftright: SDL_HapticLeftRight,
-    /// < Custom effect.
+    ///< Custom effect.
     pub custom: SDL_HapticCustom,
     _bindgen_union_align: [u64; 9usize],
 }
@@ -14742,215 +15095,215 @@ fn bindgen_test_layout_SDL_HapticEffect() {
     );
 }
 extern "C" {
-    /// \brief Count the number of haptic devices attached to the system.
+    ///  \brief Count the number of haptic devices attached to the system.
     ///
-    /// \return Number of haptic devices detected on the system.
+    ///  \return Number of haptic devices detected on the system.
     pub fn SDL_NumHaptics() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the implementation dependent name of a haptic device.
+    ///  \brief Get the implementation dependent name of a haptic device.
     ///
-    /// This can be called before any joysticks are opened.
-    /// If no name can be found, this function returns NULL.
+    ///  This can be called before any joysticks are opened.
+    ///  If no name can be found, this function returns NULL.
     ///
-    /// \param device_index Index of the device to get its name.
-    /// \return Name of the device or NULL on error.
+    ///  \param device_index Index of the device to get its name.
+    ///  \return Name of the device or NULL on error.
     ///
-    /// \sa SDL_NumHaptics
+    ///  \sa SDL_NumHaptics
     pub fn SDL_HapticName(device_index: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Opens a haptic device for use.
+    ///  \brief Opens a haptic device for use.
     ///
-    /// The index passed as an argument refers to the N'th haptic device on this
-    /// system.
+    ///  The index passed as an argument refers to the N'th haptic device on this
+    ///  system.
     ///
-    /// When opening a haptic device, its gain will be set to maximum and
-    /// autocenter will be disabled.  To modify these values use
-    /// SDL_HapticSetGain() and SDL_HapticSetAutocenter().
+    ///  When opening a haptic device, its gain will be set to maximum and
+    ///  autocenter will be disabled.  To modify these values use
+    ///  SDL_HapticSetGain() and SDL_HapticSetAutocenter().
     ///
-    /// \param device_index Index of the device to open.
-    /// \return Device identifier or NULL on error.
+    ///  \param device_index Index of the device to open.
+    ///  \return Device identifier or NULL on error.
     ///
-    /// \sa SDL_HapticIndex
-    /// \sa SDL_HapticOpenFromMouse
-    /// \sa SDL_HapticOpenFromJoystick
-    /// \sa SDL_HapticClose
-    /// \sa SDL_HapticSetGain
-    /// \sa SDL_HapticSetAutocenter
-    /// \sa SDL_HapticPause
-    /// \sa SDL_HapticStopAll
+    ///  \sa SDL_HapticIndex
+    ///  \sa SDL_HapticOpenFromMouse
+    ///  \sa SDL_HapticOpenFromJoystick
+    ///  \sa SDL_HapticClose
+    ///  \sa SDL_HapticSetGain
+    ///  \sa SDL_HapticSetAutocenter
+    ///  \sa SDL_HapticPause
+    ///  \sa SDL_HapticStopAll
     pub fn SDL_HapticOpen(device_index: ::std::os::raw::c_int) -> *mut SDL_Haptic;
 }
 extern "C" {
-    /// \brief Checks if the haptic device at index has been opened.
+    ///  \brief Checks if the haptic device at index has been opened.
     ///
-    /// \param device_index Index to check to see if it has been opened.
-    /// \return 1 if it has been opened or 0 if it hasn't.
+    ///  \param device_index Index to check to see if it has been opened.
+    ///  \return 1 if it has been opened or 0 if it hasn't.
     ///
-    /// \sa SDL_HapticOpen
-    /// \sa SDL_HapticIndex
+    ///  \sa SDL_HapticOpen
+    ///  \sa SDL_HapticIndex
     pub fn SDL_HapticOpened(device_index: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Gets the index of a haptic device.
+    ///  \brief Gets the index of a haptic device.
     ///
-    /// \param haptic Haptic device to get the index of.
-    /// \return The index of the haptic device or -1 on error.
+    ///  \param haptic Haptic device to get the index of.
+    ///  \return The index of the haptic device or -1 on error.
     ///
-    /// \sa SDL_HapticOpen
-    /// \sa SDL_HapticOpened
+    ///  \sa SDL_HapticOpen
+    ///  \sa SDL_HapticOpened
     pub fn SDL_HapticIndex(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Gets whether or not the current mouse has haptic capabilities.
+    ///  \brief Gets whether or not the current mouse has haptic capabilities.
     ///
-    /// \return SDL_TRUE if the mouse is haptic, SDL_FALSE if it isn't.
+    ///  \return SDL_TRUE if the mouse is haptic, SDL_FALSE if it isn't.
     ///
-    /// \sa SDL_HapticOpenFromMouse
+    ///  \sa SDL_HapticOpenFromMouse
     pub fn SDL_MouseIsHaptic() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Tries to open a haptic device from the current mouse.
+    ///  \brief Tries to open a haptic device from the current mouse.
     ///
-    /// \return The haptic device identifier or NULL on error.
+    ///  \return The haptic device identifier or NULL on error.
     ///
-    /// \sa SDL_MouseIsHaptic
-    /// \sa SDL_HapticOpen
+    ///  \sa SDL_MouseIsHaptic
+    ///  \sa SDL_HapticOpen
     pub fn SDL_HapticOpenFromMouse() -> *mut SDL_Haptic;
 }
 extern "C" {
-    /// \brief Checks to see if a joystick has haptic features.
+    ///  \brief Checks to see if a joystick has haptic features.
     ///
-    /// \param joystick Joystick to test for haptic capabilities.
-    /// \return SDL_TRUE if the joystick is haptic, SDL_FALSE if it isn't
-    /// or -1 if an error occurred.
+    ///  \param joystick Joystick to test for haptic capabilities.
+    ///  \return SDL_TRUE if the joystick is haptic, SDL_FALSE if it isn't
+    ///          or -1 if an error occurred.
     ///
-    /// \sa SDL_HapticOpenFromJoystick
+    ///  \sa SDL_HapticOpenFromJoystick
     pub fn SDL_JoystickIsHaptic(joystick: *mut SDL_Joystick) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Opens a haptic device for use from a joystick device.
+    ///  \brief Opens a haptic device for use from a joystick device.
     ///
-    /// You must still close the haptic device separately.  It will not be closed
-    /// with the joystick.
+    ///  You must still close the haptic device separately.  It will not be closed
+    ///  with the joystick.
     ///
-    /// When opening from a joystick you should first close the haptic device before
-    /// closing the joystick device.  If not, on some implementations the haptic
-    /// device will also get unallocated and you'll be unable to use force feedback
-    /// on that device.
+    ///  When opening from a joystick you should first close the haptic device before
+    ///  closing the joystick device.  If not, on some implementations the haptic
+    ///  device will also get unallocated and you'll be unable to use force feedback
+    ///  on that device.
     ///
-    /// \param joystick Joystick to create a haptic device from.
-    /// \return A valid haptic device identifier on success or NULL on error.
+    ///  \param joystick Joystick to create a haptic device from.
+    ///  \return A valid haptic device identifier on success or NULL on error.
     ///
-    /// \sa SDL_HapticOpen
-    /// \sa SDL_HapticClose
+    ///  \sa SDL_HapticOpen
+    ///  \sa SDL_HapticClose
     pub fn SDL_HapticOpenFromJoystick(joystick: *mut SDL_Joystick) -> *mut SDL_Haptic;
 }
 extern "C" {
-    /// \brief Closes a haptic device previously opened with SDL_HapticOpen().
+    ///  \brief Closes a haptic device previously opened with SDL_HapticOpen().
     ///
-    /// \param haptic Haptic device to close.
+    ///  \param haptic Haptic device to close.
     pub fn SDL_HapticClose(haptic: *mut SDL_Haptic);
 }
 extern "C" {
-    /// \brief Returns the number of effects a haptic device can store.
+    ///  \brief Returns the number of effects a haptic device can store.
     ///
-    /// On some platforms this isn't fully supported, and therefore is an
-    /// approximation.  Always check to see if your created effect was actually
-    /// created and do not rely solely on SDL_HapticNumEffects().
+    ///  On some platforms this isn't fully supported, and therefore is an
+    ///  approximation.  Always check to see if your created effect was actually
+    ///  created and do not rely solely on SDL_HapticNumEffects().
     ///
-    /// \param haptic The haptic device to query effect max.
-    /// \return The number of effects the haptic device can store or
-    /// -1 on error.
+    ///  \param haptic The haptic device to query effect max.
+    ///  \return The number of effects the haptic device can store or
+    ///          -1 on error.
     ///
-    /// \sa SDL_HapticNumEffectsPlaying
-    /// \sa SDL_HapticQuery
+    ///  \sa SDL_HapticNumEffectsPlaying
+    ///  \sa SDL_HapticQuery
     pub fn SDL_HapticNumEffects(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Returns the number of effects a haptic device can play at the same
-    /// time.
+    ///  \brief Returns the number of effects a haptic device can play at the same
+    ///         time.
     ///
-    /// This is not supported on all platforms, but will always return a value.
-    /// Added here for the sake of completeness.
+    ///  This is not supported on all platforms, but will always return a value.
+    ///  Added here for the sake of completeness.
     ///
-    /// \param haptic The haptic device to query maximum playing effects.
-    /// \return The number of effects the haptic device can play at the same time
-    /// or -1 on error.
+    ///  \param haptic The haptic device to query maximum playing effects.
+    ///  \return The number of effects the haptic device can play at the same time
+    ///          or -1 on error.
     ///
-    /// \sa SDL_HapticNumEffects
-    /// \sa SDL_HapticQuery
+    ///  \sa SDL_HapticNumEffects
+    ///  \sa SDL_HapticQuery
     pub fn SDL_HapticNumEffectsPlaying(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Gets the haptic device's supported features in bitwise manner.
+    ///  \brief Gets the haptic device's supported features in bitwise manner.
     ///
-    /// Example:
-    /// \code
-    /// if (SDL_HapticQuery(haptic) & SDL_HAPTIC_CONSTANT) {
-    /// printf("We have constant haptic effect!\n");
-    /// }
-    /// \endcode
+    ///  Example:
+    ///  \code
+    ///  if (SDL_HapticQuery(haptic) & SDL_HAPTIC_CONSTANT) {
+    ///      printf("We have constant haptic effect!\n");
+    ///  }
+    ///  \endcode
     ///
-    /// \param haptic The haptic device to query.
-    /// \return Haptic features in bitwise manner (OR'd).
+    ///  \param haptic The haptic device to query.
+    ///  \return Haptic features in bitwise manner (OR'd).
     ///
-    /// \sa SDL_HapticNumEffects
-    /// \sa SDL_HapticEffectSupported
+    ///  \sa SDL_HapticNumEffects
+    ///  \sa SDL_HapticEffectSupported
     pub fn SDL_HapticQuery(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    /// \brief Gets the number of haptic axes the device has.
+    ///  \brief Gets the number of haptic axes the device has.
     ///
-    /// \sa SDL_HapticDirection
+    ///  \sa SDL_HapticDirection
     pub fn SDL_HapticNumAxes(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Checks to see if effect is supported by haptic.
+    ///  \brief Checks to see if effect is supported by haptic.
     ///
-    /// \param haptic Haptic device to check on.
-    /// \param effect Effect to check to see if it is supported.
-    /// \return SDL_TRUE if effect is supported, SDL_FALSE if it isn't or -1 on error.
+    ///  \param haptic Haptic device to check on.
+    ///  \param effect Effect to check to see if it is supported.
+    ///  \return SDL_TRUE if effect is supported, SDL_FALSE if it isn't or -1 on error.
     ///
-    /// \sa SDL_HapticQuery
-    /// \sa SDL_HapticNewEffect
+    ///  \sa SDL_HapticQuery
+    ///  \sa SDL_HapticNewEffect
     pub fn SDL_HapticEffectSupported(
         haptic: *mut SDL_Haptic,
         effect: *mut SDL_HapticEffect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Creates a new haptic effect on the device.
+    ///  \brief Creates a new haptic effect on the device.
     ///
-    /// \param haptic Haptic device to create the effect on.
-    /// \param effect Properties of the effect to create.
-    /// \return The identifier of the effect on success or -1 on error.
+    ///  \param haptic Haptic device to create the effect on.
+    ///  \param effect Properties of the effect to create.
+    ///  \return The identifier of the effect on success or -1 on error.
     ///
-    /// \sa SDL_HapticUpdateEffect
-    /// \sa SDL_HapticRunEffect
-    /// \sa SDL_HapticDestroyEffect
+    ///  \sa SDL_HapticUpdateEffect
+    ///  \sa SDL_HapticRunEffect
+    ///  \sa SDL_HapticDestroyEffect
     pub fn SDL_HapticNewEffect(
         haptic: *mut SDL_Haptic,
         effect: *mut SDL_HapticEffect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Updates the properties of an effect.
+    ///  \brief Updates the properties of an effect.
     ///
-    /// Can be used dynamically, although behavior when dynamically changing
-    /// direction may be strange.  Specifically the effect may reupload itself
-    /// and start playing from the start.  You cannot change the type either when
-    /// running SDL_HapticUpdateEffect().
+    ///  Can be used dynamically, although behavior when dynamically changing
+    ///  direction may be strange.  Specifically the effect may reupload itself
+    ///  and start playing from the start.  You cannot change the type either when
+    ///  running SDL_HapticUpdateEffect().
     ///
-    /// \param haptic Haptic device that has the effect.
-    /// \param effect Identifier of the effect to update.
-    /// \param data New effect properties to use.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device that has the effect.
+    ///  \param effect Identifier of the effect to update.
+    ///  \param data New effect properties to use.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticNewEffect
-    /// \sa SDL_HapticRunEffect
-    /// \sa SDL_HapticDestroyEffect
+    ///  \sa SDL_HapticNewEffect
+    ///  \sa SDL_HapticRunEffect
+    ///  \sa SDL_HapticDestroyEffect
     pub fn SDL_HapticUpdateEffect(
         haptic: *mut SDL_Haptic,
         effect: ::std::os::raw::c_int,
@@ -14958,22 +15311,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Runs the haptic effect on its associated haptic device.
+    ///  \brief Runs the haptic effect on its associated haptic device.
     ///
-    /// If iterations are ::SDL_HAPTIC_INFINITY, it'll run the effect over and over
-    /// repeating the envelope (attack and fade) every time.  If you only want the
-    /// effect to last forever, set ::SDL_HAPTIC_INFINITY in the effect's length
-    /// parameter.
+    ///  If iterations are ::SDL_HAPTIC_INFINITY, it'll run the effect over and over
+    ///  repeating the envelope (attack and fade) every time.  If you only want the
+    ///  effect to last forever, set ::SDL_HAPTIC_INFINITY in the effect's length
+    ///  parameter.
     ///
-    /// \param haptic Haptic device to run the effect on.
-    /// \param effect Identifier of the haptic effect to run.
-    /// \param iterations Number of iterations to run the effect. Use
-    /// ::SDL_HAPTIC_INFINITY for infinity.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to run the effect on.
+    ///  \param effect Identifier of the haptic effect to run.
+    ///  \param iterations Number of iterations to run the effect. Use
+    ///         ::SDL_HAPTIC_INFINITY for infinity.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticStopEffect
-    /// \sa SDL_HapticDestroyEffect
-    /// \sa SDL_HapticGetEffectStatus
+    ///  \sa SDL_HapticStopEffect
+    ///  \sa SDL_HapticDestroyEffect
+    ///  \sa SDL_HapticGetEffectStatus
     pub fn SDL_HapticRunEffect(
         haptic: *mut SDL_Haptic,
         effect: ::std::os::raw::c_int,
@@ -14981,152 +15334,152 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Stops the haptic effect on its associated haptic device.
+    ///  \brief Stops the haptic effect on its associated haptic device.
     ///
-    /// \param haptic Haptic device to stop the effect on.
-    /// \param effect Identifier of the effect to stop.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to stop the effect on.
+    ///  \param effect Identifier of the effect to stop.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticRunEffect
-    /// \sa SDL_HapticDestroyEffect
+    ///  \sa SDL_HapticRunEffect
+    ///  \sa SDL_HapticDestroyEffect
     pub fn SDL_HapticStopEffect(
         haptic: *mut SDL_Haptic,
         effect: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Destroys a haptic effect on the device.
+    ///  \brief Destroys a haptic effect on the device.
     ///
-    /// This will stop the effect if it's running.  Effects are automatically
-    /// destroyed when the device is closed.
+    ///  This will stop the effect if it's running.  Effects are automatically
+    ///  destroyed when the device is closed.
     ///
-    /// \param haptic Device to destroy the effect on.
-    /// \param effect Identifier of the effect to destroy.
+    ///  \param haptic Device to destroy the effect on.
+    ///  \param effect Identifier of the effect to destroy.
     ///
-    /// \sa SDL_HapticNewEffect
+    ///  \sa SDL_HapticNewEffect
     pub fn SDL_HapticDestroyEffect(haptic: *mut SDL_Haptic, effect: ::std::os::raw::c_int);
 }
 extern "C" {
-    /// \brief Gets the status of the current effect on the haptic device.
+    ///  \brief Gets the status of the current effect on the haptic device.
     ///
-    /// Device must support the ::SDL_HAPTIC_STATUS feature.
+    ///  Device must support the ::SDL_HAPTIC_STATUS feature.
     ///
-    /// \param haptic Haptic device to query the effect status on.
-    /// \param effect Identifier of the effect to query its status.
-    /// \return 0 if it isn't playing, 1 if it is playing or -1 on error.
+    ///  \param haptic Haptic device to query the effect status on.
+    ///  \param effect Identifier of the effect to query its status.
+    ///  \return 0 if it isn't playing, 1 if it is playing or -1 on error.
     ///
-    /// \sa SDL_HapticRunEffect
-    /// \sa SDL_HapticStopEffect
+    ///  \sa SDL_HapticRunEffect
+    ///  \sa SDL_HapticStopEffect
     pub fn SDL_HapticGetEffectStatus(
         haptic: *mut SDL_Haptic,
         effect: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets the global gain of the device.
+    ///  \brief Sets the global gain of the device.
     ///
-    /// Device must support the ::SDL_HAPTIC_GAIN feature.
+    ///  Device must support the ::SDL_HAPTIC_GAIN feature.
     ///
-    /// The user may specify the maximum gain by setting the environment variable
-    /// SDL_HAPTIC_GAIN_MAX which should be between 0 and 100.  All calls to
-    /// SDL_HapticSetGain() will scale linearly using SDL_HAPTIC_GAIN_MAX as the
-    /// maximum.
+    ///  The user may specify the maximum gain by setting the environment variable
+    ///  SDL_HAPTIC_GAIN_MAX which should be between 0 and 100.  All calls to
+    ///  SDL_HapticSetGain() will scale linearly using SDL_HAPTIC_GAIN_MAX as the
+    ///  maximum.
     ///
-    /// \param haptic Haptic device to set the gain on.
-    /// \param gain Value to set the gain to, should be between 0 and 100.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to set the gain on.
+    ///  \param gain Value to set the gain to, should be between 0 and 100.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticQuery
+    ///  \sa SDL_HapticQuery
     pub fn SDL_HapticSetGain(
         haptic: *mut SDL_Haptic,
         gain: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Sets the global autocenter of the device.
+    ///  \brief Sets the global autocenter of the device.
     ///
-    /// Autocenter should be between 0 and 100.  Setting it to 0 will disable
-    /// autocentering.
+    ///  Autocenter should be between 0 and 100.  Setting it to 0 will disable
+    ///  autocentering.
     ///
-    /// Device must support the ::SDL_HAPTIC_AUTOCENTER feature.
+    ///  Device must support the ::SDL_HAPTIC_AUTOCENTER feature.
     ///
-    /// \param haptic Haptic device to set autocentering on.
-    /// \param autocenter Value to set autocenter to, 0 disables autocentering.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to set autocentering on.
+    ///  \param autocenter Value to set autocenter to, 0 disables autocentering.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticQuery
+    ///  \sa SDL_HapticQuery
     pub fn SDL_HapticSetAutocenter(
         haptic: *mut SDL_Haptic,
         autocenter: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Pauses a haptic device.
+    ///  \brief Pauses a haptic device.
     ///
-    /// Device must support the ::SDL_HAPTIC_PAUSE feature.  Call
-    /// SDL_HapticUnpause() to resume playback.
+    ///  Device must support the ::SDL_HAPTIC_PAUSE feature.  Call
+    ///  SDL_HapticUnpause() to resume playback.
     ///
-    /// Do not modify the effects nor add new ones while the device is paused.
-    /// That can cause all sorts of weird errors.
+    ///  Do not modify the effects nor add new ones while the device is paused.
+    ///  That can cause all sorts of weird errors.
     ///
-    /// \param haptic Haptic device to pause.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to pause.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticUnpause
+    ///  \sa SDL_HapticUnpause
     pub fn SDL_HapticPause(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Unpauses a haptic device.
+    ///  \brief Unpauses a haptic device.
     ///
-    /// Call to unpause after SDL_HapticPause().
+    ///  Call to unpause after SDL_HapticPause().
     ///
-    /// \param haptic Haptic device to unpause.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to unpause.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticPause
+    ///  \sa SDL_HapticPause
     pub fn SDL_HapticUnpause(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Stops all the currently playing effects on a haptic device.
+    ///  \brief Stops all the currently playing effects on a haptic device.
     ///
-    /// \param haptic Haptic device to stop.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to stop.
+    ///  \return 0 on success or -1 on error.
     pub fn SDL_HapticStopAll(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Checks to see if rumble is supported on a haptic device.
+    ///  \brief Checks to see if rumble is supported on a haptic device.
     ///
-    /// \param haptic Haptic device to check to see if it supports rumble.
-    /// \return SDL_TRUE if effect is supported, SDL_FALSE if it isn't or -1 on error.
+    ///  \param haptic Haptic device to check to see if it supports rumble.
+    ///  \return SDL_TRUE if effect is supported, SDL_FALSE if it isn't or -1 on error.
     ///
-    /// \sa SDL_HapticRumbleInit
-    /// \sa SDL_HapticRumblePlay
-    /// \sa SDL_HapticRumbleStop
+    ///  \sa SDL_HapticRumbleInit
+    ///  \sa SDL_HapticRumblePlay
+    ///  \sa SDL_HapticRumbleStop
     pub fn SDL_HapticRumbleSupported(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Initializes the haptic device for simple rumble playback.
+    ///  \brief Initializes the haptic device for simple rumble playback.
     ///
-    /// \param haptic Haptic device to initialize for simple rumble playback.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to initialize for simple rumble playback.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticOpen
-    /// \sa SDL_HapticRumbleSupported
-    /// \sa SDL_HapticRumblePlay
-    /// \sa SDL_HapticRumbleStop
+    ///  \sa SDL_HapticOpen
+    ///  \sa SDL_HapticRumbleSupported
+    ///  \sa SDL_HapticRumblePlay
+    ///  \sa SDL_HapticRumbleStop
     pub fn SDL_HapticRumbleInit(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Runs simple rumble on a haptic device
+    ///  \brief Runs simple rumble on a haptic device
     ///
-    /// \param haptic Haptic device to play rumble effect on.
-    /// \param strength Strength of the rumble to play as a 0-1 float value.
-    /// \param length Length of the rumble to play in milliseconds.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic device to play rumble effect on.
+    ///  \param strength Strength of the rumble to play as a 0-1 float value.
+    ///  \param length Length of the rumble to play in milliseconds.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticRumbleSupported
-    /// \sa SDL_HapticRumbleInit
-    /// \sa SDL_HapticRumbleStop
+    ///  \sa SDL_HapticRumbleSupported
+    ///  \sa SDL_HapticRumbleInit
+    ///  \sa SDL_HapticRumbleStop
     pub fn SDL_HapticRumblePlay(
         haptic: *mut SDL_Haptic,
         strength: f32,
@@ -15134,18 +15487,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Stops the simple rumble on a haptic device.
+    ///  \brief Stops the simple rumble on a haptic device.
     ///
-    /// \param haptic Haptic to stop the rumble on.
-    /// \return 0 on success or -1 on error.
+    ///  \param haptic Haptic to stop the rumble on.
+    ///  \return 0 on success or -1 on error.
     ///
-    /// \sa SDL_HapticRumbleSupported
-    /// \sa SDL_HapticRumbleInit
-    /// \sa SDL_HapticRumblePlay
+    ///  \sa SDL_HapticRumbleSupported
+    ///  \sa SDL_HapticRumbleInit
+    ///  \sa SDL_HapticRumblePlay
     pub fn SDL_HapticRumbleStop(haptic: *mut SDL_Haptic) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
-/// \brief  An enumeration of hint priorities
+///  \brief  An enumeration of hint priorities
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_HintPriority {
     SDL_HINT_DEFAULT = 0,
@@ -15153,13 +15506,13 @@ pub enum SDL_HintPriority {
     SDL_HINT_OVERRIDE = 2,
 }
 extern "C" {
-    /// \brief Set a hint with a specific priority
+    ///  \brief Set a hint with a specific priority
     ///
-    /// The priority controls the behavior when setting a hint that already
-    /// has a value.  Hints will replace existing hints of their priority and
-    /// lower.  Environment variables are considered to have override priority.
+    ///  The priority controls the behavior when setting a hint that already
+    ///  has a value.  Hints will replace existing hints of their priority and
+    ///  lower.  Environment variables are considered to have override priority.
     ///
-    /// \return SDL_TRUE if the hint was set, SDL_FALSE otherwise
+    ///  \return SDL_TRUE if the hint was set, SDL_FALSE otherwise
     pub fn SDL_SetHintWithPriority(
         name: *const ::std::os::raw::c_char,
         value: *const ::std::os::raw::c_char,
@@ -15167,24 +15520,24 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Set a hint with normal priority
+    ///  \brief Set a hint with normal priority
     ///
-    /// \return SDL_TRUE if the hint was set, SDL_FALSE otherwise
+    ///  \return SDL_TRUE if the hint was set, SDL_FALSE otherwise
     pub fn SDL_SetHint(
         name: *const ::std::os::raw::c_char,
         value: *const ::std::os::raw::c_char,
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Get a hint
+    ///  \brief Get a hint
     ///
-    /// \return The string value of a hint variable.
+    ///  \return The string value of a hint variable.
     pub fn SDL_GetHint(name: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Get a hint
+    ///  \brief Get a hint
     ///
-    /// \return The boolean value of a hint variable.
+    ///  \return The boolean value of a hint variable.
     pub fn SDL_GetHintBoolean(
         name: *const ::std::os::raw::c_char,
         default_value: SDL_bool,
@@ -15200,11 +15553,11 @@ pub type SDL_HintCallback = ::std::option::Option<
     ),
 >;
 extern "C" {
-    /// \brief Add a function to watch a particular hint
+    ///  \brief Add a function to watch a particular hint
     ///
-    /// \param name The hint to watch
-    /// \param callback The function to call when the hint value changes
-    /// \param userdata A pointer to pass to the callback function
+    ///  \param name The hint to watch
+    ///  \param callback The function to call when the hint value changes
+    ///  \param userdata A pointer to pass to the callback function
     pub fn SDL_AddHintCallback(
         name: *const ::std::os::raw::c_char,
         callback: SDL_HintCallback,
@@ -15212,11 +15565,11 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Remove a function watching a particular hint
+    ///  \brief Remove a function watching a particular hint
     ///
-    /// \param name The hint being watched
-    /// \param callback The function being called when the hint value changes
-    /// \param userdata A pointer being passed to the callback function
+    ///  \param name The hint being watched
+    ///  \param callback The function being called when the hint value changes
+    ///  \param userdata A pointer being passed to the callback function
     pub fn SDL_DelHintCallback(
         name: *const ::std::os::raw::c_char,
         callback: SDL_HintCallback,
@@ -15224,28 +15577,28 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief  Clear all hints
+    ///  \brief  Clear all hints
     ///
-    /// This function is called during SDL_Quit() to free stored hints.
+    ///  This function is called during SDL_Quit() to free stored hints.
     pub fn SDL_ClearHints();
 }
 extern "C" {
-    /// This function dynamically loads a shared object and returns a pointer
-    /// to the object handle (or NULL if there was an error).
-    /// The 'sofile' parameter is a system dependent name of the object file.
+    ///  This function dynamically loads a shared object and returns a pointer
+    ///  to the object handle (or NULL if there was an error).
+    ///  The 'sofile' parameter is a system dependent name of the object file.
     pub fn SDL_LoadObject(sofile: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// Given an object handle, this function looks up the address of the
-    /// named function in the shared object and returns it.  This address
-    /// is no longer valid after calling SDL_UnloadObject().
+    ///  Given an object handle, this function looks up the address of the
+    ///  named function in the shared object and returns it.  This address
+    ///  is no longer valid after calling SDL_UnloadObject().
     pub fn SDL_LoadFunction(
         handle: *mut ::std::os::raw::c_void,
         name: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// Unload a shared object from memory.
+    ///  Unload a shared object from memory.
     pub fn SDL_UnloadObject(handle: *mut ::std::os::raw::c_void);
 }
 pub const SDL_LOG_CATEGORY_APPLICATION: _bindgen_ty_8 = _bindgen_ty_8::SDL_LOG_CATEGORY_APPLICATION;
@@ -15269,12 +15622,12 @@ pub const SDL_LOG_CATEGORY_RESERVED9: _bindgen_ty_8 = _bindgen_ty_8::SDL_LOG_CAT
 pub const SDL_LOG_CATEGORY_RESERVED10: _bindgen_ty_8 = _bindgen_ty_8::SDL_LOG_CATEGORY_RESERVED10;
 pub const SDL_LOG_CATEGORY_CUSTOM: _bindgen_ty_8 = _bindgen_ty_8::SDL_LOG_CATEGORY_CUSTOM;
 #[repr(u32)]
-/// \brief The predefined log categories
+///  \brief The predefined log categories
 ///
-/// By default the application category is enabled at the INFO level,
-/// the assert category is enabled at the WARN level, test is enabled
-/// at the VERBOSE level and all other categories are enabled at the
-/// CRITICAL level.
+///  By default the application category is enabled at the INFO level,
+///  the assert category is enabled at the WARN level, test is enabled
+///  at the VERBOSE level and all other categories are enabled at the
+///  CRITICAL level.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum _bindgen_ty_8 {
     SDL_LOG_CATEGORY_APPLICATION = 0,
@@ -15299,7 +15652,7 @@ pub enum _bindgen_ty_8 {
     SDL_LOG_CATEGORY_CUSTOM = 19,
 }
 #[repr(u32)]
-/// \brief The predefined log priorities
+///  \brief The predefined log priorities
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_LogPriority {
     SDL_LOG_PRIORITY_VERBOSE = 1,
@@ -15311,49 +15664,49 @@ pub enum SDL_LogPriority {
     SDL_NUM_LOG_PRIORITIES = 7,
 }
 extern "C" {
-    /// \brief Set the priority of all log categories
+    ///  \brief Set the priority of all log categories
     pub fn SDL_LogSetAllPriority(priority: SDL_LogPriority);
 }
 extern "C" {
-    /// \brief Set the priority of a particular log category
+    ///  \brief Set the priority of a particular log category
     pub fn SDL_LogSetPriority(category: ::std::os::raw::c_int, priority: SDL_LogPriority);
 }
 extern "C" {
-    /// \brief Get the priority of a particular log category
+    ///  \brief Get the priority of a particular log category
     pub fn SDL_LogGetPriority(category: ::std::os::raw::c_int) -> SDL_LogPriority;
 }
 extern "C" {
-    /// \brief Reset all priorities to default.
+    ///  \brief Reset all priorities to default.
     ///
-    /// \note This is called in SDL_Quit().
+    ///  \note This is called in SDL_Quit().
     pub fn SDL_LogResetPriorities();
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_CATEGORY_APPLICATION and SDL_LOG_PRIORITY_INFO
+    ///  \brief Log a message with SDL_LOG_CATEGORY_APPLICATION and SDL_LOG_PRIORITY_INFO
     pub fn SDL_Log(fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_VERBOSE
+    ///  \brief Log a message with SDL_LOG_PRIORITY_VERBOSE
     pub fn SDL_LogVerbose(category: ::std::os::raw::c_int, fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_DEBUG
+    ///  \brief Log a message with SDL_LOG_PRIORITY_DEBUG
     pub fn SDL_LogDebug(category: ::std::os::raw::c_int, fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_INFO
+    ///  \brief Log a message with SDL_LOG_PRIORITY_INFO
     pub fn SDL_LogInfo(category: ::std::os::raw::c_int, fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_WARN
+    ///  \brief Log a message with SDL_LOG_PRIORITY_WARN
     pub fn SDL_LogWarn(category: ::std::os::raw::c_int, fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_ERROR
+    ///  \brief Log a message with SDL_LOG_PRIORITY_ERROR
     pub fn SDL_LogError(category: ::std::os::raw::c_int, fmt: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    /// \brief Log a message with SDL_LOG_PRIORITY_CRITICAL
+    ///  \brief Log a message with SDL_LOG_PRIORITY_CRITICAL
     pub fn SDL_LogCritical(
         category: ::std::os::raw::c_int,
         fmt: *const ::std::os::raw::c_char,
@@ -15361,7 +15714,7 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Log a message with the specified category and priority.
+    ///  \brief Log a message with the specified category and priority.
     pub fn SDL_LogMessage(
         category: ::std::os::raw::c_int,
         priority: SDL_LogPriority,
@@ -15370,7 +15723,7 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Log a message with the specified category and priority.
+    ///  \brief Log a message with the specified category and priority.
     pub fn SDL_LogMessageV(
         category: ::std::os::raw::c_int,
         priority: SDL_LogPriority,
@@ -15378,7 +15731,7 @@ extern "C" {
         ap: *mut __va_list_tag,
     );
 }
-/// \brief The prototype for the log output function
+///  \brief The prototype for the log output function
 pub type SDL_LogOutputFunction = ::std::option::Option<
     unsafe extern "C" fn(
         userdata: *mut ::std::os::raw::c_void,
@@ -15388,15 +15741,15 @@ pub type SDL_LogOutputFunction = ::std::option::Option<
     ),
 >;
 extern "C" {
-    /// \brief Get the current log output function.
+    ///  \brief Get the current log output function.
     pub fn SDL_LogGetOutputFunction(
         callback: *mut SDL_LogOutputFunction,
         userdata: *mut *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    /// \brief This function allows you to replace the default log output
-    /// function with one of your own.
+    ///  \brief This function allows you to replace the default log output
+    ///         function with one of your own.
     pub fn SDL_LogSetOutputFunction(
         callback: SDL_LogOutputFunction,
         userdata: *mut ::std::os::raw::c_void,
@@ -15406,31 +15759,31 @@ extern "C" {
 /// \brief SDL_MessageBox flags. If supported will display warning icon, etc.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_MessageBoxFlags {
-    /// < error dialog
+    ///< error dialog
     SDL_MESSAGEBOX_ERROR = 16,
-    /// < warning dialog
+    ///< warning dialog
     SDL_MESSAGEBOX_WARNING = 32,
-    /// < informational dialog
+    ///< informational dialog
     SDL_MESSAGEBOX_INFORMATION = 64,
 }
 #[repr(u32)]
 /// \brief Flags for SDL_MessageBoxButtonData.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_MessageBoxButtonFlags {
-    /// < Marks the default button when return is hit
+    ///< Marks the default button when return is hit
     SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT = 1,
-    /// < Marks the default button when escape is hit
+    ///< Marks the default button when escape is hit
     SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT = 2,
 }
-/// \brief Individual button data.
+///  \brief Individual button data.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MessageBoxButtonData {
-    /// < ::SDL_MessageBoxButtonFlags
+    ///< ::SDL_MessageBoxButtonFlags
     pub flags: Uint32,
-    /// < User defined button id (value returned via SDL_ShowMessageBox)
+    ///< User defined button id (value returned via SDL_ShowMessageBox)
     pub buttonid: ::std::os::raw::c_int,
-    /// < The UTF-8 button text
+    ///< The UTF-8 button text
     pub text: *const ::std::os::raw::c_char,
 }
 #[test]
@@ -15570,21 +15923,21 @@ fn bindgen_test_layout_SDL_MessageBoxColorScheme() {
         )
     );
 }
-/// \brief MessageBox structure containing title, text, window, etc.
+///  \brief MessageBox structure containing title, text, window, etc.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_MessageBoxData {
-    /// < ::SDL_MessageBoxFlags
+    ///< ::SDL_MessageBoxFlags
     pub flags: Uint32,
-    /// < Parent window, can be NULL
+    ///< Parent window, can be NULL
     pub window: *mut SDL_Window,
-    /// < UTF-8 title
+    ///< UTF-8 title
     pub title: *const ::std::os::raw::c_char,
-    /// < UTF-8 message text
+    ///< UTF-8 message text
     pub message: *const ::std::os::raw::c_char,
     pub numbuttons: ::std::os::raw::c_int,
     pub buttons: *const SDL_MessageBoxButtonData,
-    /// < ::SDL_MessageBoxColorScheme, can be NULL to use system settings
+    ///< ::SDL_MessageBoxColorScheme, can be NULL to use system settings
     pub colorScheme: *const SDL_MessageBoxColorScheme,
 }
 #[test]
@@ -15671,34 +16024,34 @@ fn bindgen_test_layout_SDL_MessageBoxData() {
     );
 }
 extern "C" {
-    /// \brief Create a modal message box.
+    ///  \brief Create a modal message box.
     ///
-    /// \param messageboxdata The SDL_MessageBoxData structure with title, text, etc.
-    /// \param buttonid The pointer to which user id of hit button should be copied.
+    ///  \param messageboxdata The SDL_MessageBoxData structure with title, text, etc.
+    ///  \param buttonid The pointer to which user id of hit button should be copied.
     ///
-    /// \return -1 on error, otherwise 0 and buttonid contains user id of button
-    /// hit or -1 if dialog was closed.
+    ///  \return -1 on error, otherwise 0 and buttonid contains user id of button
+    ///          hit or -1 if dialog was closed.
     ///
-    /// \note This function should be called on the thread that created the parent
-    /// window, or on the main thread if the messagebox has no parent.  It will
-    /// block execution of that thread until the user clicks a button or
-    /// closes the messagebox.
+    ///  \note This function should be called on the thread that created the parent
+    ///        window, or on the main thread if the messagebox has no parent.  It will
+    ///        block execution of that thread until the user clicks a button or
+    ///        closes the messagebox.
     pub fn SDL_ShowMessageBox(
         messageboxdata: *const SDL_MessageBoxData,
         buttonid: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Create a simple modal message box
+    ///  \brief Create a simple modal message box
     ///
-    /// \param flags    ::SDL_MessageBoxFlags
-    /// \param title    UTF-8 title text
-    /// \param message  UTF-8 message text
-    /// \param window   The parent window, or NULL for no parent
+    ///  \param flags    ::SDL_MessageBoxFlags
+    ///  \param title    UTF-8 title text
+    ///  \param message  UTF-8 message text
+    ///  \param window   The parent window, or NULL for no parent
     ///
-    /// \return 0 on success, -1 on error
+    ///  \return 0 on success, -1 on error
     ///
-    /// \sa SDL_ShowMessageBox
+    ///  \sa SDL_ShowMessageBox
     pub fn SDL_ShowSimpleMessageBox(
         flags: Uint32,
         title: *const ::std::os::raw::c_char,
@@ -15707,68 +16060,68 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
-/// \brief The basic state for the system's power supply.
+///  \brief The basic state for the system's power supply.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_PowerState {
-    /// < cannot determine power status
+    ///< cannot determine power status
     SDL_POWERSTATE_UNKNOWN = 0,
-    /// < Not plugged in, running on the battery
+    ///< Not plugged in, running on the battery
     SDL_POWERSTATE_ON_BATTERY = 1,
-    /// < Plugged in, no battery available
+    ///< Plugged in, no battery available
     SDL_POWERSTATE_NO_BATTERY = 2,
-    /// < Plugged in, charging battery
+    ///< Plugged in, charging battery
     SDL_POWERSTATE_CHARGING = 3,
-    /// < Plugged in, battery charged
+    ///< Plugged in, battery charged
     SDL_POWERSTATE_CHARGED = 4,
 }
 extern "C" {
-    /// \brief Get the current power supply details.
+    ///  \brief Get the current power supply details.
     ///
-    /// \param secs Seconds of battery life left. You can pass a NULL here if
-    /// you don't care. Will return -1 if we can't determine a
-    /// value, or we're not running on a battery.
+    ///  \param secs Seconds of battery life left. You can pass a NULL here if
+    ///              you don't care. Will return -1 if we can't determine a
+    ///              value, or we're not running on a battery.
     ///
-    /// \param pct Percentage of battery life left, between 0 and 100. You can
-    /// pass a NULL here if you don't care. Will return -1 if we
-    /// can't determine a value, or we're not running on a battery.
+    ///  \param pct Percentage of battery life left, between 0 and 100. You can
+    ///             pass a NULL here if you don't care. Will return -1 if we
+    ///             can't determine a value, or we're not running on a battery.
     ///
-    /// \return The state of the battery (if any).
+    ///  \return The state of the battery (if any).
     pub fn SDL_GetPowerInfo(
         secs: *mut ::std::os::raw::c_int,
         pct: *mut ::std::os::raw::c_int,
     ) -> SDL_PowerState;
 }
 #[repr(u32)]
-/// \brief Flags used when creating a rendering context
+///  \brief Flags used when creating a rendering context
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_RendererFlags {
-    /// < The renderer is a software fallback
+    ///< The renderer is a software fallback
     SDL_RENDERER_SOFTWARE = 1,
-    /// < The renderer uses hardware
-    /// acceleration
+    ///< The renderer uses hardware
+    ///acceleration
     SDL_RENDERER_ACCELERATED = 2,
-    /// < Present is synchronized
-    /// with the refresh rate
+    ///< Present is synchronized
+    ///with the refresh rate
     SDL_RENDERER_PRESENTVSYNC = 4,
-    /// < The renderer supports
-    /// rendering to texture
+    ///< The renderer supports
+    ///rendering to texture
     SDL_RENDERER_TARGETTEXTURE = 8,
 }
-/// \brief Information on the capabilities of a render driver or context.
+///  \brief Information on the capabilities of a render driver or context.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_RendererInfo {
-    /// < The name of the renderer
+    ///< The name of the renderer
     pub name: *const ::std::os::raw::c_char,
-    /// < Supported ::SDL_RendererFlags
+    ///< Supported ::SDL_RendererFlags
     pub flags: Uint32,
-    /// < The number of available texture formats
+    ///< The number of available texture formats
     pub num_texture_formats: Uint32,
-    /// < The available texture formats
+    ///< The available texture formats
     pub texture_formats: [Uint32; 16usize],
-    /// < The maximum texture width
+    ///< The maximum texture width
     pub max_texture_width: ::std::os::raw::c_int,
-    /// < The maximum texture height
+    ///< The maximum texture height
     pub max_texture_height: ::std::os::raw::c_int,
 }
 #[test]
@@ -15853,88 +16206,88 @@ fn bindgen_test_layout_SDL_RendererInfo() {
     );
 }
 #[repr(u32)]
-/// \brief The access pattern allowed for a texture.
+///  \brief The access pattern allowed for a texture.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_TextureAccess {
-    /// < Changes rarely, not lockable
+    ///< Changes rarely, not lockable
     SDL_TEXTUREACCESS_STATIC = 0,
-    /// < Changes frequently, lockable
+    ///< Changes frequently, lockable
     SDL_TEXTUREACCESS_STREAMING = 1,
-    /// < Texture can be used as a render target
+    ///< Texture can be used as a render target
     SDL_TEXTUREACCESS_TARGET = 2,
 }
 #[repr(u32)]
-/// \brief The texture channel modulation used in SDL_RenderCopy().
+///  \brief The texture channel modulation used in SDL_RenderCopy().
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_TextureModulate {
-    /// < No modulation
+    ///< No modulation
     SDL_TEXTUREMODULATE_NONE = 0,
-    /// < srcC = srcC * color
+    ///< srcC = srcC * color
     SDL_TEXTUREMODULATE_COLOR = 1,
-    /// < srcA = srcA * alpha
+    ///< srcA = srcA * alpha
     SDL_TEXTUREMODULATE_ALPHA = 2,
 }
 #[repr(u32)]
-/// \brief Flip constants for SDL_RenderCopyEx
+///  \brief Flip constants for SDL_RenderCopyEx
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_RendererFlip {
-    /// < Do not flip
+    ///< Do not flip
     SDL_FLIP_NONE = 0,
-    /// < flip horizontally
+    ///< flip horizontally
     SDL_FLIP_HORIZONTAL = 1,
-    /// < flip vertically
+    ///< flip vertically
     SDL_FLIP_VERTICAL = 2,
 }
-/// \brief A structure representing rendering state
+///  \brief A structure representing rendering state
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Renderer {
     _unused: [u8; 0],
 }
-/// \brief An efficient driver-specific representation of pixel data
+///  \brief An efficient driver-specific representation of pixel data
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_Texture {
     _unused: [u8; 0],
 }
 extern "C" {
-    /// \brief Get the number of 2D rendering drivers available for the current
-    /// display.
+    ///  \brief Get the number of 2D rendering drivers available for the current
+    ///         display.
     ///
-    /// A render driver is a set of code that handles rendering and texture
-    /// management on a particular display.  Normally there is only one, but
-    /// some drivers may have several available with different capabilities.
+    ///  A render driver is a set of code that handles rendering and texture
+    ///  management on a particular display.  Normally there is only one, but
+    ///  some drivers may have several available with different capabilities.
     ///
-    /// \sa SDL_GetRenderDriverInfo()
-    /// \sa SDL_CreateRenderer()
+    ///  \sa SDL_GetRenderDriverInfo()
+    ///  \sa SDL_CreateRenderer()
     pub fn SDL_GetNumRenderDrivers() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get information about a specific 2D rendering driver for the current
-    /// display.
+    ///  \brief Get information about a specific 2D rendering driver for the current
+    ///         display.
     ///
-    /// \param index The index of the driver to query information about.
-    /// \param info  A pointer to an SDL_RendererInfo struct to be filled with
-    /// information on the rendering driver.
+    ///  \param index The index of the driver to query information about.
+    ///  \param info  A pointer to an SDL_RendererInfo struct to be filled with
+    ///               information on the rendering driver.
     ///
-    /// \return 0 on success, -1 if the index was out of range.
+    ///  \return 0 on success, -1 if the index was out of range.
     ///
-    /// \sa SDL_CreateRenderer()
+    ///  \sa SDL_CreateRenderer()
     pub fn SDL_GetRenderDriverInfo(
         index: ::std::os::raw::c_int,
         info: *mut SDL_RendererInfo,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Create a window and default renderer
+    ///  \brief Create a window and default renderer
     ///
-    /// \param width    The width of the window
-    /// \param height   The height of the window
-    /// \param window_flags The flags used to create the window
-    /// \param window   A pointer filled with the window, or NULL on error
-    /// \param renderer A pointer filled with the renderer, or NULL on error
+    ///  \param width    The width of the window
+    ///  \param height   The height of the window
+    ///  \param window_flags The flags used to create the window
+    ///  \param window   A pointer filled with the window, or NULL on error
+    ///  \param renderer A pointer filled with the renderer, or NULL on error
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_CreateWindowAndRenderer(
         width: ::std::os::raw::c_int,
         height: ::std::os::raw::c_int,
@@ -15944,18 +16297,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Create a 2D rendering context for a window.
+    ///  \brief Create a 2D rendering context for a window.
     ///
-    /// \param window The window where rendering is displayed.
-    /// \param index    The index of the rendering driver to initialize, or -1 to
-    /// initialize the first one supporting the requested flags.
-    /// \param flags    ::SDL_RendererFlags.
+    ///  \param window The window where rendering is displayed.
+    ///  \param index    The index of the rendering driver to initialize, or -1 to
+    ///                  initialize the first one supporting the requested flags.
+    ///  \param flags    ::SDL_RendererFlags.
     ///
-    /// \return A valid rendering context or NULL if there was an error.
+    ///  \return A valid rendering context or NULL if there was an error.
     ///
-    /// \sa SDL_CreateSoftwareRenderer()
-    /// \sa SDL_GetRendererInfo()
-    /// \sa SDL_DestroyRenderer()
+    ///  \sa SDL_CreateSoftwareRenderer()
+    ///  \sa SDL_GetRendererInfo()
+    ///  \sa SDL_DestroyRenderer()
     pub fn SDL_CreateRenderer(
         window: *mut SDL_Window,
         index: ::std::os::raw::c_int,
@@ -15963,29 +16316,29 @@ extern "C" {
     ) -> *mut SDL_Renderer;
 }
 extern "C" {
-    /// \brief Create a 2D software rendering context for a surface.
+    ///  \brief Create a 2D software rendering context for a surface.
     ///
-    /// \param surface The surface where rendering is done.
+    ///  \param surface The surface where rendering is done.
     ///
-    /// \return A valid rendering context or NULL if there was an error.
+    ///  \return A valid rendering context or NULL if there was an error.
     ///
-    /// \sa SDL_CreateRenderer()
-    /// \sa SDL_DestroyRenderer()
+    ///  \sa SDL_CreateRenderer()
+    ///  \sa SDL_DestroyRenderer()
     pub fn SDL_CreateSoftwareRenderer(surface: *mut SDL_Surface) -> *mut SDL_Renderer;
 }
 extern "C" {
-    /// \brief Get the renderer associated with a window.
+    ///  \brief Get the renderer associated with a window.
     pub fn SDL_GetRenderer(window: *mut SDL_Window) -> *mut SDL_Renderer;
 }
 extern "C" {
-    /// \brief Get information about a rendering context.
+    ///  \brief Get information about a rendering context.
     pub fn SDL_GetRendererInfo(
         renderer: *mut SDL_Renderer,
         info: *mut SDL_RendererInfo,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the output size in pixels of a rendering context.
+    ///  \brief Get the output size in pixels of a rendering context.
     pub fn SDL_GetRendererOutputSize(
         renderer: *mut SDL_Renderer,
         w: *mut ::std::os::raw::c_int,
@@ -15993,23 +16346,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Create a texture for a rendering context.
+    ///  \brief Create a texture for a rendering context.
     ///
-    /// \param renderer The renderer.
-    /// \param format The format of the texture.
-    /// \param access One of the enumerated values in ::SDL_TextureAccess.
-    /// \param w      The width of the texture in pixels.
-    /// \param h      The height of the texture in pixels.
+    ///  \param renderer The renderer.
+    ///  \param format The format of the texture.
+    ///  \param access One of the enumerated values in ::SDL_TextureAccess.
+    ///  \param w      The width of the texture in pixels.
+    ///  \param h      The height of the texture in pixels.
     ///
-    /// \return The created texture is returned, or NULL if no rendering context was
-    /// active,  the format was unsupported, or the width or height were out
-    /// of range.
+    ///  \return The created texture is returned, or NULL if no rendering context was
+    ///          active,  the format was unsupported, or the width or height were out
+    ///          of range.
     ///
-    /// \note The contents of the texture are not defined at creation.
+    ///  \note The contents of the texture are not defined at creation.
     ///
-    /// \sa SDL_QueryTexture()
-    /// \sa SDL_UpdateTexture()
-    /// \sa SDL_DestroyTexture()
+    ///  \sa SDL_QueryTexture()
+    ///  \sa SDL_UpdateTexture()
+    ///  \sa SDL_DestroyTexture()
     pub fn SDL_CreateTexture(
         renderer: *mut SDL_Renderer,
         format: Uint32,
@@ -16019,34 +16372,34 @@ extern "C" {
     ) -> *mut SDL_Texture;
 }
 extern "C" {
-    /// \brief Create a texture from an existing surface.
+    ///  \brief Create a texture from an existing surface.
     ///
-    /// \param renderer The renderer.
-    /// \param surface The surface containing pixel data used to fill the texture.
+    ///  \param renderer The renderer.
+    ///  \param surface The surface containing pixel data used to fill the texture.
     ///
-    /// \return The created texture is returned, or NULL on error.
+    ///  \return The created texture is returned, or NULL on error.
     ///
-    /// \note The surface is not modified or freed by this function.
+    ///  \note The surface is not modified or freed by this function.
     ///
-    /// \sa SDL_QueryTexture()
-    /// \sa SDL_DestroyTexture()
+    ///  \sa SDL_QueryTexture()
+    ///  \sa SDL_DestroyTexture()
     pub fn SDL_CreateTextureFromSurface(
         renderer: *mut SDL_Renderer,
         surface: *mut SDL_Surface,
     ) -> *mut SDL_Texture;
 }
 extern "C" {
-    /// \brief Query the attributes of a texture
+    ///  \brief Query the attributes of a texture
     ///
-    /// \param texture A texture to be queried.
-    /// \param format  A pointer filled in with the raw format of the texture.  The
-    /// actual format may differ, but pixel transfers will use this
-    /// format.
-    /// \param access  A pointer filled in with the actual access to the texture.
-    /// \param w       A pointer filled in with the width of the texture in pixels.
-    /// \param h       A pointer filled in with the height of the texture in pixels.
+    ///  \param texture A texture to be queried.
+    ///  \param format  A pointer filled in with the raw format of the texture.  The
+    ///                 actual format may differ, but pixel transfers will use this
+    ///                 format.
+    ///  \param access  A pointer filled in with the actual access to the texture.
+    ///  \param w       A pointer filled in with the width of the texture in pixels.
+    ///  \param h       A pointer filled in with the height of the texture in pixels.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     pub fn SDL_QueryTexture(
         texture: *mut SDL_Texture,
         format: *mut Uint32,
@@ -16056,17 +16409,17 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set an additional color value used in render copy operations.
+    ///  \brief Set an additional color value used in render copy operations.
     ///
-    /// \param texture The texture to update.
-    /// \param r       The red color value multiplied into copy operations.
-    /// \param g       The green color value multiplied into copy operations.
-    /// \param b       The blue color value multiplied into copy operations.
+    ///  \param texture The texture to update.
+    ///  \param r       The red color value multiplied into copy operations.
+    ///  \param g       The green color value multiplied into copy operations.
+    ///  \param b       The blue color value multiplied into copy operations.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid or color modulation
-    /// is not supported.
+    ///  \return 0 on success, or -1 if the texture is not valid or color modulation
+    ///          is not supported.
     ///
-    /// \sa SDL_GetTextureColorMod()
+    ///  \sa SDL_GetTextureColorMod()
     pub fn SDL_SetTextureColorMod(
         texture: *mut SDL_Texture,
         r: Uint8,
@@ -16075,16 +16428,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the additional color value used in render copy operations.
+    ///  \brief Get the additional color value used in render copy operations.
     ///
-    /// \param texture The texture to query.
-    /// \param r         A pointer filled in with the current red color value.
-    /// \param g         A pointer filled in with the current green color value.
-    /// \param b         A pointer filled in with the current blue color value.
+    ///  \param texture The texture to query.
+    ///  \param r         A pointer filled in with the current red color value.
+    ///  \param g         A pointer filled in with the current green color value.
+    ///  \param b         A pointer filled in with the current blue color value.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     ///
-    /// \sa SDL_SetTextureColorMod()
+    ///  \sa SDL_SetTextureColorMod()
     pub fn SDL_GetTextureColorMod(
         texture: *mut SDL_Texture,
         r: *mut Uint8,
@@ -16093,79 +16446,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set an additional alpha value used in render copy operations.
+    ///  \brief Set an additional alpha value used in render copy operations.
     ///
-    /// \param texture The texture to update.
-    /// \param alpha     The alpha value multiplied into copy operations.
+    ///  \param texture The texture to update.
+    ///  \param alpha     The alpha value multiplied into copy operations.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid or alpha modulation
-    /// is not supported.
+    ///  \return 0 on success, or -1 if the texture is not valid or alpha modulation
+    ///          is not supported.
     ///
-    /// \sa SDL_GetTextureAlphaMod()
+    ///  \sa SDL_GetTextureAlphaMod()
     pub fn SDL_SetTextureAlphaMod(texture: *mut SDL_Texture, alpha: Uint8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the additional alpha value used in render copy operations.
+    ///  \brief Get the additional alpha value used in render copy operations.
     ///
-    /// \param texture The texture to query.
-    /// \param alpha     A pointer filled in with the current alpha value.
+    ///  \param texture The texture to query.
+    ///  \param alpha     A pointer filled in with the current alpha value.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     ///
-    /// \sa SDL_SetTextureAlphaMod()
+    ///  \sa SDL_SetTextureAlphaMod()
     pub fn SDL_GetTextureAlphaMod(
         texture: *mut SDL_Texture,
         alpha: *mut Uint8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the blend mode used for texture copy operations.
+    ///  \brief Set the blend mode used for texture copy operations.
     ///
-    /// \param texture The texture to update.
-    /// \param blendMode ::SDL_BlendMode to use for texture blending.
+    ///  \param texture The texture to update.
+    ///  \param blendMode ::SDL_BlendMode to use for texture blending.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid or the blend mode is
-    /// not supported.
+    ///  \return 0 on success, or -1 if the texture is not valid or the blend mode is
+    ///          not supported.
     ///
-    /// \note If the blend mode is not supported, the closest supported mode is
-    /// chosen.
+    ///  \note If the blend mode is not supported, the closest supported mode is
+    ///        chosen.
     ///
-    /// \sa SDL_GetTextureBlendMode()
+    ///  \sa SDL_GetTextureBlendMode()
     pub fn SDL_SetTextureBlendMode(
         texture: *mut SDL_Texture,
         blendMode: SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the blend mode used for texture copy operations.
+    ///  \brief Get the blend mode used for texture copy operations.
     ///
-    /// \param texture   The texture to query.
-    /// \param blendMode A pointer filled in with the current blend mode.
+    ///  \param texture   The texture to query.
+    ///  \param blendMode A pointer filled in with the current blend mode.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     ///
-    /// \sa SDL_SetTextureBlendMode()
+    ///  \sa SDL_SetTextureBlendMode()
     pub fn SDL_GetTextureBlendMode(
         texture: *mut SDL_Texture,
         blendMode: *mut SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Update the given texture rectangle with new pixel data.
+    ///  \brief Update the given texture rectangle with new pixel data.
     ///
-    /// \param texture   The texture to update
-    /// \param rect      A pointer to the rectangle of pixels to update, or NULL to
-    /// update the entire texture.
-    /// \param pixels    The raw pixel data in the format of the texture.
-    /// \param pitch     The number of bytes in a row of pixel data, including padding between lines.
+    ///  \param texture   The texture to update
+    ///  \param rect      A pointer to the rectangle of pixels to update, or NULL to
+    ///                   update the entire texture.
+    ///  \param pixels    The raw pixel data in the format of the texture.
+    ///  \param pitch     The number of bytes in a row of pixel data, including padding between lines.
     ///
-    /// The pixel data must be in the format of the texture. The pixel format can be
-    /// queried with SDL_QueryTexture.
+    ///  The pixel data must be in the format of the texture. The pixel format can be
+    ///  queried with SDL_QueryTexture.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     ///
-    /// \note This is a fairly slow function.
+    ///  \note This is a fairly slow function.
     pub fn SDL_UpdateTexture(
         texture: *mut SDL_Texture,
         rect: *const SDL_Rect,
@@ -16174,23 +16527,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Update a rectangle within a planar YV12 or IYUV texture with new pixel data.
+    ///  \brief Update a rectangle within a planar YV12 or IYUV texture with new pixel data.
     ///
-    /// \param texture   The texture to update
-    /// \param rect      A pointer to the rectangle of pixels to update, or NULL to
-    /// update the entire texture.
-    /// \param Yplane    The raw pixel data for the Y plane.
-    /// \param Ypitch    The number of bytes between rows of pixel data for the Y plane.
-    /// \param Uplane    The raw pixel data for the U plane.
-    /// \param Upitch    The number of bytes between rows of pixel data for the U plane.
-    /// \param Vplane    The raw pixel data for the V plane.
-    /// \param Vpitch    The number of bytes between rows of pixel data for the V plane.
+    ///  \param texture   The texture to update
+    ///  \param rect      A pointer to the rectangle of pixels to update, or NULL to
+    ///                   update the entire texture.
+    ///  \param Yplane    The raw pixel data for the Y plane.
+    ///  \param Ypitch    The number of bytes between rows of pixel data for the Y plane.
+    ///  \param Uplane    The raw pixel data for the U plane.
+    ///  \param Upitch    The number of bytes between rows of pixel data for the U plane.
+    ///  \param Vplane    The raw pixel data for the V plane.
+    ///  \param Vpitch    The number of bytes between rows of pixel data for the V plane.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid.
+    ///  \return 0 on success, or -1 if the texture is not valid.
     ///
-    /// \note You can use SDL_UpdateTexture() as long as your pixel data is
-    /// a contiguous block of Y and U/V planes in the proper order, but
-    /// this function is available if your pixel data is not contiguous.
+    ///  \note You can use SDL_UpdateTexture() as long as your pixel data is
+    ///        a contiguous block of Y and U/V planes in the proper order, but
+    ///        this function is available if your pixel data is not contiguous.
     pub fn SDL_UpdateYUVTexture(
         texture: *mut SDL_Texture,
         rect: *const SDL_Rect,
@@ -16203,19 +16556,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Lock a portion of the texture for write-only pixel access.
+    ///  \brief Lock a portion of the texture for write-only pixel access.
     ///
-    /// \param texture   The texture to lock for access, which was created with
-    /// ::SDL_TEXTUREACCESS_STREAMING.
-    /// \param rect      A pointer to the rectangle to lock for access. If the rect
-    /// is NULL, the entire texture will be locked.
-    /// \param pixels    This is filled in with a pointer to the locked pixels,
-    /// appropriately offset by the locked area.
-    /// \param pitch     This is filled in with the pitch of the locked pixels.
+    ///  \param texture   The texture to lock for access, which was created with
+    ///                   ::SDL_TEXTUREACCESS_STREAMING.
+    ///  \param rect      A pointer to the rectangle to lock for access. If the rect
+    ///                   is NULL, the entire texture will be locked.
+    ///  \param pixels    This is filled in with a pointer to the locked pixels,
+    ///                   appropriately offset by the locked area.
+    ///  \param pitch     This is filled in with the pitch of the locked pixels.
     ///
-    /// \return 0 on success, or -1 if the texture is not valid or was not created with ::SDL_TEXTUREACCESS_STREAMING.
+    ///  \return 0 on success, or -1 if the texture is not valid or was not created with ::SDL_TEXTUREACCESS_STREAMING.
     ///
-    /// \sa SDL_UnlockTexture()
+    ///  \sa SDL_UnlockTexture()
     pub fn SDL_LockTexture(
         texture: *mut SDL_Texture,
         rect: *const SDL_Rect,
@@ -16224,9 +16577,9 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Unlock a texture, uploading the changes to video memory, if needed.
+    ///  \brief Unlock a texture, uploading the changes to video memory, if needed.
     ///
-    /// \sa SDL_LockTexture()
+    ///  \sa SDL_LockTexture()
     pub fn SDL_UnlockTexture(texture: *mut SDL_Texture);
 }
 extern "C" {
@@ -16245,7 +16598,7 @@ extern "C" {
     ///
     /// \return 0 on success, or -1 on error
     ///
-    /// \sa SDL_GetRenderTarget()
+    ///  \sa SDL_GetRenderTarget()
     pub fn SDL_SetRenderTarget(
         renderer: *mut SDL_Renderer,
         texture: *mut SDL_Texture,
@@ -16256,31 +16609,31 @@ extern "C" {
     ///
     /// \return The current render target
     ///
-    /// \sa SDL_SetRenderTarget()
+    ///  \sa SDL_SetRenderTarget()
     pub fn SDL_GetRenderTarget(renderer: *mut SDL_Renderer) -> *mut SDL_Texture;
 }
 extern "C" {
-    /// \brief Set device independent resolution for rendering
+    ///  \brief Set device independent resolution for rendering
     ///
-    /// \param renderer The renderer for which resolution should be set.
-    /// \param w      The width of the logical resolution
-    /// \param h      The height of the logical resolution
+    ///  \param renderer The renderer for which resolution should be set.
+    ///  \param w      The width of the logical resolution
+    ///  \param h      The height of the logical resolution
     ///
-    /// This function uses the viewport and scaling functionality to allow a fixed logical
-    /// resolution for rendering, regardless of the actual output resolution.  If the actual
-    /// output resolution doesn't have the same aspect ratio the output rendering will be
-    /// centered within the output display.
+    ///  This function uses the viewport and scaling functionality to allow a fixed logical
+    ///  resolution for rendering, regardless of the actual output resolution.  If the actual
+    ///  output resolution doesn't have the same aspect ratio the output rendering will be
+    ///  centered within the output display.
     ///
-    /// If the output display is a window, mouse events in the window will be filtered
-    /// and scaled so they seem to arrive within the logical resolution.
+    ///  If the output display is a window, mouse events in the window will be filtered
+    ///  and scaled so they seem to arrive within the logical resolution.
     ///
-    /// \note If this function results in scaling or subpixel drawing by the
-    /// rendering backend, it will be handled using the appropriate
-    /// quality hints.
+    ///  \note If this function results in scaling or subpixel drawing by the
+    ///        rendering backend, it will be handled using the appropriate
+    ///        quality hints.
     ///
-    /// \sa SDL_RenderGetLogicalSize()
-    /// \sa SDL_RenderSetScale()
-    /// \sa SDL_RenderSetViewport()
+    ///  \sa SDL_RenderGetLogicalSize()
+    ///  \sa SDL_RenderSetScale()
+    ///  \sa SDL_RenderSetViewport()
     pub fn SDL_RenderSetLogicalSize(
         renderer: *mut SDL_Renderer,
         w: ::std::os::raw::c_int,
@@ -16288,13 +16641,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get device independent resolution for rendering
+    ///  \brief Get device independent resolution for rendering
     ///
-    /// \param renderer The renderer from which resolution should be queried.
-    /// \param w      A pointer filled with the width of the logical resolution
-    /// \param h      A pointer filled with the height of the logical resolution
+    ///  \param renderer The renderer from which resolution should be queried.
+    ///  \param w      A pointer filled with the width of the logical resolution
+    ///  \param h      A pointer filled with the height of the logical resolution
     ///
-    /// \sa SDL_RenderSetLogicalSize()
+    ///  \sa SDL_RenderSetLogicalSize()
     pub fn SDL_RenderGetLogicalSize(
         renderer: *mut SDL_Renderer,
         w: *mut ::std::os::raw::c_int,
@@ -16302,104 +16655,104 @@ extern "C" {
     );
 }
 extern "C" {
-    /// \brief Set whether to force integer scales for resolution-independent rendering
+    ///  \brief Set whether to force integer scales for resolution-independent rendering
     ///
-    /// \param renderer The renderer for which integer scaling should be set.
-    /// \param enable   Enable or disable integer scaling
+    ///  \param renderer The renderer for which integer scaling should be set.
+    ///  \param enable   Enable or disable integer scaling
     ///
-    /// This function restricts the logical viewport to integer values - that is, when
-    /// a resolution is between two multiples of a logical size, the viewport size is
-    /// rounded down to the lower multiple.
+    ///  This function restricts the logical viewport to integer values - that is, when
+    ///  a resolution is between two multiples of a logical size, the viewport size is
+    ///  rounded down to the lower multiple.
     ///
-    /// \sa SDL_RenderSetLogicalSize()
+    ///  \sa SDL_RenderSetLogicalSize()
     pub fn SDL_RenderSetIntegerScale(
         renderer: *mut SDL_Renderer,
         enable: SDL_bool,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get whether integer scales are forced for resolution-independent rendering
+    ///  \brief Get whether integer scales are forced for resolution-independent rendering
     ///
-    /// \param renderer The renderer from which integer scaling should be queried.
+    ///  \param renderer The renderer from which integer scaling should be queried.
     ///
-    /// \sa SDL_RenderSetIntegerScale()
+    ///  \sa SDL_RenderSetIntegerScale()
     pub fn SDL_RenderGetIntegerScale(renderer: *mut SDL_Renderer) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Set the drawing area for rendering on the current target.
+    ///  \brief Set the drawing area for rendering on the current target.
     ///
-    /// \param renderer The renderer for which the drawing area should be set.
-    /// \param rect The rectangle representing the drawing area, or NULL to set the viewport to the entire target.
+    ///  \param renderer The renderer for which the drawing area should be set.
+    ///  \param rect The rectangle representing the drawing area, or NULL to set the viewport to the entire target.
     ///
-    /// The x,y of the viewport rect represents the origin for rendering.
+    ///  The x,y of the viewport rect represents the origin for rendering.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     ///
-    /// \note If the window associated with the renderer is resized, the viewport is automatically reset.
+    ///  \note If the window associated with the renderer is resized, the viewport is automatically reset.
     ///
-    /// \sa SDL_RenderGetViewport()
-    /// \sa SDL_RenderSetLogicalSize()
+    ///  \sa SDL_RenderGetViewport()
+    ///  \sa SDL_RenderSetLogicalSize()
     pub fn SDL_RenderSetViewport(
         renderer: *mut SDL_Renderer,
         rect: *const SDL_Rect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the drawing area for the current target.
+    ///  \brief Get the drawing area for the current target.
     ///
-    /// \sa SDL_RenderSetViewport()
+    ///  \sa SDL_RenderSetViewport()
     pub fn SDL_RenderGetViewport(renderer: *mut SDL_Renderer, rect: *mut SDL_Rect);
 }
 extern "C" {
-    /// \brief Set the clip rectangle for the current target.
+    ///  \brief Set the clip rectangle for the current target.
     ///
-    /// \param renderer The renderer for which clip rectangle should be set.
-    /// \param rect   A pointer to the rectangle to set as the clip rectangle, or
-    /// NULL to disable clipping.
+    ///  \param renderer The renderer for which clip rectangle should be set.
+    ///  \param rect   A pointer to the rectangle to set as the clip rectangle, or
+    ///                NULL to disable clipping.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     ///
-    /// \sa SDL_RenderGetClipRect()
+    ///  \sa SDL_RenderGetClipRect()
     pub fn SDL_RenderSetClipRect(
         renderer: *mut SDL_Renderer,
         rect: *const SDL_Rect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the clip rectangle for the current target.
+    ///  \brief Get the clip rectangle for the current target.
     ///
-    /// \param renderer The renderer from which clip rectangle should be queried.
-    /// \param rect   A pointer filled in with the current clip rectangle, or
-    /// an empty rectangle if clipping is disabled.
+    ///  \param renderer The renderer from which clip rectangle should be queried.
+    ///  \param rect   A pointer filled in with the current clip rectangle, or
+    ///                an empty rectangle if clipping is disabled.
     ///
-    /// \sa SDL_RenderSetClipRect()
+    ///  \sa SDL_RenderSetClipRect()
     pub fn SDL_RenderGetClipRect(renderer: *mut SDL_Renderer, rect: *mut SDL_Rect);
 }
 extern "C" {
-    /// \brief Get whether clipping is enabled on the given renderer.
+    ///  \brief Get whether clipping is enabled on the given renderer.
     ///
-    /// \param renderer The renderer from which clip state should be queried.
+    ///  \param renderer The renderer from which clip state should be queried.
     ///
-    /// \sa SDL_RenderGetClipRect()
+    ///  \sa SDL_RenderGetClipRect()
     pub fn SDL_RenderIsClipEnabled(renderer: *mut SDL_Renderer) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Set the drawing scale for rendering on the current target.
+    ///  \brief Set the drawing scale for rendering on the current target.
     ///
-    /// \param renderer The renderer for which the drawing scale should be set.
-    /// \param scaleX The horizontal scaling factor
-    /// \param scaleY The vertical scaling factor
+    ///  \param renderer The renderer for which the drawing scale should be set.
+    ///  \param scaleX The horizontal scaling factor
+    ///  \param scaleY The vertical scaling factor
     ///
-    /// The drawing coordinates are scaled by the x/y scaling factors
-    /// before they are used by the renderer.  This allows resolution
-    /// independent drawing with a single coordinate system.
+    ///  The drawing coordinates are scaled by the x/y scaling factors
+    ///  before they are used by the renderer.  This allows resolution
+    ///  independent drawing with a single coordinate system.
     ///
-    /// \note If this results in scaling or subpixel drawing by the
-    /// rendering backend, it will be handled using the appropriate
-    /// quality hints.  For best results use integer scaling factors.
+    ///  \note If this results in scaling or subpixel drawing by the
+    ///        rendering backend, it will be handled using the appropriate
+    ///        quality hints.  For best results use integer scaling factors.
     ///
-    /// \sa SDL_RenderGetScale()
-    /// \sa SDL_RenderSetLogicalSize()
+    ///  \sa SDL_RenderGetScale()
+    ///  \sa SDL_RenderSetLogicalSize()
     pub fn SDL_RenderSetScale(
         renderer: *mut SDL_Renderer,
         scaleX: f32,
@@ -16407,26 +16760,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the drawing scale for the current target.
+    ///  \brief Get the drawing scale for the current target.
     ///
-    /// \param renderer The renderer from which drawing scale should be queried.
-    /// \param scaleX A pointer filled in with the horizontal scaling factor
-    /// \param scaleY A pointer filled in with the vertical scaling factor
+    ///  \param renderer The renderer from which drawing scale should be queried.
+    ///  \param scaleX A pointer filled in with the horizontal scaling factor
+    ///  \param scaleY A pointer filled in with the vertical scaling factor
     ///
-    /// \sa SDL_RenderSetScale()
+    ///  \sa SDL_RenderSetScale()
     pub fn SDL_RenderGetScale(renderer: *mut SDL_Renderer, scaleX: *mut f32, scaleY: *mut f32);
 }
 extern "C" {
-    /// \brief Set the color used for drawing operations (Rect, Line and Clear).
+    ///  \brief Set the color used for drawing operations (Rect, Line and Clear).
     ///
-    /// \param renderer The renderer for which drawing color should be set.
-    /// \param r The red value used to draw on the rendering target.
-    /// \param g The green value used to draw on the rendering target.
-    /// \param b The blue value used to draw on the rendering target.
-    /// \param a The alpha value used to draw on the rendering target, usually
-    /// ::SDL_ALPHA_OPAQUE (255).
+    ///  \param renderer The renderer for which drawing color should be set.
+    ///  \param r The red value used to draw on the rendering target.
+    ///  \param g The green value used to draw on the rendering target.
+    ///  \param b The blue value used to draw on the rendering target.
+    ///  \param a The alpha value used to draw on the rendering target, usually
+    ///           ::SDL_ALPHA_OPAQUE (255).
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_SetRenderDrawColor(
         renderer: *mut SDL_Renderer,
         r: Uint8,
@@ -16436,16 +16789,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the color used for drawing operations (Rect, Line and Clear).
+    ///  \brief Get the color used for drawing operations (Rect, Line and Clear).
     ///
-    /// \param renderer The renderer from which drawing color should be queried.
-    /// \param r A pointer to the red value used to draw on the rendering target.
-    /// \param g A pointer to the green value used to draw on the rendering target.
-    /// \param b A pointer to the blue value used to draw on the rendering target.
-    /// \param a A pointer to the alpha value used to draw on the rendering target,
-    /// usually ::SDL_ALPHA_OPAQUE (255).
+    ///  \param renderer The renderer from which drawing color should be queried.
+    ///  \param r A pointer to the red value used to draw on the rendering target.
+    ///  \param g A pointer to the green value used to draw on the rendering target.
+    ///  \param b A pointer to the blue value used to draw on the rendering target.
+    ///  \param a A pointer to the alpha value used to draw on the rendering target,
+    ///           usually ::SDL_ALPHA_OPAQUE (255).
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_GetRenderDrawColor(
         renderer: *mut SDL_Renderer,
         r: *mut Uint8,
@@ -16455,53 +16808,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Set the blend mode used for drawing operations (Fill and Line).
+    ///  \brief Set the blend mode used for drawing operations (Fill and Line).
     ///
-    /// \param renderer The renderer for which blend mode should be set.
-    /// \param blendMode ::SDL_BlendMode to use for blending.
+    ///  \param renderer The renderer for which blend mode should be set.
+    ///  \param blendMode ::SDL_BlendMode to use for blending.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     ///
-    /// \note If the blend mode is not supported, the closest supported mode is
-    /// chosen.
+    ///  \note If the blend mode is not supported, the closest supported mode is
+    ///        chosen.
     ///
-    /// \sa SDL_GetRenderDrawBlendMode()
+    ///  \sa SDL_GetRenderDrawBlendMode()
     pub fn SDL_SetRenderDrawBlendMode(
         renderer: *mut SDL_Renderer,
         blendMode: SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the blend mode used for drawing operations.
+    ///  \brief Get the blend mode used for drawing operations.
     ///
-    /// \param renderer The renderer from which blend mode should be queried.
-    /// \param blendMode A pointer filled in with the current blend mode.
+    ///  \param renderer The renderer from which blend mode should be queried.
+    ///  \param blendMode A pointer filled in with the current blend mode.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     ///
-    /// \sa SDL_SetRenderDrawBlendMode()
+    ///  \sa SDL_SetRenderDrawBlendMode()
     pub fn SDL_GetRenderDrawBlendMode(
         renderer: *mut SDL_Renderer,
         blendMode: *mut SDL_BlendMode,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Clear the current rendering target with the drawing color
+    ///  \brief Clear the current rendering target with the drawing color
     ///
-    /// This function clears the entire rendering target, ignoring the viewport and
-    /// the clip rectangle.
+    ///  This function clears the entire rendering target, ignoring the viewport and
+    ///  the clip rectangle.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderClear(renderer: *mut SDL_Renderer) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw a point on the current rendering target.
+    ///  \brief Draw a point on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw a point.
-    /// \param x The x coordinate of the point.
-    /// \param y The y coordinate of the point.
+    ///  \param renderer The renderer which should draw a point.
+    ///  \param x The x coordinate of the point.
+    ///  \param y The y coordinate of the point.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawPoint(
         renderer: *mut SDL_Renderer,
         x: ::std::os::raw::c_int,
@@ -16509,13 +16862,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw multiple points on the current rendering target.
+    ///  \brief Draw multiple points on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw multiple points.
-    /// \param points The points to draw
-    /// \param count The number of points to draw
+    ///  \param renderer The renderer which should draw multiple points.
+    ///  \param points The points to draw
+    ///  \param count The number of points to draw
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawPoints(
         renderer: *mut SDL_Renderer,
         points: *const SDL_Point,
@@ -16523,15 +16876,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw a line on the current rendering target.
+    ///  \brief Draw a line on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw a line.
-    /// \param x1 The x coordinate of the start point.
-    /// \param y1 The y coordinate of the start point.
-    /// \param x2 The x coordinate of the end point.
-    /// \param y2 The y coordinate of the end point.
+    ///  \param renderer The renderer which should draw a line.
+    ///  \param x1 The x coordinate of the start point.
+    ///  \param y1 The y coordinate of the start point.
+    ///  \param x2 The x coordinate of the end point.
+    ///  \param y2 The y coordinate of the end point.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawLine(
         renderer: *mut SDL_Renderer,
         x1: ::std::os::raw::c_int,
@@ -16541,13 +16894,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw a series of connected lines on the current rendering target.
+    ///  \brief Draw a series of connected lines on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw multiple lines.
-    /// \param points The points along the lines
-    /// \param count The number of points, drawing count-1 lines
+    ///  \param renderer The renderer which should draw multiple lines.
+    ///  \param points The points along the lines
+    ///  \param count The number of points, drawing count-1 lines
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawLines(
         renderer: *mut SDL_Renderer,
         points: *const SDL_Point,
@@ -16555,25 +16908,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw a rectangle on the current rendering target.
+    ///  \brief Draw a rectangle on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw a rectangle.
-    /// \param rect A pointer to the destination rectangle, or NULL to outline the entire rendering target.
+    ///  \param renderer The renderer which should draw a rectangle.
+    ///  \param rect A pointer to the destination rectangle, or NULL to outline the entire rendering target.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawRect(
         renderer: *mut SDL_Renderer,
         rect: *const SDL_Rect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Draw some number of rectangles on the current rendering target.
+    ///  \brief Draw some number of rectangles on the current rendering target.
     ///
-    /// \param renderer The renderer which should draw multiple rectangles.
-    /// \param rects A pointer to an array of destination rectangles.
-    /// \param count The number of rectangles.
+    ///  \param renderer The renderer which should draw multiple rectangles.
+    ///  \param rects A pointer to an array of destination rectangles.
+    ///  \param count The number of rectangles.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderDrawRects(
         renderer: *mut SDL_Renderer,
         rects: *const SDL_Rect,
@@ -16581,26 +16934,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill a rectangle on the current rendering target with the drawing color.
+    ///  \brief Fill a rectangle on the current rendering target with the drawing color.
     ///
-    /// \param renderer The renderer which should fill a rectangle.
-    /// \param rect A pointer to the destination rectangle, or NULL for the entire
-    /// rendering target.
+    ///  \param renderer The renderer which should fill a rectangle.
+    ///  \param rect A pointer to the destination rectangle, or NULL for the entire
+    ///              rendering target.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderFillRect(
         renderer: *mut SDL_Renderer,
         rect: *const SDL_Rect,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Fill some number of rectangles on the current rendering target with the drawing color.
+    ///  \brief Fill some number of rectangles on the current rendering target with the drawing color.
     ///
-    /// \param renderer The renderer which should fill multiple rectangles.
-    /// \param rects A pointer to an array of destination rectangles.
-    /// \param count The number of rectangles.
+    ///  \param renderer The renderer which should fill multiple rectangles.
+    ///  \param rects A pointer to an array of destination rectangles.
+    ///  \param count The number of rectangles.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderFillRects(
         renderer: *mut SDL_Renderer,
         rects: *const SDL_Rect,
@@ -16608,16 +16961,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Copy a portion of the texture to the current rendering target.
+    ///  \brief Copy a portion of the texture to the current rendering target.
     ///
-    /// \param renderer The renderer which should copy parts of a texture.
-    /// \param texture The source texture.
-    /// \param srcrect   A pointer to the source rectangle, or NULL for the entire
-    /// texture.
-    /// \param dstrect   A pointer to the destination rectangle, or NULL for the
-    /// entire rendering target.
+    ///  \param renderer The renderer which should copy parts of a texture.
+    ///  \param texture The source texture.
+    ///  \param srcrect   A pointer to the source rectangle, or NULL for the entire
+    ///                   texture.
+    ///  \param dstrect   A pointer to the destination rectangle, or NULL for the
+    ///                   entire rendering target.
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderCopy(
         renderer: *mut SDL_Renderer,
         texture: *mut SDL_Texture,
@@ -16626,19 +16979,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Copy a portion of the source texture to the current rendering target, rotating it by angle around the given center
+    ///  \brief Copy a portion of the source texture to the current rendering target, rotating it by angle around the given center
     ///
-    /// \param renderer The renderer which should copy parts of a texture.
-    /// \param texture The source texture.
-    /// \param srcrect   A pointer to the source rectangle, or NULL for the entire
-    /// texture.
-    /// \param dstrect   A pointer to the destination rectangle, or NULL for the
-    /// entire rendering target.
-    /// \param angle    An angle in degrees that indicates the rotation that will be applied to dstrect, rotating it in a clockwise direction
-    /// \param center   A pointer to a point indicating the point around which dstrect will be rotated (if NULL, rotation will be done around dstrect.w/2, dstrect.h/2).
-    /// \param flip     An SDL_RendererFlip value stating which flipping actions should be performed on the texture
+    ///  \param renderer The renderer which should copy parts of a texture.
+    ///  \param texture The source texture.
+    ///  \param srcrect   A pointer to the source rectangle, or NULL for the entire
+    ///                   texture.
+    ///  \param dstrect   A pointer to the destination rectangle, or NULL for the
+    ///                   entire rendering target.
+    ///  \param angle    An angle in degrees that indicates the rotation that will be applied to dstrect, rotating it in a clockwise direction
+    ///  \param center   A pointer to a point indicating the point around which dstrect will be rotated (if NULL, rotation will be done around dstrect.w/2, dstrect.h/2).
+    ///  \param flip     An SDL_RendererFlip value stating which flipping actions should be performed on the texture
     ///
-    /// \return 0 on success, or -1 on error
+    ///  \return 0 on success, or -1 on error
     pub fn SDL_RenderCopyEx(
         renderer: *mut SDL_Renderer,
         texture: *mut SDL_Texture,
@@ -16650,19 +17003,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Read pixels from the current rendering target.
+    ///  \brief Read pixels from the current rendering target.
     ///
-    /// \param renderer The renderer from which pixels should be read.
-    /// \param rect   A pointer to the rectangle to read, or NULL for the entire
-    /// render target.
-    /// \param format The desired format of the pixel data, or 0 to use the format
-    /// of the rendering target
-    /// \param pixels A pointer to be filled in with the pixel data
-    /// \param pitch  The pitch of the pixels parameter.
+    ///  \param renderer The renderer from which pixels should be read.
+    ///  \param rect   A pointer to the rectangle to read, or NULL for the entire
+    ///                render target.
+    ///  \param format The desired format of the pixel data, or 0 to use the format
+    ///                of the rendering target
+    ///  \param pixels A pointer to be filled in with the pixel data
+    ///  \param pitch  The pitch of the pixels parameter.
     ///
-    /// \return 0 on success, or -1 if pixel reading is not supported.
+    ///  \return 0 on success, or -1 if pixel reading is not supported.
     ///
-    /// \warning This is a very slow operation, and should not be used frequently.
+    ///  \warning This is a very slow operation, and should not be used frequently.
     pub fn SDL_RenderReadPixels(
         renderer: *mut SDL_Renderer,
         rect: *const SDL_Rect,
@@ -16672,32 +17025,32 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Update the screen with rendering performed.
+    ///  \brief Update the screen with rendering performed.
     pub fn SDL_RenderPresent(renderer: *mut SDL_Renderer);
 }
 extern "C" {
-    /// \brief Destroy the specified texture.
+    ///  \brief Destroy the specified texture.
     ///
-    /// \sa SDL_CreateTexture()
-    /// \sa SDL_CreateTextureFromSurface()
+    ///  \sa SDL_CreateTexture()
+    ///  \sa SDL_CreateTextureFromSurface()
     pub fn SDL_DestroyTexture(texture: *mut SDL_Texture);
 }
 extern "C" {
-    /// \brief Destroy the rendering context for a window and free associated
-    /// textures.
+    ///  \brief Destroy the rendering context for a window and free associated
+    ///         textures.
     ///
-    /// \sa SDL_CreateRenderer()
+    ///  \sa SDL_CreateRenderer()
     pub fn SDL_DestroyRenderer(renderer: *mut SDL_Renderer);
 }
 extern "C" {
-    /// \brief Bind the texture to the current OpenGL/ES/ES2 context for use with
-    /// OpenGL instructions.
+    ///  \brief Bind the texture to the current OpenGL/ES/ES2 context for use with
+    ///         OpenGL instructions.
     ///
-    /// \param texture  The SDL texture to bind
-    /// \param texw     A pointer to a float that will be filled with the texture width
-    /// \param texh     A pointer to a float that will be filled with the texture height
+    ///  \param texture  The SDL texture to bind
+    ///  \param texw     A pointer to a float that will be filled with the texture width
+    ///  \param texh     A pointer to a float that will be filled with the texture height
     ///
-    /// \return 0 on success, or -1 if the operation is not supported
+    ///  \return 0 on success, or -1 if the operation is not supported
     pub fn SDL_GL_BindTexture(
         texture: *mut SDL_Texture,
         texw: *mut f32,
@@ -16705,54 +17058,192 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Unbind a texture from the current OpenGL/ES/ES2 context.
+    ///  \brief Unbind a texture from the current OpenGL/ES/ES2 context.
     ///
-    /// \param texture  The SDL texture to unbind
+    ///  \param texture  The SDL texture to unbind
     ///
-    /// \return 0 on success, or -1 if the operation is not supported
+    ///  \return 0 on success, or -1 if the operation is not supported
     pub fn SDL_GL_UnbindTexture(texture: *mut SDL_Texture) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the CAMetalLayer associated with the given Metal renderer
+    ///  \brief Get the CAMetalLayer associated with the given Metal renderer
     ///
-    /// \param renderer The renderer to query
+    ///  \param renderer The renderer to query
     ///
-    /// \return CAMetalLayer* on success, or NULL if the renderer isn't a Metal renderer
+    ///  \return CAMetalLayer* on success, or NULL if the renderer isn't a Metal renderer
     ///
-    /// \sa SDL_RenderGetMetalCommandEncoder()
+    ///  \sa SDL_RenderGetMetalCommandEncoder()
     pub fn SDL_RenderGetMetalLayer(renderer: *mut SDL_Renderer) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Get the Metal command encoder for the current frame
+    ///  \brief Get the Metal command encoder for the current frame
     ///
-    /// \param renderer The renderer to query
+    ///  \param renderer The renderer to query
     ///
-    /// \return id<MTLRenderCommandEncoder> on success, or NULL if the renderer isn't a Metal renderer
+    ///  \return id<MTLRenderCommandEncoder> on success, or NULL if the renderer isn't a Metal renderer
     ///
-    /// \sa SDL_RenderGetMetalLayer()
+    ///  \sa SDL_RenderGetMetalLayer()
     pub fn SDL_RenderGetMetalCommandEncoder(
         renderer: *mut SDL_Renderer,
     ) -> *mut ::std::os::raw::c_void;
 }
+///  \brief SDL_sensor.h
+///
+///  In order to use these functions, SDL_Init() must have been called
+///  with the ::SDL_INIT_SENSOR flag.  This causes SDL to scan the system
+///  for sensors, and load appropriate drivers.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _SDL_Sensor {
+    _unused: [u8; 0],
+}
+pub type SDL_Sensor = _SDL_Sensor;
+/// This is a unique ID for a sensor for the time it is connected to the system,
+/// and is never reused for the lifetime of the application.
+///
+/// The ID value starts at 0 and increments from there. The value -1 is an invalid ID.
+pub type SDL_SensorID = Sint32;
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum SDL_SensorType {
+    ///< Returned for an invalid sensor
+    SDL_SENSOR_INVALID = -1,
+    ///< Unknown sensor type
+    SDL_SENSOR_UNKNOWN = 0,
+    ///< Accelerometer
+    SDL_SENSOR_ACCEL = 1,
+    ///< Gyroscope
+    SDL_SENSOR_GYRO = 2,
+}
 extern "C" {
-    /// \brief Create a window that can be shaped with the specified position, dimensions, and flags.
+    ///  \brief Count the number of sensors attached to the system right now
+    pub fn SDL_NumSensors() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  \brief Get the implementation dependent name of a sensor.
     ///
-    /// \param title The title of the window, in UTF-8 encoding.
-    /// \param x     The x position of the window, ::SDL_WINDOWPOS_CENTERED, or
-    /// ::SDL_WINDOWPOS_UNDEFINED.
-    /// \param y     The y position of the window, ::SDL_WINDOWPOS_CENTERED, or
-    /// ::SDL_WINDOWPOS_UNDEFINED.
-    /// \param w     The width of the window.
-    /// \param h     The height of the window.
-    /// \param flags The flags for the window, a mask of SDL_WINDOW_BORDERLESS with any of the following:
-    /// ::SDL_WINDOW_OPENGL,     ::SDL_WINDOW_INPUT_GRABBED,
-    /// ::SDL_WINDOW_HIDDEN,     ::SDL_WINDOW_RESIZABLE,
-    /// ::SDL_WINDOW_MAXIMIZED,  ::SDL_WINDOW_MINIMIZED,
-    /// ::SDL_WINDOW_BORDERLESS is always set, and ::SDL_WINDOW_FULLSCREEN is always unset.
+    ///  This can be called before any sensors are opened.
     ///
-    /// \return The window created, or NULL if window creation failed.
+    ///  \return The sensor name, or NULL if device_index is out of range.
+    pub fn SDL_SensorGetDeviceName(
+        device_index: ::std::os::raw::c_int,
+    ) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    ///  \brief Get the type of a sensor.
     ///
-    /// \sa SDL_DestroyWindow()
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor type, or SDL_SENSOR_INVALID if device_index is out of range.
+    pub fn SDL_SensorGetDeviceType(device_index: ::std::os::raw::c_int) -> SDL_SensorType;
+}
+extern "C" {
+    ///  \brief Get the platform dependent type of a sensor.
+    ///
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor platform dependent type, or -1 if device_index is out of range.
+    pub fn SDL_SensorGetDeviceNonPortableType(
+        device_index: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  \brief Get the instance ID of a sensor.
+    ///
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor instance ID, or -1 if device_index is out of range.
+    pub fn SDL_SensorGetDeviceInstanceID(device_index: ::std::os::raw::c_int) -> SDL_SensorID;
+}
+extern "C" {
+    ///  \brief Open a sensor for use.
+    ///
+    ///  The index passed as an argument refers to the N'th sensor on the system.
+    ///
+    ///  \return A sensor identifier, or NULL if an error occurred.
+    pub fn SDL_SensorOpen(device_index: ::std::os::raw::c_int) -> *mut SDL_Sensor;
+}
+extern "C" {
+    /// Return the SDL_Sensor associated with an instance id.
+    pub fn SDL_SensorFromInstanceID(instance_id: SDL_SensorID) -> *mut SDL_Sensor;
+}
+extern "C" {
+    ///  \brief Get the implementation dependent name of a sensor.
+    ///
+    ///  \return The sensor name, or NULL if the sensor is NULL.
+    pub fn SDL_SensorGetName(sensor: *mut SDL_Sensor) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    ///  \brief Get the type of a sensor.
+    ///
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor type, or SDL_SENSOR_INVALID if the sensor is NULL.
+    pub fn SDL_SensorGetType(sensor: *mut SDL_Sensor) -> SDL_SensorType;
+}
+extern "C" {
+    ///  \brief Get the platform dependent type of a sensor.
+    ///
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor platform dependent type, or -1 if the sensor is NULL.
+    pub fn SDL_SensorGetNonPortableType(sensor: *mut SDL_Sensor) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  \brief Get the instance ID of a sensor.
+    ///
+    ///  This can be called before any sensors are opened.
+    ///
+    ///  \return The sensor instance ID, or -1 if the sensor is NULL.
+    pub fn SDL_SensorGetInstanceID(sensor: *mut SDL_Sensor) -> SDL_SensorID;
+}
+extern "C" {
+    ///  Get the current state of an opened sensor.
+    ///
+    ///  The number of values and interpretation of the data is sensor dependent.
+    ///
+    ///  \param sensor The sensor to query
+    ///  \param data A pointer filled with the current sensor state
+    ///  \param num_values The number of values to write to data
+    ///
+    ///  \return 0 or -1 if an error occurred.
+    pub fn SDL_SensorGetData(
+        sensor: *mut SDL_Sensor,
+        data: *mut f32,
+        num_values: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///  Close a sensor previously opened with SDL_SensorOpen()
+    pub fn SDL_SensorClose(sensor: *mut SDL_Sensor);
+}
+extern "C" {
+    ///  Update the current state of the open sensors.
+    ///
+    ///  This is called automatically by the event loop if sensor events are enabled.
+    ///
+    ///  This needs to be called from the thread that initialized the sensor subsystem.
+    pub fn SDL_SensorUpdate();
+}
+extern "C" {
+    ///  \brief Create a window that can be shaped with the specified position, dimensions, and flags.
+    ///
+    ///  \param title The title of the window, in UTF-8 encoding.
+    ///  \param x     The x position of the window, ::SDL_WINDOWPOS_CENTERED, or
+    ///               ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param y     The y position of the window, ::SDL_WINDOWPOS_CENTERED, or
+    ///               ::SDL_WINDOWPOS_UNDEFINED.
+    ///  \param w     The width of the window.
+    ///  \param h     The height of the window.
+    ///  \param flags The flags for the window, a mask of SDL_WINDOW_BORDERLESS with any of the following:
+    ///               ::SDL_WINDOW_OPENGL,     ::SDL_WINDOW_INPUT_GRABBED,
+    ///               ::SDL_WINDOW_HIDDEN,     ::SDL_WINDOW_RESIZABLE,
+    ///               ::SDL_WINDOW_MAXIMIZED,  ::SDL_WINDOW_MINIMIZED,
+    ///       ::SDL_WINDOW_BORDERLESS is always set, and ::SDL_WINDOW_FULLSCREEN is always unset.
+    ///
+    ///  \return The window created, or NULL if window creation failed.
+    ///
+    ///  \sa SDL_DestroyWindow()
     pub fn SDL_CreateShapedWindow(
         title: *const ::std::os::raw::c_char,
         x: ::std::os::raw::c_uint,
@@ -16880,7 +17371,7 @@ extern "C" {
     /// \param shape_mode The parameters to set for the shaped window.
     ///
     /// \return 0 on success, SDL_INVALID_SHAPE_ARGUMENT on an invalid shape argument, or SDL_NONSHAPEABLE_WINDOW
-    /// if the SDL_Window given does not reference a valid shaped window.
+    ///           if the SDL_Window given does not reference a valid shaped window.
     ///
     /// \sa SDL_WindowShapeMode
     /// \sa SDL_GetShapedWindowMode.
@@ -16897,8 +17388,8 @@ extern "C" {
     /// \param shape_mode An empty shape-mode structure to fill, or NULL to check whether the window has a shape.
     ///
     /// \return 0 if the window has a shape and, provided shape_mode was not NULL, shape_mode has been filled with the mode
-    /// data, SDL_NONSHAPEABLE_WINDOW if the SDL_Window given is not a shaped window, or SDL_WINDOW_LACKS_SHAPE if
-    /// the SDL_Window given is a shapeable window currently lacking a shape.
+    ///           data, SDL_NONSHAPEABLE_WINDOW if the SDL_Window given is not a shaped window, or SDL_WINDOW_LACKS_SHAPE if
+    ///           the SDL_Window given is a shapeable window currently lacking a shape.
     ///
     /// \sa SDL_WindowShapeMode
     /// \sa SDL_SetWindowShape
@@ -16906,6 +17397,19 @@ extern "C" {
         window: *mut SDL_Window,
         shape_mode: *mut SDL_WindowShapeMode,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///\brief Sets the UNIX nice value for a thread, using setpriority() if possible, and RealtimeKit if available.
+    ///
+    ///\return 0 on success, or -1 on error.
+    pub fn SDL_LinuxSetThreadPriority(
+        threadID: Sint64,
+        priority: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    ///\brief Return true if the current device is a tablet.
+    pub fn SDL_IsTablet() -> SDL_bool;
 }
 extern "C" {
     /// \brief Get the number of milliseconds since the SDL library initialization.
@@ -16925,12 +17429,12 @@ extern "C" {
     /// \brief Wait a specified number of milliseconds before returning.
     pub fn SDL_Delay(ms: Uint32);
 }
-/// Function prototype for the timer callback function.
+///  Function prototype for the timer callback function.
 ///
-/// The callback function is passed the current timer interval and returns
-/// the next timer interval.  If the returned value is the same as the one
-/// passed in, the periodic alarm continues, otherwise a new alarm is
-/// scheduled.  If the callback returns 0, the periodic alarm is cancelled.
+///  The callback function is passed the current timer interval and returns
+///  the next timer interval.  If the returned value is the same as the one
+///  passed in, the periodic alarm continues, otherwise a new alarm is
+///  scheduled.  If the callback returns 0, the periodic alarm is cancelled.
 pub type SDL_TimerCallback = ::std::option::Option<
     unsafe extern "C" fn(interval: Uint32, param: *mut ::std::os::raw::c_void) -> Uint32,
 >;
@@ -16954,24 +17458,24 @@ extern "C" {
     /// \warning It is not safe to remove a timer multiple times.
     pub fn SDL_RemoveTimer(id: SDL_TimerID) -> SDL_bool;
 }
-/// \brief Information the version of SDL in use.
+///  \brief Information the version of SDL in use.
 ///
-/// Represents the library's version as three levels: major revision
-/// (increments with massive changes, additions, and enhancements),
-/// minor revision (increments with backwards-compatible changes to the
-/// major revision), and patchlevel (increments with fixes to the minor
-/// revision).
+///  Represents the library's version as three levels: major revision
+///  (increments with massive changes, additions, and enhancements),
+///  minor revision (increments with backwards-compatible changes to the
+///  major revision), and patchlevel (increments with fixes to the minor
+///  revision).
 ///
-/// \sa SDL_VERSION
-/// \sa SDL_GetVersion
+///  \sa SDL_VERSION
+///  \sa SDL_GetVersion
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_version {
-    /// < major version
+    ///< major version
     pub major: Uint8,
-    /// < minor version
+    ///< minor version
     pub minor: Uint8,
-    /// < update version
+    ///< update version
     pub patch: Uint8,
 }
 #[test]
@@ -17018,74 +17522,74 @@ fn bindgen_test_layout_SDL_version() {
     );
 }
 extern "C" {
-    /// \brief Get the version of SDL that is linked against your program.
+    ///  \brief Get the version of SDL that is linked against your program.
     ///
-    /// If you are linking to SDL dynamically, then it is possible that the
-    /// current version will be different than the version you compiled against.
-    /// This function returns the current version, while SDL_VERSION() is a
-    /// macro that tells you what version you compiled with.
+    ///  If you are linking to SDL dynamically, then it is possible that the
+    ///  current version will be different than the version you compiled against.
+    ///  This function returns the current version, while SDL_VERSION() is a
+    ///  macro that tells you what version you compiled with.
     ///
-    /// \code
-    /// SDL_version compiled;
-    /// SDL_version linked;
+    ///  \code
+    ///  SDL_version compiled;
+    ///  SDL_version linked;
     ///
-    /// SDL_VERSION(&compiled);
-    /// SDL_GetVersion(&linked);
-    /// printf("We compiled against SDL version %d.%d.%d ...\n",
-    /// compiled.major, compiled.minor, compiled.patch);
-    /// printf("But we linked against SDL version %d.%d.%d.\n",
-    /// linked.major, linked.minor, linked.patch);
-    /// \endcode
+    ///  SDL_VERSION(&compiled);
+    ///  SDL_GetVersion(&linked);
+    ///  printf("We compiled against SDL version %d.%d.%d ...\n",
+    ///         compiled.major, compiled.minor, compiled.patch);
+    ///  printf("But we linked against SDL version %d.%d.%d.\n",
+    ///         linked.major, linked.minor, linked.patch);
+    ///  \endcode
     ///
-    /// This function may be called safely at any time, even before SDL_Init().
+    ///  This function may be called safely at any time, even before SDL_Init().
     ///
-    /// \sa SDL_VERSION
+    ///  \sa SDL_VERSION
     pub fn SDL_GetVersion(ver: *mut SDL_version);
 }
 extern "C" {
-    /// \brief Get the code revision of SDL that is linked against your program.
+    ///  \brief Get the code revision of SDL that is linked against your program.
     ///
-    /// Returns an arbitrary string (a hash value) uniquely identifying the
-    /// exact revision of the SDL library in use, and is only useful in comparing
-    /// against other revisions. It is NOT an incrementing number.
+    ///  Returns an arbitrary string (a hash value) uniquely identifying the
+    ///  exact revision of the SDL library in use, and is only useful in comparing
+    ///  against other revisions. It is NOT an incrementing number.
     pub fn SDL_GetRevision() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    /// \brief Get the revision number of SDL that is linked against your program.
+    ///  \brief Get the revision number of SDL that is linked against your program.
     ///
-    /// Returns a number uniquely identifying the exact revision of the SDL
-    /// library in use. It is an incrementing number based on commits to
-    /// hg.libsdl.org.
+    ///  Returns a number uniquely identifying the exact revision of the SDL
+    ///  library in use. It is an incrementing number based on commits to
+    ///  hg.libsdl.org.
     pub fn SDL_GetRevisionNumber() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This function initializes  the subsystems specified by \c flags
+    ///  This function initializes  the subsystems specified by \c flags
     pub fn SDL_Init(flags: Uint32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This function initializes specific SDL subsystems
+    ///  This function initializes specific SDL subsystems
     ///
-    /// Subsystem initialization is ref-counted, you must call
-    /// SDL_QuitSubSystem() for each SDL_InitSubSystem() to correctly
-    /// shutdown a subsystem manually (or call SDL_Quit() to force shutdown).
-    /// If a subsystem is already loaded then this call will
-    /// increase the ref-count and return.
+    ///  Subsystem initialization is ref-counted, you must call
+    ///  SDL_QuitSubSystem() for each SDL_InitSubSystem() to correctly
+    ///  shutdown a subsystem manually (or call SDL_Quit() to force shutdown).
+    ///  If a subsystem is already loaded then this call will
+    ///  increase the ref-count and return.
     pub fn SDL_InitSubSystem(flags: Uint32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// This function cleans up specific SDL subsystems
+    ///  This function cleans up specific SDL subsystems
     pub fn SDL_QuitSubSystem(flags: Uint32);
 }
 extern "C" {
-    /// This function returns a mask of the specified subsystems which have
-    /// previously been initialized.
+    ///  This function returns a mask of the specified subsystems which have
+    ///  previously been initialized.
     ///
-    /// If \c flags is 0, it returns a mask of all initialized subsystems.
+    ///  If \c flags is 0, it returns a mask of all initialized subsystems.
     pub fn SDL_WasInit(flags: Uint32) -> Uint32;
 }
 extern "C" {
-    /// This function cleans up all initialized subsystems. You should
-    /// call it upon all exit conditions.
+    ///  This function cleans up all initialized subsystems. You should
+    ///  call it upon all exit conditions.
     pub fn SDL_Quit();
 }
 pub type XID = ::std::os::raw::c_ulong;
@@ -18687,8 +19191,10 @@ pub struct _XImage_funcs {
         ) -> *mut _XImage,
     >,
     pub add_pixel: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut _XImage, arg2: ::std::os::raw::c_long)
-            -> ::std::os::raw::c_int,
+        unsafe extern "C" fn(
+            arg1: *mut _XImage,
+            arg2: ::std::os::raw::c_long,
+        ) -> ::std::os::raw::c_int,
     >,
 }
 #[test]
@@ -26387,8 +26893,10 @@ extern "C" {
         arg1: *mut Display,
         arg2: ::std::os::raw::c_int,
     ) -> ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut Display, arg2: ::std::os::raw::c_int)
-            -> ::std::os::raw::c_int,
+        unsafe extern "C" fn(
+            arg1: *mut Display,
+            arg2: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
     >;
 }
 extern "C" {
@@ -26985,8 +27493,11 @@ extern "C" {
         arg1: *mut Display,
         arg2: *mut XEvent,
         arg3: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut Display, arg2: *mut XEvent, arg3: XPointer)
-                -> ::std::os::raw::c_int,
+            unsafe extern "C" fn(
+                arg1: *mut Display,
+                arg2: *mut XEvent,
+                arg3: XPointer,
+            ) -> ::std::os::raw::c_int,
         >,
         arg4: XPointer,
     ) -> ::std::os::raw::c_int;
@@ -27649,8 +28160,11 @@ extern "C" {
         arg1: *mut Display,
         arg2: *mut XEvent,
         arg3: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut Display, arg2: *mut XEvent, arg3: XPointer)
-                -> ::std::os::raw::c_int,
+            unsafe extern "C" fn(
+                arg1: *mut Display,
+                arg2: *mut XEvent,
+                arg3: XPointer,
+            ) -> ::std::os::raw::c_int,
         >,
         arg4: XPointer,
     ) -> ::std::os::raw::c_int;
@@ -27750,8 +28264,11 @@ extern "C" {
         arg1: *mut Display,
         arg2: *mut XEvent,
         arg3: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut Display, arg2: *mut XEvent, arg3: XPointer)
-                -> ::std::os::raw::c_int,
+            unsafe extern "C" fn(
+                arg1: *mut Display,
+                arg2: *mut XEvent,
+                arg3: XPointer,
+            ) -> ::std::os::raw::c_int,
         >,
         arg4: XPointer,
     ) -> ::std::os::raw::c_int;
@@ -28886,7 +29403,7 @@ extern "C" {
     pub fn XFreeEventData(arg1: *mut Display, arg2: *mut XGenericEventCookie);
 }
 #[repr(u32)]
-/// These are the various supported windowing subsystems
+///  These are the various supported windowing subsystems
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SDL_SYSWM_TYPE {
     SDL_SYSWM_UNKNOWN = 0,
@@ -28902,7 +29419,7 @@ pub enum SDL_SYSWM_TYPE {
     SDL_SYSWM_VIVANTE = 10,
     SDL_SYSWM_OS2 = 11,
 }
-/// The custom event structure.
+///  The custom event structure.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct SDL_SysWMmsg {
@@ -29032,10 +29549,10 @@ fn bindgen_test_layout_SDL_SysWMmsg() {
         )
     );
 }
-/// The custom window manager information structure.
+///  The custom window manager information structure.
 ///
-/// When this structure is returned, it holds information about which
-/// low level system it is using, and will be one of SDL_SYSWM_TYPE.
+///  When this structure is returned, it holds information about which
+///  low level system it is using, and will be one of SDL_SYSWM_TYPE.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct SDL_SysWMinfo {
@@ -29054,9 +29571,9 @@ pub union SDL_SysWMinfo__bindgen_ty_1 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_SysWMinfo__bindgen_ty_1__bindgen_ty_1 {
-    /// < The X11 display
+    ///< The X11 display
     pub display: *mut Display,
-    /// < The X11 window
+    ///< The X11 window
     pub window: Window,
 }
 #[test]
@@ -29107,11 +29624,11 @@ fn bindgen_test_layout_SDL_SysWMinfo__bindgen_ty_1__bindgen_ty_1() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_SysWMinfo__bindgen_ty_1__bindgen_ty_2 {
-    /// < Wayland display
+    ///< Wayland display
     pub display: *mut wl_display,
-    /// < Wayland surface
+    ///< Wayland surface
     pub surface: *mut wl_surface,
-    /// < Wayland shell_surface (window manager handle)
+    ///< Wayland shell_surface (window manager handle)
     pub shell_surface: *mut wl_shell_surface,
 }
 #[test]
@@ -29261,21 +29778,21 @@ fn bindgen_test_layout_SDL_SysWMinfo() {
     );
 }
 extern "C" {
-    /// \brief This function allows access to driver-dependent window information.
+    ///  \brief This function allows access to driver-dependent window information.
     ///
-    /// \param window The window about which information is being requested
-    /// \param info This structure must be initialized with the SDL version, and is
-    /// then filled in with information about the given window.
+    ///  \param window The window about which information is being requested
+    ///  \param info This structure must be initialized with the SDL version, and is
+    ///              then filled in with information about the given window.
     ///
-    /// \return SDL_TRUE if the function is implemented and the version member of
-    /// the \c info struct is valid, SDL_FALSE otherwise.
+    ///  \return SDL_TRUE if the function is implemented and the version member of
+    ///          the \c info struct is valid, SDL_FALSE otherwise.
     ///
-    /// You typically use this function like this:
-    /// \code
-    /// SDL_SysWMinfo info;
-    /// SDL_VERSION(&info.version);
-    /// if ( SDL_GetWindowWMInfo(window, &info) ) { ... }
-    /// \endcode
+    ///  You typically use this function like this:
+    ///  \code
+    ///  SDL_SysWMinfo info;
+    ///  SDL_VERSION(&info.version);
+    ///  if ( SDL_GetWindowWMInfo(window, &info) ) { ... }
+    ///  \endcode
     pub fn SDL_GetWindowWMInfo(window: *mut SDL_Window, info: *mut SDL_SysWMinfo) -> SDL_bool;
 }
 #[repr(C)]
@@ -29291,135 +29808,140 @@ pub struct VkSurfaceKHR_T {
 pub type SDL_vulkanInstance = VkInstance;
 pub type SDL_vulkanSurface = VkSurfaceKHR;
 extern "C" {
-    /// \brief Dynamically load a Vulkan loader library.
+    ///  \brief Dynamically load a Vulkan loader library.
     ///
-    /// \param [in] path The platform dependent Vulkan loader library name, or
-    /// \c NULL.
+    ///  \param [in] path The platform dependent Vulkan loader library name, or
+    ///              \c NULL.
     ///
-    /// \return \c 0 on success, or \c -1 if the library couldn't be loaded.
+    ///  \return \c 0 on success, or \c -1 if the library couldn't be loaded.
     ///
-    /// If \a path is NULL SDL will use the value of the environment variable
-    /// \c SDL_VULKAN_LIBRARY, if set, otherwise it loads the default Vulkan
-    /// loader library.
+    ///  If \a path is NULL SDL will use the value of the environment variable
+    ///  \c SDL_VULKAN_LIBRARY, if set, otherwise it loads the default Vulkan
+    ///  loader library.
     ///
-    /// This should be called after initializing the video driver, but before
-    /// creating any Vulkan windows. If no Vulkan loader library is loaded, the
-    /// default library will be loaded upon creation of the first Vulkan window.
+    ///  This should be called after initializing the video driver, but before
+    ///  creating any Vulkan windows. If no Vulkan loader library is loaded, the
+    ///  default library will be loaded upon creation of the first Vulkan window.
     ///
-    /// \note It is fairly common for Vulkan applications to link with \a libvulkan
-    /// instead of explicitly loading it at run time. This will work with
-    /// SDL provided the application links to a dynamic library and both it
-    /// and SDL use the same search path.
+    ///  \note It is fairly common for Vulkan applications to link with \a libvulkan
+    ///        instead of explicitly loading it at run time. This will work with
+    ///        SDL provided the application links to a dynamic library and both it
+    ///        and SDL use the same search path.
     ///
-    /// \note If you specify a non-NULL \c path, an application should retrieve all
-    /// of the Vulkan functions it uses from the dynamic library using
-    /// \c SDL_Vulkan_GetVkGetInstanceProcAddr() unless you can guarantee
-    /// \c path points to the same vulkan loader library the application
-    /// linked to.
+    ///  \note If you specify a non-NULL \c path, an application should retrieve all
+    ///        of the Vulkan functions it uses from the dynamic library using
+    ///        \c SDL_Vulkan_GetVkGetInstanceProcAddr() unless you can guarantee
+    ///        \c path points to the same vulkan loader library the application
+    ///        linked to.
     ///
-    /// \note On Apple devices, if \a path is NULL, SDL will attempt to find
-    /// the vkGetInstanceProcAddr address within all the mach-o images of
-    /// the current process. This is because it is fairly common for Vulkan
-    /// applications to link with libvulkan (and historically MoltenVK was
-    /// provided as a static library). If it is not found then, on macOS, SDL
-    /// will attempt to load \c vulkan.framework/vulkan, \c libvulkan.1.dylib,
-    /// \c MoltenVK.framework/MoltenVK and \c libMoltenVK.dylib in that order.
-    /// On iOS SDL will attempt to load \c libMoltenVK.dylib. Applications
-    /// using a dynamic framework or .dylib must ensure it is included in its
-    /// application bundle.
+    ///  \note On Apple devices, if \a path is NULL, SDL will attempt to find
+    ///        the vkGetInstanceProcAddr address within all the mach-o images of
+    ///        the current process. This is because it is fairly common for Vulkan
+    ///        applications to link with libvulkan (and historically MoltenVK was
+    ///        provided as a static library). If it is not found then, on macOS, SDL
+    ///        will attempt to load \c vulkan.framework/vulkan, \c libvulkan.1.dylib,
+    ///        \c MoltenVK.framework/MoltenVK and \c libMoltenVK.dylib in that order.
+    ///        On iOS SDL will attempt to load \c libMoltenVK.dylib. Applications
+    ///        using a dynamic framework or .dylib must ensure it is included in its
+    ///        application bundle.
     ///
-    /// \note On non-Apple devices, application linking with a static libvulkan is
-    /// not supported. Either do not link to the Vulkan loader or link to a
-    /// dynamic library version.
+    ///  \note On non-Apple devices, application linking with a static libvulkan is
+    ///        not supported. Either do not link to the Vulkan loader or link to a
+    ///        dynamic library version.
     ///
-    /// \note This function will fail if there are no working Vulkan drivers
-    /// installed.
+    ///  \note This function will fail if there are no working Vulkan drivers
+    ///        installed.
     ///
-    /// \sa SDL_Vulkan_GetVkGetInstanceProcAddr()
-    /// \sa SDL_Vulkan_UnloadLibrary()
+    ///  \sa SDL_Vulkan_GetVkGetInstanceProcAddr()
+    ///  \sa SDL_Vulkan_UnloadLibrary()
     pub fn SDL_Vulkan_LoadLibrary(path: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    /// \brief Get the address of the \c vkGetInstanceProcAddr function.
+    ///  \brief Get the address of the \c vkGetInstanceProcAddr function.
     ///
-    /// \note This should be called after either calling SDL_Vulkan_LoadLibrary
-    /// or creating an SDL_Window with the SDL_WINDOW_VULKAN flag.
+    ///  \note This should be called after either calling SDL_Vulkan_LoadLibrary
+    ///        or creating an SDL_Window with the SDL_WINDOW_VULKAN flag.
     pub fn SDL_Vulkan_GetVkGetInstanceProcAddr() -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    /// \brief Unload the Vulkan loader library previously loaded by
-    /// \c SDL_Vulkan_LoadLibrary().
+    ///  \brief Unload the Vulkan loader library previously loaded by
+    ///         \c SDL_Vulkan_LoadLibrary().
     ///
-    /// \sa SDL_Vulkan_LoadLibrary()
+    ///  \sa SDL_Vulkan_LoadLibrary()
     pub fn SDL_Vulkan_UnloadLibrary();
 }
 extern "C" {
-    /// \brief Get the names of the Vulkan instance extensions needed to create
-    /// a surface with \c SDL_Vulkan_CreateSurface().
+    ///  \brief Get the names of the Vulkan instance extensions needed to create
+    ///         a surface with \c SDL_Vulkan_CreateSurface().
     ///
-    /// \param [in]     window Window for which the required Vulkan instance
-    /// extensions should be retrieved
-    /// \param [in,out] count pointer to an \c unsigned related to the number of
-    /// required Vulkan instance extensions
-    /// \param [out]    names \c NULL or a pointer to an array to be filled with the
-    /// required Vulkan instance extensions
+    ///  \param [in]     \c NULL or window Window for which the required Vulkan instance
+    ///                  extensions should be retrieved
+    ///  \param [in,out] pCount pointer to an \c unsigned related to the number of
+    ///                  required Vulkan instance extensions
+    ///  \param [out]    pNames \c NULL or a pointer to an array to be filled with the
+    ///                  required Vulkan instance extensions
     ///
-    /// \return \c SDL_TRUE on success, \c SDL_FALSE on error.
+    ///  \return \c SDL_TRUE on success, \c SDL_FALSE on error.
     ///
-    /// If \a pNames is \c NULL, then the number of required Vulkan instance
-    /// extensions is returned in pCount. Otherwise, \a pCount must point to a
-    /// variable set to the number of elements in the \a pNames array, and on
-    /// return the variable is overwritten with the number of names actually
-    /// written to \a pNames. If \a pCount is less than the number of required
-    /// extensions, at most \a pCount structures will be written. If \a pCount
-    /// is smaller than the number of required extensions, \c SDL_FALSE will be
-    /// returned instead of \c SDL_TRUE, to indicate that not all the required
-    /// extensions were returned.
+    ///  If \a pNames is \c NULL, then the number of required Vulkan instance
+    ///  extensions is returned in pCount. Otherwise, \a pCount must point to a
+    ///  variable set to the number of elements in the \a pNames array, and on
+    ///  return the variable is overwritten with the number of names actually
+    ///  written to \a pNames. If \a pCount is less than the number of required
+    ///  extensions, at most \a pCount structures will be written. If \a pCount
+    ///  is smaller than the number of required extensions, \c SDL_FALSE will be
+    ///  returned instead of \c SDL_TRUE, to indicate that not all the required
+    ///  extensions were returned.
     ///
-    /// \note The returned list of extensions will contain \c VK_KHR_surface
-    /// and zero or more platform specific extensions
+    ///  \note If \c window is not NULL, it will be checked against its creation
+    ///        flags to ensure that the Vulkan flag is present. This parameter
+    ///        will be removed in a future major release.
     ///
-    /// \note The extension names queried here must be enabled when calling
-    /// VkCreateInstance, otherwise surface creation will fail.
+    ///  \note The returned list of extensions will contain \c VK_KHR_surface
+    ///        and zero or more platform specific extensions
     ///
-    /// \note \c window should have been created with the \c SDL_WINDOW_VULKAN flag.
+    ///  \note The extension names queried here must be enabled when calling
+    ///        VkCreateInstance, otherwise surface creation will fail.
     ///
-    /// \code
-    /// unsigned int count;
-    /// // get count of required extensions
-    /// if(!SDL_Vulkan_GetInstanceExtensions(window, &count, NULL))
-    /// handle_error();
+    ///  \note \c window should have been created with the \c SDL_WINDOW_VULKAN flag
+    ///        or be \c NULL
     ///
-    /// static const char *const additionalExtensions[] =
-    /// {
-    /// VK_EXT_DEBUG_REPORT_EXTENSION_NAME, // example additional extension
-    /// };
-    /// size_t additionalExtensionsCount = sizeof(additionalExtensions) / sizeof(additionalExtensions[0]);
-    /// size_t extensionCount = count + additionalExtensionsCount;
-    /// const char **names = malloc(sizeof(const char *) * extensionCount);
-    /// if(!names)
-    /// handle_error();
+    ///  \code
+    ///  unsigned int count;
+    ///  // get count of required extensions
+    ///  if(!SDL_Vulkan_GetInstanceExtensions(NULL, &count, NULL))
+    ///      handle_error();
     ///
-    /// // get names of required extensions
-    /// if(!SDL_Vulkan_GetInstanceExtensions(window, &count, names))
-    /// handle_error();
+    ///  static const char *const additionalExtensions[] =
+    ///  {
+    ///      VK_EXT_DEBUG_REPORT_EXTENSION_NAME, // example additional extension
+    ///  };
+    ///  size_t additionalExtensionsCount = sizeof(additionalExtensions) / sizeof(additionalExtensions[0]);
+    ///  size_t extensionCount = count + additionalExtensionsCount;
+    ///  const char **names = malloc(sizeof(const char *) * extensionCount);
+    ///  if(!names)
+    ///      handle_error();
     ///
-    /// // copy additional extensions after required extensions
-    /// for(size_t i = 0; i < additionalExtensionsCount; i++)
-    /// names[i + count] = additionalExtensions[i];
+    ///  // get names of required extensions
+    ///  if(!SDL_Vulkan_GetInstanceExtensions(NULL, &count, names))
+    ///      handle_error();
     ///
-    /// VkInstanceCreateInfo instanceCreateInfo = {};
-    /// instanceCreateInfo.enabledExtensionCount = extensionCount;
-    /// instanceCreateInfo.ppEnabledExtensionNames = names;
-    /// // fill in rest of instanceCreateInfo
+    ///  // copy additional extensions after required extensions
+    ///  for(size_t i = 0; i < additionalExtensionsCount; i++)
+    ///      names[i + count] = additionalExtensions[i];
     ///
-    /// VkInstance instance;
-    /// // create the Vulkan instance
-    /// VkResult result = vkCreateInstance(&instanceCreateInfo, NULL, &instance);
-    /// free(names);
-    /// \endcode
+    ///  VkInstanceCreateInfo instanceCreateInfo = {};
+    ///  instanceCreateInfo.enabledExtensionCount = extensionCount;
+    ///  instanceCreateInfo.ppEnabledExtensionNames = names;
+    ///  // fill in rest of instanceCreateInfo
     ///
-    /// \sa SDL_Vulkan_CreateSurface()
+    ///  VkInstance instance;
+    ///  // create the Vulkan instance
+    ///  VkResult result = vkCreateInstance(&instanceCreateInfo, NULL, &instance);
+    ///  free(names);
+    ///  \endcode
+    ///
+    ///  \sa SDL_Vulkan_CreateSurface()
     pub fn SDL_Vulkan_GetInstanceExtensions(
         window: *mut SDL_Window,
         pCount: *mut ::std::os::raw::c_uint,
@@ -29427,33 +29949,33 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Create a Vulkan rendering surface for a window.
+    ///  \brief Create a Vulkan rendering surface for a window.
     ///
-    /// \param [in]  window   SDL_Window to which to attach the rendering surface.
-    /// \param [in]  instance handle to the Vulkan instance to use.
-    /// \param [out] surface  pointer to a VkSurfaceKHR handle to receive the
-    /// handle of the newly created surface.
+    ///  \param [in]  window   SDL_Window to which to attach the rendering surface.
+    ///  \param [in]  instance handle to the Vulkan instance to use.
+    ///  \param [out] surface  pointer to a VkSurfaceKHR handle to receive the
+    ///                        handle of the newly created surface.
     ///
-    /// \return \c SDL_TRUE on success, \c SDL_FALSE on error.
+    ///  \return \c SDL_TRUE on success, \c SDL_FALSE on error.
     ///
-    /// \code
-    /// VkInstance instance;
-    /// SDL_Window *window;
+    ///  \code
+    ///  VkInstance instance;
+    ///  SDL_Window *window;
     ///
-    /// // create instance and window
+    ///  // create instance and window
     ///
-    /// // create the Vulkan surface
-    /// VkSurfaceKHR surface;
-    /// if(!SDL_Vulkan_CreateSurface(window, instance, &surface))
-    /// handle_error();
-    /// \endcode
+    ///  // create the Vulkan surface
+    ///  VkSurfaceKHR surface;
+    ///  if(!SDL_Vulkan_CreateSurface(window, instance, &surface))
+    ///      handle_error();
+    ///  \endcode
     ///
-    /// \note \a window should have been created with the \c SDL_WINDOW_VULKAN flag.
+    ///  \note \a window should have been created with the \c SDL_WINDOW_VULKAN flag.
     ///
-    /// \note \a instance should have been created with the extensions returned
-    /// by \c SDL_Vulkan_CreateSurface() enabled.
+    ///  \note \a instance should have been created with the extensions returned
+    ///        by \c SDL_Vulkan_CreateSurface() enabled.
     ///
-    /// \sa SDL_Vulkan_GetInstanceExtensions()
+    ///  \sa SDL_Vulkan_GetInstanceExtensions()
     pub fn SDL_Vulkan_CreateSurface(
         window: *mut SDL_Window,
         instance: VkInstance,
@@ -29461,25 +29983,25 @@ extern "C" {
     ) -> SDL_bool;
 }
 extern "C" {
-    /// \brief Get the size of a window's underlying drawable in pixels (for use
-    /// with setting viewport, scissor & etc).
+    ///  \brief Get the size of a window's underlying drawable in pixels (for use
+    ///         with setting viewport, scissor & etc).
     ///
-    /// \param window   SDL_Window from which the drawable size should be queried
-    /// \param w        Pointer to variable for storing the width in pixels,
-    /// may be NULL
-    /// \param h        Pointer to variable for storing the height in pixels,
-    /// may be NULL
+    ///  \param window   SDL_Window from which the drawable size should be queried
+    ///  \param w        Pointer to variable for storing the width in pixels,
+    ///                  may be NULL
+    ///  \param h        Pointer to variable for storing the height in pixels,
+    ///                  may be NULL
     ///
     /// This may differ from SDL_GetWindowSize() if we're rendering to a high-DPI
     /// drawable, i.e. the window was created with SDL_WINDOW_ALLOW_HIGHDPI on a
     /// platform with high-DPI support (Apple calls this "Retina"), and not disabled
     /// by the \c SDL_HINT_VIDEO_HIGHDPI_DISABLED hint.
     ///
-    /// \note On macOS high-DPI support must be enabled for an application by
-    /// setting NSHighResolutionCapable to true in its Info.plist.
+    ///  \note On macOS high-DPI support must be enabled for an application by
+    ///        setting NSHighResolutionCapable to true in its Info.plist.
     ///
-    /// \sa SDL_GetWindowSize()
-    /// \sa SDL_CreateWindow()
+    ///  \sa SDL_GetWindowSize()
+    ///  \sa SDL_CreateWindow()
     pub fn SDL_Vulkan_GetDrawableSize(
         window: *mut SDL_Window,
         w: *mut ::std::os::raw::c_int,
@@ -29552,25 +30074,25 @@ fn bindgen_test_layout___va_list_tag() {
         )
     );
 }
-/// < Private
+///< Private
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SDL_BlitMap {
     pub _address: u8,
 }
-/// < Wayland display
+///< Wayland display
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_display {
     pub _address: u8,
 }
-/// < Wayland surface
+///< Wayland surface
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_surface {
     pub _address: u8,
 }
-/// < Wayland shell_surface (window manager handle)
+///< Wayland shell_surface (window manager handle)
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wl_shell_surface {


### PR DESCRIPTION
For the record, I generated these using the following command, running Arch Linux and bindgen 0.42.3:
```
bindgen "wrapper.h" "--rust-target" "1.21" "--rustified-enum" ".*" "--blacklist-type" "FP_NAN" "--blacklist-type" "FP_INFINITE" "--blacklist-type" "FP_ZERO" "--blacklist-type" "FP_SUBNORMAL" "--blacklist-type" "FP_NORMAL" "--blacklist-type" "max_align_t" "--no-derive-default" "--generate" "functions,types,vars,methods,constructors,destructors" -- "-I$HOME/dev/rust-sdl2/sdl2-sys/SDL2-2.0.9/include" "-DSDL_VIDEO_DRIVER_X11" "-DSDL_VIDEO_DRIVER_WAYLAND"
```

I got these parameters by extending the `generate_bindings` function in `build.rs` with some debug output sourced from `bindings.command_line_flags()` just before `bindings.generate()`.
I had to fix "function" to "functions" though and removed the `--no-derive-debug` option, because the old bindings contained the Debug derives.

A friend tested the new bindings for me on macOS, I tested them on Linux and Windows and it seems they're working fine.