### PR TITLE
Improved Exaple Error Handling: Replaced all calls to unwrap() in examples with either the ? operator or expect()

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -7,27 +7,28 @@ use sdl2::rect::Rect;
 use sdl2::rect::Point;
 use std::time::Duration;
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem.window("SDL2", 640, 480)
-        .position_centered().build().unwrap();
+        .position_centered().build().map_err(|e| e.to_string())?;
 
     let mut canvas = window.into_canvas()
-        .accelerated().build().unwrap();
+        .accelerated().build().map_err(|e| e.to_string())?;
     let texture_creator = canvas.texture_creator();
 
     canvas.set_draw_color(sdl2::pixels::Color::RGBA(0,0,0,255));
 
-    let mut timer = sdl_context.timer().unwrap();
+    let mut timer = sdl_context.timer()?;
 
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
 
     // animation sheet and extras are available from
     // https://opengameart.org/content/a-platformer-in-the-forest
-    let temp_surface = sdl2::surface::Surface::load_bmp(Path::new("assets/characters.bmp")).unwrap();
-    let texture = texture_creator.create_texture_from_surface(&temp_surface).unwrap();
+    let temp_surface = sdl2::surface::Surface::load_bmp(Path::new("assets/characters.bmp"))?;
+    let texture = texture_creator.create_texture_from_surface(&temp_surface)
+        .map_err(|e| e.to_string())?;
 
     let frames_per_anim = 4;
     let sprite_tile_size = (32,32);
@@ -72,11 +73,13 @@ fn main() {
 
         canvas.clear();
         // copy the frame to the canvas
-        canvas.copy_ex(&texture, Some(source_rect_0), Some(dest_rect_0), 0.0, None, false, false).unwrap();
-        canvas.copy_ex(&texture, Some(source_rect_1), Some(dest_rect_1), 0.0, None, true, false).unwrap();
-        canvas.copy_ex(&texture, Some(source_rect_2), Some(dest_rect_2), 0.0, None, false, false).unwrap();
+        canvas.copy_ex(&texture, Some(source_rect_0), Some(dest_rect_0), 0.0, None, false, false)?;
+        canvas.copy_ex(&texture, Some(source_rect_1), Some(dest_rect_1), 0.0, None, true, false)?;
+        canvas.copy_ex(&texture, Some(source_rect_2), Some(dest_rect_2), 0.0, None, false, false)?;
         canvas.present();
 
         std::thread::sleep(Duration::from_millis(100));
     }
+
+    Ok(())
 }

--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -13,20 +13,20 @@ fn gen_wave(bytes_to_write: i32) -> Vec<i16> {
 
     for x in 0..sample_count {
         result.push(
-                if (x / period) % 2 == 0 {
+            if (x / period) % 2 == 0 {
                 tone_volume
-                }
-                else {
+            }
+            else {
                 -tone_volume
-                }
+            }
         );
     }
     result
 }
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let audio_subsystem = sdl_context.audio().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {
         freq: Some(48_000),
@@ -34,9 +34,9 @@ fn main() {
         // mono  -
         samples: Some(4)
         // default sample size
-        };
+    };
 
-    let device = audio_subsystem.open_queue::<i16, _>(None, &desired_spec).unwrap();
+    let device = audio_subsystem.open_queue::<i16, _>(None, &desired_spec)?;
 
     let target_bytes = 48_000 * 4;
     let wave = gen_wave(target_bytes);
@@ -48,4 +48,6 @@ fn main() {
     std::thread::sleep(Duration::from_millis(2_000));
 
     // Device is automatically closed when dropped
+
+    Ok(())
 }

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -21,9 +21,9 @@ impl AudioCallback for SquareWave {
     }
 }
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let audio_subsystem = sdl_context.audio().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {
         freq: Some(44_100),
@@ -41,7 +41,7 @@ fn main() {
             phase: 0.0,
             volume: 0.25
         }
-    }).unwrap();
+    })?;
 
     // Start playback
     device.resume();
@@ -50,4 +50,6 @@ fn main() {
     std::thread::sleep(Duration::from_millis(2_000));
 
     // Device is automatically closed when dropped
+    
+    Ok(())
 }

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -25,13 +25,13 @@ impl AudioCallback for Sound {
     }
 }
 
-fn main() {
+fn main() -> Result<(), String> {
     let wav_file : Cow<'static, Path> = match std::env::args().nth(1) {
         None => Cow::from(Path::new("./assets/sine.wav")),
         Some(s) => Cow::from(PathBuf::from(s))
     };
-    let sdl_context = sdl2::init().unwrap();
-    let audio_subsystem = sdl_context.audio().unwrap();
+    let sdl_context = sdl2::init()?;
+    let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {
         freq: Some(44_100),
@@ -56,7 +56,7 @@ fn main() {
             volume: 0.25,
             pos: 0,
         }
-    }).unwrap();
+    })?;
 
     // Start playback
     device.resume();
@@ -65,4 +65,6 @@ fn main() {
     std::thread::sleep(Duration::from_millis(1_000));
 
     // Device is automatically closed when dropped
+
+    Ok(())
 }

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -21,9 +21,9 @@ impl AudioCallback for MyCallback {
     }
 }
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let audio_subsystem = sdl_context.audio().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {
         freq: Some(44_100),
@@ -37,7 +37,7 @@ fn main() {
         println!("{:?}", spec);
 
         MyCallback { volume: 0.5 }
-    }).unwrap();
+    })?;
 
     // Start playback
     device.resume();
@@ -56,4 +56,6 @@ fn main() {
     std::thread::sleep(Duration::from_millis(1_000));
 
     // Device is automatically closed when dropped
+
+    Ok(())
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -10,26 +10,21 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::surface::Surface;
 
-pub fn run(png: &Path) {
-
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
-    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG).unwrap();
+pub fn run(png: &Path) -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
+    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let window = video_subsystem.window("rust-sdl2 demo: Cursor", 800, 600)
       .position_centered()
       .build()
-      .unwrap();
+      .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().software().build().unwrap();
+    let mut canvas = window.into_canvas().software().build().map_err(|e| e.to_string())?;
 
-    let surface = match Surface::from_file(png) {
-        Ok(surface) => surface,
-        Err(err)    => panic!("failed to load cursor image: {}", err)
-    };
-    let cursor = match Cursor::from_surface(surface, 0, 0) {
-        Ok(cursor) => cursor,
-        Err(err) => panic!("failed to load cursor: {}", err)
-    };
+    let surface = Surface::from_file(png)
+        .map_err(|err| format!("failed to load cursor image: {}", err))?;
+    let cursor = Cursor::from_surface(surface, 0, 0)
+        .map_err(|err| format!("failed to load cursor: {}", err))?;
     cursor.set();
 
     canvas.clear();
@@ -37,7 +32,7 @@ pub fn run(png: &Path) {
 
     canvas.set_draw_color(Color::RGBA(255, 255, 255, 255));
 
-    let mut events = sdl_context.event_pump().unwrap();
+    let mut events = sdl_context.event_pump()?;
 
     'mainloop: loop {
         for event in events.poll_iter() {
@@ -46,23 +41,26 @@ pub fn run(png: &Path) {
                 Event::KeyDown {keycode: Option::Some(Keycode::Escape), ..} =>
                     break 'mainloop,
                  Event::MouseButtonDown {x, y, ..} => {
-                    canvas.fill_rect(Rect::new(x, y, 1, 1)).unwrap();
+                    canvas.fill_rect(Rect::new(x, y, 1, 1))?;
                     canvas.present();
                 }
                 _ => {}
             }
         }
     }
+
+    Ok(())
 }
 
 
-fn main() {
-
+fn main() -> Result<(), String> {
     let args: Vec<_> = env::args().collect();
 
     if args.len() < 2 {
         println!("Usage: cargo run /path/to/image.(png|jpg)")
     } else {
-        run(Path::new(&args[1]));
+        run(Path::new(&args[1]))?;
     }
+
+    Ok(())
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,22 +5,22 @@ use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use std::time::Duration;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
 
     canvas.set_draw_color(Color::RGB(255, 0, 0));
     canvas.clear();
     canvas.present();
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
 
     'running: loop {
         for event in event_pump.poll_iter() {
@@ -34,4 +34,6 @@ pub fn main() {
         ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
         // The rest of the game loop goes here...
     }
+
+    Ok(())
 }

--- a/examples/game-of-life-unsafe-textures.rs
+++ b/examples/game-of-life-unsafe-textures.rs
@@ -126,15 +126,13 @@ mod game_of_life {
 }
 
 #[cfg(feature = "unsafe_textures")]
-fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> (Texture, Texture) {
+fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> Result<(Texture, Texture), String> {
     enum TextureColor {
         Yellow,
         White,
     };
-    let mut square_texture1 : Texture =
-        canvas.create_texture_target(None, SQUARE_SIZE, SQUARE_SIZE).unwrap();
-    let mut square_texture2 : Texture =
-        canvas.create_texture_target(None, SQUARE_SIZE, SQUARE_SIZE).unwrap();
+    let mut square_texture1 = canvas.create_texture_target(None, SQUARE_SIZE, SQUARE_SIZE).map_err(|e| e.to_string())?;
+    let mut square_texture2 = canvas.create_texture_target(None, SQUARE_SIZE, SQUARE_SIZE).map_err(|e| e.to_string())?;
         // let's change the textures we just created
     {
         let textures = vec![
@@ -150,11 +148,13 @@ fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> (Texture, Texture) {
                         for j in 0..SQUARE_SIZE {
                             if (i+j) % 4 == 0 {
                                 texture_canvas.set_draw_color(Color::RGB(255, 255, 0));
-                                texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                                texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                                    .expect("could not draw point");
                             }
                             if (i+j*2) % 9 == 0 {
                                 texture_canvas.set_draw_color(Color::RGB(200, 200, 0));
-                                texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                                texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                                    .expect("could not draw point");
                             }
                         }
                     }
@@ -168,11 +168,13 @@ fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> (Texture, Texture) {
                                 // this doesn't mean anything, there was some trial and error to find
                                 // something that wasn't too ugly
                                 texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
-                                texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                                texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                                    .expect("could not draw point");
                             }
                             if (i+j*2) % 5 == 0 {
                                 texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
-                                texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                                texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                                    .expect("could not draw point");
                             }
                         }
                     }
@@ -186,24 +188,26 @@ fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> (Texture, Texture) {
                         // this doesn't mean anything, there was some trial and serror to find
                         // something that wasn't too ugly
                         texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
-                        texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                        texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                            .expect("could not draw point");
                     }
                     if (i+j*2) % 5 == 0 {
                         texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
-                        texture_canvas.draw_point(Point::new(i as i32, j as i32)).unwrap();
+                        texture_canvas.draw_point(Point::new(i as i32, j as i32))
+                            .expect("could not draw point");
                     }
                 }
             }
-        }).unwrap();
+        }).map_err(|e| e.to_string())?;
     }
-    (square_texture1, square_texture2)
+    Ok((square_texture1, square_texture2))
 }
 
 #[cfg(feature = "unsafe_textures")]
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
-    
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
+
     // the window is the representation of a window in your operating system,
     // however you can only manipulate properties of that window, like its size, whether it's
     // fullscreen, ... but you cannot change its content without using a Canvas or using the
@@ -214,14 +218,14 @@ pub fn main() {
                 SQUARE_SIZE*PLAYGROUND_HEIGHT)
         .position_centered()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
     // the canvas allows us to both manipulate the property of the window and to change its content
     // via hardware or software rendering. See CanvasBuilder for more info.
     let mut canvas = window.into_canvas()
         .target_texture()
         .present_vsync()
-        .build().unwrap();
+        .build().map_err(|e| e.to_string())?;
 
     println!("Using SDL_Renderer \"{}\"", canvas.info().name);
     canvas.set_draw_color(Color::RGB(0, 0, 0));
@@ -233,10 +237,10 @@ pub fn main() {
     canvas.present();
 
     // Create a "target" texture so that we can use our Renderer with it later
-    let (square_texture1, square_texture2) = dummy_texture(&mut canvas);
+    let (square_texture1, square_texture2) = dummy_texture(&mut canvas)?;
     let mut game = game_of_life::GameOfLife::new();
 
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
     let mut frame : u32 = 0;
     'running: loop {
         // get the inputs here
@@ -253,7 +257,7 @@ pub fn main() {
                     let y = (y as u32) / SQUARE_SIZE;
                     match game.get_mut(x as i32, y as i32) {
                         Some(square) => {*square = !(*square);},
-                        None => {panic!()}
+                        None => unreachable!(),
                     };
                 },
                 _ => {}
@@ -281,7 +285,7 @@ pub fn main() {
                             Rect::new(((i % PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
                                       ((i / PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
                                       SQUARE_SIZE,
-                                      SQUARE_SIZE)).unwrap();
+                                      SQUARE_SIZE))?;
             }
         }
         canvas.present();
@@ -289,6 +293,8 @@ pub fn main() {
             frame += 1;
         };
     }
+
+    Ok(())
 }
 
 #[cfg(not(feature = "unsafe_textures"))]

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -9,16 +9,16 @@ use sdl2::gfx::primitives::DrawRenderer;
 const SCREEN_WIDTH: u32 = 800;
 const SCREEN_HEIGHT: u32 = 600;
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsys = sdl_context.video().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsys = sdl_context.video()?;
     let window = video_subsys.window("rust-sdl2_gfx: draw line & FPSManager", SCREEN_WIDTH, SCREEN_HEIGHT)
         .position_centered()
         .opengl()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
 
     canvas.set_draw_color(pixels::Color::RGB(0, 0, 0));
     canvas.clear();
@@ -27,7 +27,7 @@ fn main() {
     let mut lastx = 0;
     let mut lasty = 0;
 
-    let mut events = sdl_context.event_pump().unwrap();
+    let mut events = sdl_context.event_pump()?;
 
     'main: loop {
         for event in events.poll_iter() {
@@ -42,10 +42,9 @@ fn main() {
                     } else if keycode == Keycode::Space {
                         println!("space down");
                         for i in 0..400 {
-                            canvas.pixel(i as i16, i as i16, 0xFF000FFu32).unwrap();
+                            canvas.pixel(i as i16, i as i16, 0xFF000FFu32)?;
                         }
                         canvas.present();
-
                     }
                 }
 
@@ -62,4 +61,6 @@ fn main() {
             }
         }
     }
+
+    Ok(())
 }

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -6,25 +6,24 @@ use sdl2::image::{LoadTexture, InitFlag};
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
-pub fn run(png: &Path) {
-
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
-    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG).unwrap();
+pub fn run(png: &Path) -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
+    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
       .position_centered()
       .build()
-      .unwrap();
+      .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().software().build().unwrap();
+    let mut canvas = window.into_canvas().software().build().map_err(|e| e.to_string())?;
     let texture_creator = canvas.texture_creator();
-    let texture = texture_creator.load_texture(png).unwrap();
+    let texture = texture_creator.load_texture(png)?;
 
-    canvas.copy(&texture, None, None).expect("Render failed");
+    canvas.copy(&texture, None, None)?;
     canvas.present();
 
     'mainloop: loop {
-        for event in sdl_context.event_pump().unwrap().poll_iter() {
+        for event in sdl_context.event_pump()?.poll_iter() {
             match event {
                 Event::Quit{..} |
                 Event::KeyDown {keycode: Option::Some(Keycode::Escape), ..} =>
@@ -33,16 +32,18 @@ pub fn run(png: &Path) {
             }
         }
     }
+
+    Ok(())
 }
 
-
-fn main() {
-
+fn main() -> Result<(), String> {
     let args: Vec<_> = env::args().collect();
 
     if args.len() < 2 {
         println!("Usage: cargo run /path/to/image.(png|jpg)")
     } else {
-        run(Path::new(&args[1]));
+        run(Path::new(&args[1]))?;
     }
+
+    Ok(())
 }

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -5,16 +5,16 @@ use sdl2::keyboard::Keycode;
 use std::collections::HashSet;
 use std::time::Duration;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem.window("Keyboard", 800, 600)
         .position_centered()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut events = sdl_context.event_pump().unwrap();
+    let mut events = sdl_context.event_pump()?;
 
     let mut prev_keys = HashSet::new();
 
@@ -40,4 +40,6 @@ pub fn main() {
 
         std::thread::sleep(Duration::from_millis(100));
     }
+
+    Ok(())
 }

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -5,39 +5,32 @@ use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use ::sdl2::messagebox::*;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
 
     canvas.set_draw_color(Color::RGB(255, 0, 0));
     canvas.clear();
     canvas.present();
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
 
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
                 Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
-                    let res =
-                        show_simple_message_box(MessageBoxFlag::ERROR,
-                                                "Some title",
-                                                "Some information inside the window",
-                                                canvas.window());
-                    match res {
-                        Ok(_) => {}
-                        Err(ShowMessageError::SdlError(string)) => {
-                            println!("An error occured : {}",string);
-                        }
-                        Err(_) => println!("Unexpected error occured !"),
-                    };
+                    show_simple_message_box(MessageBoxFlag::ERROR,
+                        "Some title",
+                        "Some information inside the window",
+                        canvas.window()
+                    ).map_err(|e| e.to_string())?;
                     break 'running
                 },
                 _ => {}
@@ -69,4 +62,6 @@ pub fn main() {
                                None,
                                None);
     println!("{:?}",res);
+
+    Ok(())
 }

--- a/examples/mixer-demo.rs
+++ b/examples/mixer-demo.rs
@@ -6,34 +6,34 @@ use std::env;
 use std::path::Path;
 use sdl2::mixer::{InitFlag, DEFAULT_CHANNELS, AUDIO_S16LSB};
 
-fn main() {
-
+fn main() -> Result<(), String> {
     let args: Vec<_> = env::args().collect();
 
     if args.len() < 2 {
         println!("Usage: ./demo music.[mp3|wav|ogg] [sound-effect.[mp3|wav|ogg]]")
     } else {
         let sound_file = args.get(2).map(|sound_file| Path::new(sound_file));
-        demo(Path::new(&args[1]), sound_file);
+        demo(Path::new(&args[1]), sound_file)?;
     }
+
+    Ok(())
 }
 
-fn demo(music_file: &Path, sound_file: Option<&Path>) {
-
+fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
     println!("linked version: {}", sdl2::mixer::get_linked_version());
 
-    let sdl = sdl2::init().unwrap();
-    let _audio = sdl.audio().unwrap();
-    let mut timer = sdl.timer().unwrap();
+    let sdl = sdl2::init()?;
+    let _audio = sdl.audio()?;
+    let mut timer = sdl.timer()?;
 
     let frequency = 44_100;
     let format = AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
     let channels = DEFAULT_CHANNELS; // Stereo
     let chunk_size = 1_024;
-    sdl2::mixer::open_audio(frequency, format, channels, chunk_size).unwrap();
+    sdl2::mixer::open_audio(frequency, format, channels, chunk_size)?;
     let _mixer_context = sdl2::mixer::init(
         InitFlag::MP3 | InitFlag::FLAC | InitFlag::MOD | InitFlag::OGG
-    ).unwrap();
+    )?;
 
     // Number of mixing channels available for sound effect `Chunk`s to play
     // simultaneously.
@@ -57,7 +57,7 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) {
 
     println!("query spec => {:?}", sdl2::mixer::query_spec());
 
-    let music = sdl2::mixer::Music::from_file(music_file).unwrap();
+    let music = sdl2::mixer::Music::from_file(music_file)?;
 
     fn hook_finished() {
         println!("play ends! from rust cb");
@@ -71,26 +71,18 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) {
     println!("play => {:?}", music.play(1));
 
     if let Some(sound_file_path) = sound_file {
-        let sound_chunk_res = sdl2::mixer::Chunk::from_file(sound_file_path);
+        let sound_chunk = sdl2::mixer::Chunk::from_file(sound_file_path)
+            .map_err(|e| format!("Cannot load sound file: {:?}", e))?;
 
-        match sound_chunk_res {
-            Ok(sound_chunk) => {
-                println!("chunk volume => {:?}", sound_chunk.get_volume());
-                println!("playing sound twice");
-                let play_res = sdl2::mixer::Channel::all().play(&sound_chunk, 1);
+        println!("chunk volume => {:?}", sound_chunk.get_volume());
+        println!("playing sound twice");
+        sdl2::mixer::Channel::all().play(&sound_chunk, 1)?;
 
-                // This delay is needed because when the `Chunk` goes out of scope,
-                // the sound effect stops playing. Delay long enough to hear the
-                // sound.
-                timer.delay(5_000);
-
-                match play_res {
-                    Ok(_) => println!("played sound"),
-                    Err(e) => println!("{:?}", e),
-                }
-            }
-            Err(e) => println!("Cannot load sound file: {:?}", e),
-        }
+        // This delay is needed because when the `Chunk` goes out of scope,
+        // the sound effect stops playing. Delay long enough to hear the
+        // sound.
+        timer.delay(5_000);
+        println!("played sound");
     }
 
     timer.delay(10_000);
@@ -100,11 +92,13 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) {
     timer.delay(5_000);
 
     println!("fading in from pos ... {:?}",
-             music.fade_in_from_pos(1, 10_000, 100.0));
+        music.fade_in_from_pos(1, 10_000, 100.0));
 
     timer.delay(5_000);
     sdl2::mixer::Music::halt();
     timer.delay(1_000);
 
     println!("quitting sdl");
+
+    Ok(())
 }

--- a/examples/mouse-state.rs
+++ b/examples/mouse-state.rs
@@ -5,16 +5,16 @@ use sdl2::keyboard::Keycode;
 use std::collections::HashSet;
 use std::time::Duration;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem.window("Mouse", 800, 600)
         .position_centered()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut events = sdl_context.event_pump().unwrap();
+    let mut events = sdl_context.event_pump()?;
 
     let mut prev_buttons = HashSet::new();
 
@@ -45,4 +45,6 @@ pub fn main() {
 
         std::thread::sleep(Duration::from_millis(100));
     }
+
+    Ok(())
 }

--- a/examples/no-renderer.rs
+++ b/examples/no-renderer.rs
@@ -19,8 +19,8 @@ enum Gradient {
     White
 }
 
-fn set_window_gradient(window: &mut Window, event_pump: &sdl2::EventPump, gradient: Gradient) {
-    let mut surface = window.surface(event_pump).unwrap();
+fn set_window_gradient(window: &mut Window, event_pump: &sdl2::EventPump, gradient: Gradient) -> Result<(), String> {
+    let mut surface = window.surface(event_pump)?;
     for i in 0 .. (WINDOW_WIDTH / 4) {
         let c : u8 = 255 - (i as u8);
         let i = i as i32;
@@ -31,9 +31,9 @@ fn set_window_gradient(window: &mut Window, event_pump: &sdl2::EventPump, gradie
             Gradient::Blue => Color::RGB(0, 0, c),
             Gradient::White => Color::RGB(c, c, c),
         };
-        surface.fill_rect(Rect::new(i*4, 0, 4, WINDOW_HEIGHT), color).unwrap();
+        surface.fill_rect(Rect::new(i*4, 0, 4, WINDOW_HEIGHT), color)?;
     }
-    surface.finish().unwrap();
+    surface.finish()
 }
 
 fn next_gradient(gradient: Gradient) -> Gradient {
@@ -47,17 +47,17 @@ fn next_gradient(gradient: Gradient) -> Gradient {
     }
 }
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
-    
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
+
     let mut window = video_subsystem.window("rust-sdl2 demo: No Renderer", WINDOW_WIDTH, WINDOW_HEIGHT)
         .position_centered()
         .build()
-        .unwrap();
-    let mut event_pump = sdl_context.event_pump().unwrap();
+        .map_err(|e| e.to_string())?;
+    let mut event_pump = sdl_context.event_pump()?;
     let mut current_gradient = Gradient::Red;
-    set_window_gradient(&mut window, &event_pump, current_gradient);
+    set_window_gradient(&mut window, &event_pump, current_gradient)?;
     'running: loop {
         let mut keypress : bool = false;
         for event in event_pump.poll_iter() {
@@ -73,8 +73,10 @@ pub fn main() {
         }
         if keypress {
             current_gradient = next_gradient(current_gradient);
-            set_window_gradient(&mut window, &event_pump, current_gradient);
+            set_window_gradient(&mut window, &event_pump, current_gradient)?;
         }
         ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
     }
+
+    Ok(())
 }

--- a/examples/relative-mouse-state.rs
+++ b/examples/relative-mouse-state.rs
@@ -5,16 +5,16 @@ use sdl2::mouse::MouseButton;
 use sdl2::keyboard::Keycode;
 use std::time::Duration;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem.window("Mouse", 800, 600)
         .position_centered()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut events = sdl_context.event_pump().unwrap();
+    let mut events = sdl_context.event_pump()?;
     let mut state;
 
     'running: loop {
@@ -35,4 +35,6 @@ pub fn main() {
 
         std::thread::sleep(Duration::from_millis(100));
     }
+
+    Ok(())
 }

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -5,24 +5,23 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::{Color, PixelFormatEnum};
 use sdl2::rect::{Point, Rect};
 
-fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
     let window = video_subsystem
         .window("rust-sdl2 resource-manager demo", 800, 600)
         .position_centered()
         .build()
-        .unwrap();
-    let mut canvas = window.into_canvas().software().build().unwrap();
+        .map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas().software().build().map_err(|e| e.to_string())?;
     let creator = canvas.texture_creator();
-    let mut texture = creator
-        .create_texture_target(PixelFormatEnum::RGBA8888, 400, 300)
-        .unwrap();
+    let mut texture = creator.create_texture_target(PixelFormatEnum::RGBA8888, 400, 300)
+        .map_err(|e| e.to_string())?;
 
     let mut angle = 0.0;
 
     'mainloop: loop {
-        for event in sdl_context.event_pump().unwrap().poll_iter() {
+        for event in sdl_context.event_pump()?.poll_iter() {
             match event {
                 Event::KeyDown { keycode: Some(Keycode::Escape), .. } |
                 Event::Quit { .. } => break 'mainloop,
@@ -33,20 +32,21 @@ fn main() {
         canvas.with_texture_canvas(&mut texture, |texture_canvas| {
             texture_canvas.clear();
             texture_canvas.set_draw_color(Color::RGBA(255, 0, 0, 255));
-            texture_canvas.fill_rect(Rect::new(0, 0, 400, 300)).unwrap();
-        }).unwrap();
+            texture_canvas.fill_rect(Rect::new(0, 0, 400, 300)).expect("could not fill rect");
+        }).map_err(|e| e.to_string())?;
         canvas.set_draw_color(Color::RGBA(0, 0, 0, 255));
         let dst = Some(Rect::new(0, 0, 400, 300));
         canvas.clear();
-        canvas
-            .copy_ex(&texture,
-                     None,
-                     dst,
-                     angle,
-                     Some(Point::new(400, 300)),
-                     false,
-                     false)
-            .unwrap();
+        canvas.copy_ex(&texture,
+            None,
+            dst,
+            angle,
+            Some(Point::new(400, 300)),
+            false,
+            false
+        )?;
         canvas.present();
     }
+
+    Ok(())
 }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -5,21 +5,21 @@ use sdl2::rect::Rect;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
     let texture_creator = canvas.texture_creator();
 
-    let mut texture = texture_creator.create_texture_streaming(
-        PixelFormatEnum::RGB24, 256, 256).unwrap();
+    let mut texture = texture_creator.create_texture_streaming(PixelFormatEnum::RGB24, 256, 256)
+        .map_err(|e| e.to_string())?;
     // Create a red-green gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
         for y in 0..256 {
@@ -30,20 +30,20 @@ pub fn main() {
                 buffer[offset + 2] = 0;
             }
         }
-    }).unwrap();
+    })?;
 
     canvas.clear();
-    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
+    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)))?;
     canvas.copy_ex(&texture, None,
-        Some(Rect::new(450, 100, 256, 256)), 30.0, None, false, false).unwrap();
+        Some(Rect::new(450, 100, 256, 256)), 30.0, None, false, false)?;
     canvas.present();
 
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
 
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit {..} 
+                Event::Quit {..}
                 | Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
                     break 'running
                 },
@@ -52,4 +52,6 @@ pub fn main() {
         }
         // The rest of the game loop goes here...
     }
+
+    Ok(())
 }

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -5,21 +5,21 @@ use sdl2::rect::Rect;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
     let texture_creator = canvas.texture_creator();
 
-    let mut texture = texture_creator.create_texture_streaming(
-        PixelFormatEnum::IYUV, 256, 256).unwrap();
+    let mut texture = texture_creator.create_texture_streaming(PixelFormatEnum::IYUV, 256, 256)
+        .map_err(|e| e.to_string())?;
     // Create a U-V gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {
         // `pitch` is the width of the Y component
@@ -47,13 +47,13 @@ pub fn main() {
                 buffer[v_offset] = (y*2) as u8;
             }
         }
-    }).unwrap();
+    })?;
 
     canvas.clear();
-    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256))).unwrap();
+    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)))?;
     canvas.present();
 
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump()?;
 
     'running: loop {
         for event in event_pump.poll_iter() {
@@ -66,4 +66,6 @@ pub fn main() {
         }
         // The rest of the game loop goes here...
     }
+
+    Ok(())
 }

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -4,21 +4,21 @@ use sdl2::pixels::Color;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 
-pub fn main() {
-    let sdl_context = sdl2::init().unwrap();
-    let video_subsystem = sdl_context.video().unwrap();
+pub fn main() -> Result<(), String> {
+    let sdl_context = sdl2::init()?;
+    let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
         .window("rust-sdl2 demo: Window", 800, 600)
         .resizable()
         .build()
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().present_vsync().build().unwrap();
+    let mut canvas = window.into_canvas().present_vsync().build().map_err(|e| e.to_string())?;
 
     let mut tick = 0;
 
-    let mut event_pump = sdl_context.event_pump().unwrap();
+    let mut event_pump = sdl_context.event_pump().map_err(|e| e.to_string())?;
 
     'running: loop {
         for event in event_pump.poll_iter() {
@@ -41,7 +41,7 @@ pub fn main() {
                                 size.0,
                                 size.1,
                                 tick);
-            window.set_title(&title).unwrap();
+            window.set_title(&title).map_err(|e| e.to_string())?;
 
             tick += 1;
         }
@@ -50,4 +50,6 @@ pub fn main() {
         canvas.clear();
         canvas.present();
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Part of #836 

This PR modifies all the examples in the `examples/` folder to use more idiomatic Rust error handling code. This PR is already quite big with quite a few (hopefully small and easy to review) changes, so converting the examples in the docs will be a separate PR later.

I manually went through and ran `cargo run` for each example, so hopefully they all compile and CI will pass.

Everything should still work exactly the same. This PR isn't meant to change any functionality. Just updating to the latest idioms.

Some notes:

* All calls to `unwrap()` are completely gone from all examples
* Majority of those calls are replaced with the `?` operator where possible
* Some calls could not be removed without a breaking change to the specs API, so `expect()` was used to keep this PR easy to merge (should be a future discussion?)
* `expect()` was also added in some places where it is totally fine. For example, some of the previous calls to `unwrap()` were for cases we expect to be unreachable. In these cases `expect()` is just in case something goes really wrong. (no need for future discussion)
* In addition to just calls to `unwrap()`, I also looked for `panic!()` calls and matching on `Result` types to find a bunch of places where code could either be improved or completely replaced with the `?` operator

To make review as easy as possible, I avoided changing the structure of code as much as I could. That being said, I definitely noticed a lot of room for improvement in these examples. There is code that is starting to show its age and could be improved to be shorter, more idomatic, etc. 

It's great to be able to give back to such a great library and I hope I'm able to contribute more in the future! Thanks for all your work on this! :smile: 