### PR TITLE
Update Rand to 0.6.* from 0.5.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path       = "src/sdl2/lib.rs"
 [dependencies]
 bitflags = "0.7"
 libc = "^0.2"
-rand = "^0.5"
+rand = "^0.6"
 lazy_static = "^1"
 
 [dependencies.num]

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -1,10 +1,11 @@
 extern crate rand;
+use self::rand::Rng;
+use self::rand::distributions::{Distribution, Standard};
 
-use num::FromPrimitive;
-
-use sys;
 use libc::uint32_t;
+use num::FromPrimitive;
 use std::mem::transmute;
+use sys;
 
 use get_error;
 
@@ -170,10 +171,13 @@ impl From<(u8, u8, u8, u8)> for Color {
     }
 }
 
-impl rand::Rand for Color {
-    fn rand<R: rand::Rng>(rng: &mut R) -> Color {
-        if rng.gen() { Color::RGBA(rng.gen(), rng.gen(), rng.gen(), rng.gen()) }
-        else { Color::RGB(rng.gen(), rng.gen(), rng.gen()) }
+impl Distribution<Color> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Color {
+        if rng.gen() {
+            Color::RGBA(rng.gen(), rng.gen(), rng.gen(), rng.gen())
+        } else {
+            Color::RGB(rng.gen(), rng.gen(), rng.gen())
+        }
     }
 }
 


### PR DESCRIPTION
Rand 0.6 no longer includes the [`Rand`](https://docs.rs/rand/0.5.5/rand/trait.Rand.html) trait; it was replaced with the `Standard` [`rand::distribution`](https://docs.rs/rand/0.6.1/rand/distributions/index.html#the-standard-distribution).

As per the docs, implementing `Distribution<T> for Standard` allows `Rng::gen()` and `random()` to generate the given type (in this case, `Color`s), so (as far as I can tell) this update won't change the interface of pixles.rs in any meaningful way.