### PR TITLE
Mark Event as Send+Sync

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -710,7 +710,13 @@ pub enum Event {
     }
 }
 
+/// This does not auto-derive because `User`'s `data` fields can be used to
+/// store pointers to types that are `!Send`. Dereferencing these as pointers
+/// requires using `unsafe` and ensuring your own safety guarantees.
 unsafe impl Send for Event {}
+/// This does not auto-derive because `User`'s `data` fields can be used to
+/// store pointers to types that are `!Sync`. Dereferencing these as pointers
+/// requires using `unsafe` and ensuring your own safety guarantees.
 unsafe impl Sync for Event {}
 
 /// Helper function to make converting scancodes

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -710,6 +710,9 @@ pub enum Event {
     }
 }
 
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
+
 /// Helper function to make converting scancodes
 /// and keycodes to primitive `SDL_Keysym` types.
 fn mk_keysym<S, K>(scancode: S,


### PR DESCRIPTION
The only thing keeping these from auto deriving is the `User` variant's `data1` and `data2` `*mut c_void` fields. Given that those fields are opaque "do whatever you want and ensure your own guarantees" things that aren't necessarily actual pointers and require unsafe to use at all, I don't _think_ having `Event` be `Send`+`Send` is particularly problematic.

This is stemming from https://github.com/michaelfairley/rust-imgui-sdl2/issues/5, where someone wants render their GUI in a separate specs system (which might be running in a different thread), and the GUI library does some processing on `Event`s, and it feels like it should be fine to `Send` them.