### PR TITLE
Add missing shell32 to static link libraries on Windows

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -315,6 +315,7 @@ fn link_sdl2(target_os: &str) {
 
         // Also linked to any required libraries for each supported platform
         if target_os.contains("windows") {
+            println!("cargo:rustc-link-lib=shell32");
             println!("cargo:rustc-link-lib=user32");
             println!("cargo:rustc-link-lib=gdi32");
             println!("cargo:rustc-link-lib=winmm");


### PR DESCRIPTION
Fixes unresolved externals:

```
 = note:    Creating library C:\Code\0-Research\r64emu\target\debug\deps\r64emu-31b08ffa115962a8.lib and object C:\Code\0-Research\r64emu\target\debug\deps\r64emu-31b08ffa115962a8.exp
          libsdl2_sys-dcf2e13e2a4771aa.rlib(SDL_windowsevents.obj) : error LNK2019: unresolved external symbol __imp_DragQueryFileW referenced in function WIN_WindowProc
          libsdl2_sys-dcf2e13e2a4771aa.rlib(SDL_windowsevents.obj) : error LNK2019: unresolved external symbol __imp_DragFinish referenced in function WIN_WindowProc
          libsdl2_sys-dcf2e13e2a4771aa.rlib(SDL_windowsevents.obj) : error LNK2019: unresolved external symbol __imp_ExtractIconExW referenced in function SDL_RegisterApp_REAL
          libsdl2_sys-dcf2e13e2a4771aa.rlib(SDL_sysfilesystem.obj) : error LNK2019: unresolved external symbol __imp_SHGetFolderPathW referenced in function SDL_GetPrefPath_REAL
          libsdl2_sys-dcf2e13e2a4771aa.rlib(SDL_windowswindow.obj) : error LNK2019: unresolved external symbol __imp_DragAcceptFiles referenced in function WIN_AcceptDragAndDrop
          C:\Code\0-Research\r64emu\target\debug\deps\r64emu-31b08ffa115962a8.exe : fatal error LNK1120: 5 unresolved externals
```

/cc @Chris--B