### PR TITLE
Homebrew packages are called libSDL2main and libSDL2

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -309,8 +309,16 @@ fn link_sdl2(target_os: &str) {
 
     #[cfg(feature = "static-link")] {
         if cfg!(feature = "bundled") || cfg!(feature = "use-pkgconfig") == false { 
-            println!("cargo:rustc-link-lib=static=SDL2main");
-            println!("cargo:rustc-link-lib=static=SDL2");
+            if target_os == "darwin" {
+                println!("cargo:rustc-link-lib=static=libSDL2main");
+                println!("cargo:rustc-link-lib=static=libSDL2");
+            }
+            else {
+                println!("cargo:rustc-link-lib=static=SDL2main");
+                println!("cargo:rustc-link-lib=static=SDL2");        
+            }
+
+            
         }
 
         // Also linked to any required libraries for each supported platform


### PR DESCRIPTION
It can't find `SDL2main` or `SDL2` when trying to statically link with homebrew libs.