### PR TITLE
Use ::std instead of just std in rect.rs

### DIFF
--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -70,8 +70,8 @@ pub struct Rect {
     raw: sys::SDL_Rect,
 }
 
-impl std::fmt::Debug for Rect {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+impl ::std::fmt::Debug for Rect {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         return write!(fmt, "Rect {{ x: {}, y: {}, w: {}, h: {} }}",
             self.raw.x, self.raw.y, self.raw.w, self.raw.h);
     }
@@ -665,8 +665,8 @@ pub struct Point {
     raw: sys::SDL_Point
 }
 
-impl std::fmt::Debug for Point {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+impl ::std::fmt::Debug for Point {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         return write!(fmt, "Point {{ x: {}, y: {} }}", self.raw.x, self.raw.y);
     }
 }


### PR DESCRIPTION
Without this, newer rustc versions complain with the error:

> access to extern crates through prelude is experimental (see issue #44660)

Other files in this repository also use the absolute name of entities from `std`, so I imagine this was just an oversight.