### PR TITLE
Patch NixOS build

### DIFF
--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -2,6 +2,7 @@
 #![allow(const_err)]
 
 use sys;
+use std;
 use std::mem;
 use std::ptr;
 use std::ops::{Deref, DerefMut, Add, BitAnd, BitOr, Div, Mul, Neg, Sub};


### PR DESCRIPTION
I've run into an issue when attempting to install this lib on NixOS. This patches the issue but I'm not quite sure if it's the best way.

Basic system information:

```
[nix-shell:~/Projects/rust-sdl2]$ rustc --version
rustc 1.27.0
[nix-shell:~/Projects/rust-sdl2]$ cargo --version
cargo 1.27.0
[nix-shell:~/Projects/rust-sdl2]$ cat /etc/os-release
NAME=NixOS
ID=nixos
VERSION="18.09.1829.0396345b794 (Jellyfish)"
VERSION_CODENAME=jellyfish
VERSION_ID="18.09.1829.0396345b794"
PRETTY_NAME="NixOS 18.09.1829.0396345b794 (Jellyfish)"
HOME_URL="https://nixos.org/"
SUPPORT_URL="https://nixos.org/nixos/support.html"
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
```

**see commit message for explanation of the issue**