### PR TITLE
add windows to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 before_script:
   - shopt -s expand_aliases
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then alias pip=pip2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install python2; alias pip="python2 -m pip"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install python2; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; python2 get-pip.py; alias pip="python2 -m pip"; fi
   - |
     pip install 'travis-cargo<0.2' --user &&
     export PATH=$HOME/.local/bin:$PATH &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - LD_LIBRARY_PATH: "/usr/local/lib"
     - secure: MJhmVnQ2IM7+sVmc3vU4ndKOcQgLLeHUPW3qaQBQHKQmvoswCwQK60N17uSgWn1Ln8teqvSRHq4KclIjdMHI+VuQXJHQKHDgjcYbHxwmc3AM1Whnp0XB44ksKUmD109BGWSfZQxzF+6dA+YNOQ+mti+bpydMu8n2FMVjA/SXwQ8=
+matrix:
+  include:
+    - os: windows
+      rust: stable-gnu
 
 install:
   - if [[ $CI_BUILD_FEATURES != *"bundled"* ]]; then bash scripts/travis-install-sdl2.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 before_script:
   - shopt -s expand_aliases
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then alias pip=pip2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then alias pip="python2 -m pip"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install python2; fi
   - |
     pip install 'travis-cargo<0.2' --user &&
     export PATH=$HOME/.local/bin:$PATH &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 rust:
   - beta
   - stable
+  - stable-gnu
 os:
   - linux
   - osx
@@ -18,8 +19,10 @@ env:
     - LD_LIBRARY_PATH: "/usr/local/lib"
     - secure: MJhmVnQ2IM7+sVmc3vU4ndKOcQgLLeHUPW3qaQBQHKQmvoswCwQK60N17uSgWn1Ln8teqvSRHq4KclIjdMHI+VuQXJHQKHDgjcYbHxwmc3AM1Whnp0XB44ksKUmD109BGWSfZQxzF+6dA+YNOQ+mti+bpydMu8n2FMVjA/SXwQ8=
 matrix:
-  include:
-    - os: windows
+  exclude:
+    - os: linux
+      rust: stable-gnu
+    - os: osx
       rust: stable-gnu
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 before_script:
   - shopt -s expand_aliases
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then alias pip=pip2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install python2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install python2; alias pip="python2 -m pip"; fi
   - |
     pip install 'travis-cargo<0.2' --user &&
     export PATH=$HOME/.local/bin:$PATH &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: rust
 sudo: required
 rust:
-  - beta
-  - beta-gnu
+  # - beta
+  # - beta-gnu
   - stable
   - stable-gnu
 os:
-  - linux
-  - osx
+  # - linux
+  # - osx
   - windows
 filter_secrets: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 sudo: required
 rust:
   - beta
+  - beta-gnu
   - stable
   - stable-gnu
 os:
@@ -22,8 +23,12 @@ matrix:
   exclude:
     - os: linux
       rust: stable-gnu
+    - os: linux
+      rust: beta-gnu
     - os: osx
       rust: stable-gnu
+    - os: osx
+      rust: beta-gnu
 
 install:
   - if [[ $CI_BUILD_FEATURES != *"bundled"* ]]; then bash scripts/travis-install-sdl2.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rust:
   - beta
   - stable
 os:
+  - linux
+  - osx
   - windows
 filter_secrets: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 filter_secrets: false
 env:
   matrix:
-    - CI_BUILD_FEATURES="bundled"
+    # - CI_BUILD_FEATURES="bundled"
     - CI_BUILD_FEATURES="gfx image ttf mixer"
   global:
     - RUST_TEST_THREADS=1

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,7 +5,7 @@ set -xueo pipefail
 RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
-MSBUILD="'/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe'"
+MSBUILD='"/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe"'
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     ls -l ${MSBUILD}

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -36,15 +36,19 @@ function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
-            CONFIG_SHELL="/C/Program\\ Files/Git/usr/bin/sh"
+            CONFIG_SHELL="/C/Program\\ Files/Git/bin/bash"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            sed -i 's!/bin/sh!"/C/Program Files/Git/usr/bin/sh"!' Makefile
+            sed -i 's!/bin/sh!"/C/Program Files/Git/bin/bash"!' Makefile
             cat Makefile
             mingw32-make
             mingw32-make install || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
+            pwd
+            ls ..
+            ls ../..
+            ls ../../SDL-2.0.9
             ls ${INCLUDE}
             export LIB=${PREFIX}/lib
             export UseEnv=true

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -38,7 +38,7 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
             powershell <<EOF
-Set-Item -Path Env:Path -Value (((Get-ChildItem Env:Path).Value.Split(';') | Where-Object { \$_ -ne 'C:\Program Files\Git\bin' }) -join ';')
+Set-Item -Path Env:Path -Value (((Get-ChildItem Env:Path).Value.Split(';') | Where-Object { (\$_ -ne 'C:\\Program Files\\Git\\bin' -and \$_ -ne 'C:\\Program Files\\Git\\usr\\bin') }) -join ';')
 mingw32-make V=1
 EOF
             PATH=$(nuke_bin_in_path) cmd <<< "mingw32-make V=1"
@@ -50,7 +50,7 @@ EOF
             export UseEnv=true
             cmd <<EOF
 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
-"${MSBUILD}" SDL/SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
+msbuild SDL\\SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -2,11 +2,21 @@
 
 set -xueo pipefail
 
+function build() {
+    if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+        ./configure --build=x86_64-mingw32
+        mingw32-make
+        sudo mingw32-make install
+    else
+        ./configure
+        make
+        sudo make install
+    fi
+}
+
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
-if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then CONFIG_BUILD="--build=x86_64-mingw32"; else CONFIG_BUILD=; fi
-pushd SDL2-* && ./configure ${CONFIG_BUILD} && make && sudo make install && popd
-exit
+(pushd SDL2-* && build && popd) || exit
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT=unzip
@@ -22,7 +32,7 @@ ${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
 ${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
 ${EXTRACT} SDL2_mixer-*${EXT} && rm SDL2_mixer-*${EXT}
 ${EXTRACT} SDL2_gfx-*${EXT} && rm SDL2_gfx-*${EXT}
-pushd SDL2_ttf-* && ./configure && make && sudo make install && popd
-pushd SDL2_image-* && ./configure && make && sudo make install && popd
-pushd SDL2_mixer-* && ./configure && make && sudo make install && popd
-pushd SDL2_gfx-* && ./autogen.sh && ./configure && make && sudo make install && popd
+pushd SDL2_ttf-* && build && popd
+pushd SDL2_image-* && build && popd
+pushd SDL2_mixer-* && build && popd
+pushd SDL2_gfx-* && ./autogen.sh && build && popd

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -16,8 +16,8 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin
     EXT=.zip
     EXTRACT=unzip
-    PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
+    PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
     EXT=.tar.gz
     EXTRACT="tar xzf"
@@ -26,6 +26,7 @@ fi
 function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
+            LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX}
             mingw32-make V=1
             mingw32-make install

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,8 +5,11 @@ set -xueo pipefail
 RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
+MSBUILD=/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe
+
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ls -l /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe
+    ls -l ${MSBUILD}
+    ${MSBUILD} /help
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
@@ -18,19 +21,15 @@ fi
 
 function build() {
     pushd $1
-    if [[ -f "autogen.sh" ]]; then
-        ./autogen.sh
-    fi
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
-            ./configure --build=x86_64-mingw32 --prefix=${PREFIX}
-            mingw32-make SHELL=/C/Program\ Files/Git/usr/bin/sh
-            mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh
+            ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
+            mingw32-make SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
+            mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
         else
             cd VisualC
-            /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe \
-                /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
+            ${MSBUILD} /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else
@@ -43,16 +42,24 @@ function build() {
 
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
-build SDL2-* || exit
-wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
-wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
-wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}
-wget -q -O SDL2_gfx-1.0.1${EXT} https://sourceforge.net/projects/sdl2gfx/files/SDL2_gfx-1.0.1${EXT}/download
-${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
-${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
-${EXTRACT} SDL2_mixer-*${EXT} && rm SDL2_mixer-*${EXT}
-${EXTRACT} SDL2_gfx-*${EXT} && rm SDL2_gfx-*${EXT}
-# pushd SDL2_ttf-* && build && popd
-build SDL2_image-*
-build SDL2_mixer-*
-build SDL2_gfx-*
+build SDL2-* || exit 1
+if [[ "$CI_BUILD_FEATURES" == *"ttfBROKEN"* ]]; then
+    wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
+    ${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
+    build SDL2_ttf-*
+fi
+if [[ "$CI_BUILD_FEATURES" == *"image"* ]]; then
+    wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
+    ${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
+    build SDL2_image-*
+fi
+if [[ "$CI_BUILD_FEATURES" == *"mixer"* ]]; then
+    wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}
+    ${EXTRACT} SDL2_mixer-*${EXT} && rm SDL2_mixer-*${EXT}
+    build SDL2_mixer-*
+fi
+if [[ "$CI_BUILD_FEATURES" == *"gfx"* ]]; then
+    wget -q -O SDL2_gfx-1.0.1${EXT} https://sourceforge.net/projects/sdl2gfx/files/SDL2_gfx-1.0.1${EXT}/download
+    ${EXTRACT} SDL2_gfx-*${EXT} && rm SDL2_gfx-*${EXT}
+    build SDL2_gfx-*
+fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -10,7 +10,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXTRACT=unzip
 else
     EXT=.tar.gz
-    EXTRACT=tar xzf
+    EXTRACT="tar xzf"
 fi
 wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
 wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -12,7 +12,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
     WINSDK=$(ls -1r "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug" | head -1)
-    TOOLSET=$(grep -m 1 "PlatformToolset" Common7\IDE\VC\VCWizards\default.vcxproj | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
+    TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
     EXT=.tar.gz

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,6 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
+    cat "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCTargets/Microsoft.Cpp.WindowsSDK.targets"
     WINSDK_ROOT="/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"
     ls -l "${WINSDK_ROOT}"
     for WINSDK_MAYBE in $(ls "${WINSDK_ROOT}"); do

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,7 +5,7 @@ set -xueo pipefail
 RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
-MSBUILD=/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe
+MSBUILD="'/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe'"
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     ls -l ${MSBUILD}

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -36,7 +36,7 @@ function build() {
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -t:SDL -p:Configuration=Release -p:Platform=x64 \
+            "${MSBUILD}" SDL/SDL.vcxproj -p:Configuration=Release -p:Platform=x64 \
                 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDKS=$(ls "/C/Program Files (x86)/Windows Kits/10/Lib")
+    WINSDK=10.0.17134.0
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -36,12 +36,8 @@ function build() {
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            # this is perhaps the worst thing i have ever done in my life
-            for WINSDK in $(seq 744 20000); do
-                WINSDK=10.0.${WINSDK}.0
-                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -t:SDL -p:Configuration=Release -p:Platform=x64 \
-                    -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
-            done
+            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -t:SDL -p:Configuration=Release -p:Platform=x64 \
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -38,7 +38,7 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
             powershell <<EOF
-Set-Item -Path Env:Path -Value (((Get-ChildItem Env:Path).Value.Split(';') | Where-Object { $_ -ne 'C:\Program Files\Git\bin' }) -join ';')
+Set-Item -Path Env:Path -Value (((Get-ChildItem Env:Path).Value.Split(';') | Where-Object { \$_ -ne 'C:\Program Files\Git\bin' }) -join ';')
 mingw32-make V=1
 EOF
             PATH=$(nuke_bin_in_path) cmd <<< "mingw32-make V=1"
@@ -48,9 +48,9 @@ EOF
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            cmd /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat" <<EOF
-"${MSBUILD}" SDL/SDL.vcxproj -p:Configuration=Release -p:Platform=x64 \
-    -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
+            cmd <<EOF
+"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
+"${MSBUILD}" SDL/SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=$(ls -1r "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug" | head -1)
+    WINSDKS=$(ls -1r "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug")
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -27,16 +27,18 @@ function build() {
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
             sed -i "s!/bin/sh!\"jifojsdf\"!" Makefile
-            head -n 50 Makefile
-            mingw32-make SHELL="adsdf" || return 1
+            head -n 60 Makefile
+            mingw32-make V=1 SHELL="adsdf" || return 1
             mingw32-make install SHELL="gdfhhgjh" || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
+            for WINSDK in ${WINSDKS}; do
+                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
+                    -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
+            done
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -38,16 +38,20 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             CONFIG_SHELL="/C/Program\\ Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
+            sed -i 's!/bin/sh!"/C/Program Files/Git/usr/bin/sh"!' Makefile
             cat Makefile
             mingw32-make
             mingw32-make install || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
+            ls ${INCLUDE}
             export LIB=${PREFIX}/lib
             export UseEnv=true
             cmd <<EOF
 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
+echo %INCLUDE%
+echo %UseEnv%
 msbuild $2 -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
             echo

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -26,13 +26,13 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            sed -i "s!/bin/sh!\"C:/Program Files/Git/usr/bin/sh\"!" Makefile
-            mingw32-make SHELL="C:/Program Files/Git/usr/bin/sh" || return 1
-            mingw32-make install SHELL="C:/Program Files/Git/usr/bin/sh" || return 1
+            sed -i "s!/bin/sh!\"jifojsdf\"!" Makefile
+            mingw32-make SHELL="adsdf" || return 1
+            mingw32-make install SHELL="gdfhhgjh" || return 1
         else
             cd VisualC
             "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} '-p:IncludePath=../../SDL2-2.0.9/include/SDL2;$(IncludePath)' \
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} -p:IncludePath='../../SDL2-2.0.9/include/SDL2;$(IncludePath)' \
                  || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -13,6 +13,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
+    WINSDK=$(ls "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
     EXT=.tar.gz
@@ -29,7 +30,7 @@ function build() {
             mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
         else
             cd VisualC
-            "${MSBUILD}" -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=v141 -p:WindowsTargetPlatformVersion=10.0.17763.0
+            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=v141 -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -4,6 +4,15 @@ set -xueo pipefail
 RUST_TOOLCHAIN=$(rustup show | grep -A 3 active | tail -1 | sed "s/ (default)//")
 RUST_HOST=$(rustup show | grep "Default host" | sed "s/Default host: //")
 
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+    EXT=.zip
+    EXTRACT=unzip
+    PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin
+else
+    EXT=.tar.gz
+    EXTRACT="tar xzf"
+fi
+
 rustup which cargo
 
 function build() {
@@ -26,13 +35,6 @@ function build() {
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
 (pushd SDL2-* && build && popd) || exit
-if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    EXT=.zip
-    EXTRACT=unzip
-else
-    EXT=.tar.gz
-    EXTRACT="tar xzf"
-fi
 wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
 wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
 wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -6,14 +6,7 @@ RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ls /C/
-    ls /C/Program\ Files\ \(x86\)/
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0
-    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin
+    ls -l /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
@@ -36,7 +29,8 @@ function build() {
             mingw32-make install
         else
             cd VisualC
-            MSBuild /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
+            /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild \
+                /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -14,7 +14,7 @@ function build() {
             mingw32-make install
         else
             cd VisualC
-            msbuild
+            msbuild /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
         fi
     else
         ./configure

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -6,6 +6,14 @@ RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+    ls /C/
+    ls /C/Program\ Files\ \(x86\)/
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0
+    ls /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin
     EXT=.zip
     EXTRACT=unzip
     PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,12 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=10.0.17134.0
+    ls -l "/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"
+    for WINSDK_MAYBE in $(ls "/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"); do
+        if [[ -f "${WINSDK_MAYBE}/UAP.props" ]]; then
+            export WINSDK=${WINSDK_MAYBE}
+        fi
+    done
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -9,9 +9,9 @@ MSBUILD='/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
-    EXTRACT=unzip
+    EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDKS=$(ls -1r "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug")
+    WINSDKS=$(ls -1r "/C/Program Files (x86)/Windows Kits/10/Extension SDKs/WindowsDesktop")
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -24,12 +24,9 @@ function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
-            export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            sed -i "s!/bin/sh!\"jifojsdf\"!" Makefile
-            head -n 60 Makefile
-            mingw32-make V=1 SHELL="adsdf" || return 1
-            mingw32-make install SHELL="gdfhhgjh" || return 1
+            cmd /C mingw32-make
+            mingw32-make install || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
@@ -39,7 +36,7 @@ function build() {
                 "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
                     -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
             done
-            cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
+            cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else
         ./configure

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -26,6 +26,7 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
+            sed -i "s!/bin/sh!/C/Program Files/Git/usr/bin/sh!" Makefile
             mingw32-make SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
             mingw32-make install SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
         else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,7 +5,7 @@ set -xueo pipefail
 function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         ./configure --build=x86_64-mingw32
-        mingw32-make
+        mingw32-make V=1
         sudo mingw32-make install
     else
         ./configure

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -8,12 +8,11 @@ RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 MSBUILD='/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe'
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ls -l "${MSBUILD}"
-    "${MSBUILD}" -help
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=$(ls "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug")
+    WINSDK=$(ls -1r "/C/Program Files (x86)/Microsoft SDKs/Windows Kits/10/ExtensionSDKs/Microsoft.UniversalCRT.Debug" | head -1)
+    TOOLSET=$(grep -m 1 "PlatformToolset" Common7\IDE\VC\VCWizards\default.vcxproj | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
     EXT=.tar.gz
@@ -31,7 +30,7 @@ function build() {
             mingw32-make install SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
         else
             cd VisualC
-            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=v141 -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
+            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=$(cmd <<<"reg query \"HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0\" /v ProductVersion" | grep REG_SZ | awk '{ print $3 }')
+    WINSDK=$(cmd <<<"reg query \"HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0\" /v ProductVersion" | grep REG_SZ | awk '{ print $3 }').0
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -25,7 +25,7 @@ function build() {
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            cmd <<< mingw32-make
+            cmd <<< "mingw32-make V=1"
             mingw32-make install || return 1
         else
             cd VisualC

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -27,7 +27,7 @@ function build() {
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
             sed -i "s!/bin/sh!\"jifojsdf\"!" Makefile
-            head -n 20 Makefile
+            head -n 50 Makefile
             mingw32-make SHELL="adsdf" || return 1
             mingw32-make install SHELL="gdfhhgjh" || return 1
         else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -25,11 +25,11 @@ function build() {
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX}
-            mingw32-make || mingw32-make V=1
-            mingw32-make install
+            mingw32-make SHELL=/C/Program\ Files/Git/usr/bin/sh
+            mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh
         else
             cd VisualC
-            /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild \
+            /C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe \
                 /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -6,7 +6,7 @@ function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         ./configure --build=x86_64-mingw32
         mingw32-make V=1
-        sudo mingw32-make install
+        mingw32-make install
     else
         ./configure
         make

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,14 +5,21 @@ set -xueo pipefail
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
 pushd SDL2-* && ./configure && make && sudo make install && popd
-wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.tar.gz
-wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1.tar.gz
-wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2.tar.gz
-wget -q -O SDL2_gfx-1.0.1.tar.gz https://sourceforge.net/projects/sdl2gfx/files/SDL2_gfx-1.0.1.tar.gz/download
-tar xzf SDL2_ttf-*.tar.gz
-tar xzf SDL2_image-*.tar.gz
-tar xzf SDL2_mixer-*.tar.gz
-tar xzf SDL2_gfx-*.tar.gz
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+    EXT=.zip
+    EXTRACT=unzip
+else
+    EXT=.tar.gz
+    EXTRACT=tar xzf
+fi
+wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
+wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
+wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}
+wget -q -O SDL2_gfx-1.0.1${EXT} https://sourceforge.net/projects/sdl2gfx/files/SDL2_gfx-1.0.1${EXT}/download
+${EXTRACT} SDL2_ttf-*${EXT}
+${EXTRACT} SDL2_image-*${EXT}
+${EXTRACT} SDL2_mixer-*${EXT}
+${EXTRACT} SDL2_gfx-*${EXT}
 pushd SDL2_ttf-* && ./configure && make && sudo make install && popd
 pushd SDL2_image-* && ./configure && make && sudo make install && popd
 pushd SDL2_mixer-* && ./configure && make && sudo make install && popd

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDKS=$(ls -1r "/C/Program Files (x86)/Windows Kits/10/Extension SDKs/WindowsDesktop")
+    WINSDK=$(reg query "HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0" /v ProductVersion | grep REG_SZ | awk '{ print $3 }')
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -25,17 +25,15 @@ function build() {
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            cmd /C mingw32-make
+            cmd <<< mingw32-make
             mingw32-make install || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            for WINSDK in ${WINSDKS}; do
-                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                    -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
-            done
+            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -36,9 +36,11 @@ function build() {
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            for WINSDK in ${WINSDKS}; do
+            # this is perhaps the worst thing i have ever done in my life
+            for WINSDK in $(seq 1 20000); do
+                WINSDK=10.0.${WINSDK}.0
                 "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
+                    -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
             done
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -25,9 +25,10 @@ function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
+            export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            mingw32-make SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
-            mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
+            mingw32-make SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
+            mingw32-make install SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
         else
             cd VisualC
             "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=v141 -p:WindowsTargetPlatformVersion=${WINSDK} || return 1

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
 set -xueo pipefail
+RUST_TOOLCHAIN=$(rustup show | grep -A 3 active | tail -1 | sed "s/ (default)//")
+RUST_HOST=$(rustup show | grep "Default host" | sed "s/Default host: //")
+
+rustup which cargo
 
 function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
-            ./configure --build=x86_64-mingw32
+            ./configure --build=x86_64-mingw32 --prefix=/c/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
             mingw32-make V=1
             mingw32-make install
         else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -9,7 +9,7 @@ MSBUILD='/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     ls -l "${MSBUILD}"
-    "${MSBUILD}" /help
+    "${MSBUILD}" -help
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
@@ -29,7 +29,7 @@ function build() {
             mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
         else
             cd VisualC
-            "${MSBUILD}" /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
+            "${MSBUILD}" -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=v141 -p:WindowsTargetPlatformVersion=10.0.17763.0
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -27,12 +27,15 @@ function build() {
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
             sed -i "s!/bin/sh!\"jifojsdf\"!" Makefile
+            head -n 20 Makefile
             mingw32-make SHELL="adsdf" || return 1
             mingw32-make install SHELL="gdfhhgjh" || return 1
         else
             cd VisualC
+            export INCLUDE=../../SDL-2.0.9/include
+            export LIB=${PREFIX}/lib
             "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} -p:IncludePath='../../SDL2-2.0.9/include/SDL2;$(IncludePath)' \
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} -p:IncludePath='../../SDL2-2.0.9/include;$(IncludePath)' \
                  || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -26,12 +26,14 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             export SHELL=$"/C/Program Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            sed -i "s!/bin/sh!/C/Program Files/Git/usr/bin/sh!" Makefile
-            mingw32-make SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
-            mingw32-make install SHELL="/C/Program Files/Git/usr/bin/sh" || return 1
+            sed -i "s!/bin/sh!\"C:/Program Files/Git/usr/bin/sh\"!" Makefile
+            mingw32-make SHELL="C:/Program Files/Git/usr/bin/sh" || return 1
+            mingw32-make install SHELL="C:/Program Files/Git/usr/bin/sh" || return 1
         else
             cd VisualC
-            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
+            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} '-p:IncludePath=../../SDL2-2.0.9/include/SDL2;$(IncludePath)' \
+                 || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -37,11 +37,8 @@ function build() {
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            powershell <<EOF
-Set-Item -Path Env:Path -Value (((Get-ChildItem Env:Path).Value.Split(';') | Where-Object { (\$_ -ne 'C:\\Program Files\\Git\\bin' -and \$_ -ne 'C:\\Program Files\\Git\\usr\\bin') }) -join ';')
-mingw32-make V=1
-EOF
-            PATH=$(nuke_bin_in_path) cmd <<< "mingw32-make V=1"
+            cat Makefile
+            mingw32-make V=1
             mingw32-make install || return 1
         else
             cd VisualC
@@ -52,6 +49,9 @@ EOF
 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
 msbuild SDL\\SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
+            ls
+            ls x64
+            ls x64/Release
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -36,8 +36,8 @@ function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
+            CONFIG_SHELL="/C/Program\\ Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            cat Makefile
             mingw32-make V=1
             mingw32-make install || return 1
         else
@@ -49,10 +49,12 @@ function build() {
 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
 msbuild SDL\\SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
-            ls
-            ls x64
-            ls x64/Release
-            cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
+            echo
+            ls *
+            ls SDL
+            ls SDL/x64
+            ls SDL/x64/Release
+            cp SDL/x64/Release/*.lib SDL/x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else
         ./configure

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=$(reg query "HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0" /v ProductVersion | grep REG_SZ | awk '{ print $3 }')
+    WINSDK=$(cmd <<<"reg query \"HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0\" /v ProductVersion" | grep REG_SZ | awk '{ print $3 }')
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,9 +11,11 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    ls -l "/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"
-    for WINSDK_MAYBE in $(ls "/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"); do
-        if [[ -f "${WINSDK_MAYBE}/UAP.props" ]]; then
+    WINSDK_ROOT="/C/Program Files (x86)/Windows Kits/10/DesignTime/CommonConfiguration/Neutral/UAP"
+    ls -l "${WINSDK_ROOT}"
+    for WINSDK_MAYBE in $(ls "${WINSDK_ROOT}"); do
+        ls -l "${WINSDK_ROOT}/${WINSDK_MAYBE}"
+        if [[ -f "${WINSDK_ROOT}/${WINSDK_MAYBE}/UAP.props" ]]; then
             export WINSDK=${WINSDK_MAYBE}
         fi
     done

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -4,9 +4,14 @@ set -xueo pipefail
 
 function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-        ./configure --build=x86_64-mingw32
-        mingw32-make V=1
-        mingw32-make install
+        if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
+            ./configure --build=x86_64-mingw32
+            mingw32-make V=1
+            mingw32-make install
+        else
+            cd VisualC
+            msbuild
+        fi
     else
         ./configure
         make

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -16,10 +16,10 @@ wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
 wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
 wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}
 wget -q -O SDL2_gfx-1.0.1${EXT} https://sourceforge.net/projects/sdl2gfx/files/SDL2_gfx-1.0.1${EXT}/download
-${EXTRACT} SDL2_ttf-*${EXT}
-${EXTRACT} SDL2_image-*${EXT}
-${EXTRACT} SDL2_mixer-*${EXT}
-${EXTRACT} SDL2_gfx-*${EXT}
+${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
+${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
+${EXTRACT} SDL2_mixer-*${EXT} && rm SDL2_mixer-*${EXT}
+${EXTRACT} SDL2_gfx-*${EXT} && rm SDL2_gfx-*${EXT}
 pushd SDL2_ttf-* && ./configure && make && sudo make install && popd
 pushd SDL2_image-* && ./configure && make && sudo make install && popd
 pushd SDL2_mixer-* && ./configure && make && sudo make install && popd

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 set -xueo pipefail
+
+rustup show
+rustup which cargo
 RUST_TOOLCHAIN=$(rustup show | grep -A 3 active | tail -1 | sed "s/ (default)//")
 RUST_HOST=$(rustup show | grep "Default host" | sed "s/Default host: //")
 
@@ -12,8 +15,6 @@ else
     EXT=.tar.gz
     EXTRACT="tar xzf"
 fi
-
-rustup which cargo
 
 function build() {
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -32,7 +32,7 @@ ${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
 ${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
 ${EXTRACT} SDL2_mixer-*${EXT} && rm SDL2_mixer-*${EXT}
 ${EXTRACT} SDL2_gfx-*${EXT} && rm SDL2_gfx-*${EXT}
-pushd SDL2_ttf-* && build && popd
+# pushd SDL2_ttf-* && build && popd
 pushd SDL2_image-* && build && popd
 pushd SDL2_mixer-* && build && popd
 pushd SDL2_gfx-* && ./autogen.sh && build && popd

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -37,9 +37,9 @@ function build() {
             export LIB=${PREFIX}/lib
             export UseEnv=true
             # this is perhaps the worst thing i have ever done in my life
-            for WINSDK in $(seq 1 20000); do
+            for WINSDK in $(seq 744 20000); do
                 WINSDK=10.0.${WINSDK}.0
-                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
+                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -t:SDL -p:Configuration=Release -p:Platform=x64 \
                     -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
             done
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -38,7 +38,8 @@ function build() {
             LD_LIBRARY_PATH=${PREFIX}/lib
             CONFIG_SHELL="/C/Program\\ Files/Git/usr/bin/sh"
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            mingw32-make V=1
+            cat Makefile
+            mingw32-make
             mingw32-make install || return 1
         else
             cd VisualC
@@ -47,13 +48,10 @@ function build() {
             export UseEnv=true
             cmd <<EOF
 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
-msbuild SDL\\SDL.vcxproj -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
+msbuild $2 -p:Configuration=Release -p:Platform=x64 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK}
 EOF
             echo
             ls *
-            ls SDL
-            ls SDL/x64
-            ls SDL/x64/Release
             cp SDL/x64/Release/*.lib SDL/x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else
@@ -66,7 +64,7 @@ EOF
 
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
-build SDL2-* || exit 1
+build SDL2-* SDL\\SDL.vcxproj || exit 1
 if [[ "$CI_BUILD_FEATURES" == *"ttfBROKEN"* ]]; then
     wget -q https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14${EXT}
     ${EXTRACT} SDL2_ttf-*${EXT} && rm SDL2_ttf-*${EXT}
@@ -75,7 +73,7 @@ fi
 if [[ "$CI_BUILD_FEATURES" == *"image"* ]]; then
     wget -q https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1${EXT}
     ${EXTRACT} SDL2_image-*${EXT} && rm SDL2_image-*${EXT}
-    build SDL2_image-*
+    build SDL2_image-* SDL_image.vcxproj
 fi
 if [[ "$CI_BUILD_FEATURES" == *"mixer"* ]]; then
     wget -q https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2${EXT}

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -34,9 +34,9 @@ function build() {
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
+            export UseEnv=true
             "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
-                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} -p:IncludePath='../../SDL2-2.0.9/include;$(IncludePath)' \
-                 || return 1
+                -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} || return 1
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -4,7 +4,9 @@ set -xueo pipefail
 
 wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz -O sdl2.tar.gz
 tar xzf sdl2.tar.gz
-pushd SDL2-* && ./configure && make && sudo make install && popd
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then CONFIG_BUILD="--build=x86_64-mingw32"; else CONFIG_BUILD=; fi
+pushd SDL2-* && ./configure ${CONFIG_BUILD} && make && sudo make install && popd
+exit
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT=unzip

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     EXT=.zip
     EXTRACT="unzip -q"
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
-    WINSDK=$(cmd <<<"reg query \"HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0\" /v ProductVersion" | grep REG_SZ | awk '{ print $3 }').0
+    WINSDKS=$(ls "/C/Program Files (x86)/Windows Kits/10/Lib")
     TOOLSET=$(grep -m 1 "PlatformToolset" "/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/VC/VCWizards/default.vcxproj" | sed "s/    <PlatformToolset>//" | sed "s!</PlatformToolset>!!")
     export PATH=$PATH:/C/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:${PREFIX}/bin
 else
@@ -19,21 +19,27 @@ else
     EXTRACT="tar xzf"
 fi
 
+function nuke_bin_in_path() {
+    echo $PATH | tr ":" "\n" | grep -v /usr/bin | tr "\n" ":"
+}
+
 function build() {
     pushd $1
     if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
         if [[ "$TRAVIS_RUST_VERSION" == *"-gnu" ]]; then
             LD_LIBRARY_PATH=${PREFIX}/lib
             ./configure --build=x86_64-mingw32 --prefix=${PREFIX} || return 1
-            cmd <<< "mingw32-make V=1"
+            PATH=$(nuke_bin_in_path) cmd <<< "mingw32-make V=1"
             mingw32-make install || return 1
         else
             cd VisualC
             export INCLUDE=../../SDL-2.0.9/include
             export LIB=${PREFIX}/lib
             export UseEnv=true
-            "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
+            for WINSDK in ${WINSDKS}; do
+                "${MSBUILD}" $(ls *.sln | grep -v "SDL_image_VS2008.sln") -p:Configuration=Release -p:Platform=x64 \
                 -p:PlatformToolset=${TOOLSET} -p:WindowsTargetPlatformVersion=${WINSDK} && break
+            done
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/ || return 1
         fi
     else

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -5,11 +5,11 @@ set -xueo pipefail
 RUST_HOST=$(rustup show | grep -F "Default host" | sed "s/Default host: //")
 RUST_TOOLCHAIN=$(rustup show | grep -F "(default)" | sed "s/ (default)//")
 
-MSBUILD='"/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe"'
+MSBUILD='/C/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe'
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ls -l ${MSBUILD}
-    ${MSBUILD} /help
+    ls -l "${MSBUILD}"
+    "${MSBUILD}" /help
     EXT=.zip
     EXTRACT=unzip
     PREFIX=/C/Users/travis/.rustup/toolchains/${RUST_TOOLCHAIN}/lib/rustlib/${RUST_HOST}/
@@ -29,7 +29,7 @@ function build() {
             mingw32-make install SHELL=/C/Program\ Files/Git/usr/bin/sh || return 1
         else
             cd VisualC
-            ${MSBUILD} /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
+            "${MSBUILD}" /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=10.0.17763.0
             cp x64/Release/*.lib x64/Release/*.dll ${PREFIX}/lib/
         fi
     else


### PR DESCRIPTION
in the interest of getting #800 resolved, this installs pip manually on windows in travis and also adjusts a Travis setting to work around [a known issue](https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264).

this fixes the travis configuration to not error out immediately on windows, but non-bundled configs still break on travis on windows because `scripts/travis-install-sdl2.sh` is trying to expand tarballs with symlinks. i'm not entirely sure what the best way to fix that is