### PR TITLE
Update minimum SDL2 version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We currently target the latest stable release of Rust.
 
 ## *SDL2.0 development libraries*
 
-SDL2 >= 2.0.8 is recommended to use these bindings, but note that SDL2 >= 2.0.4 is also supported. Below 2.0.4, you may experience link-time errors as some functions are used here but are not defined in SDL2. If you experience this issue because you are on a LTS machine (for instance, Ubuntu 12.04 or Ubuntu 14.04), we definitely recommend you to use the feature "bundled" which will compile the lastest stable version of SDL2 for your project.
+SDL2 >= 2.0.8 is recommended to use these bindings, but note that SDL2 >= 2.0.5 is also supported. Below 2.0.5, you may experience link-time errors as some functions are used here but are not defined in SDL2. If you experience this issue because you are on a LTS machine (for instance, Ubuntu 12.04 or Ubuntu 14.04), we definitely recommend you to use the feature "bundled" which will compile the lastest stable version of SDL2 for your project.
 
 ### "Bundled" Feature
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ Added 32-bit array pixelformats
 [PR #824](https://github.com/Rust-SDL2/rust-sdl2/pull/824):
 Added `controller::set_rumble` and `joystick::set_rumble`, wrappers for `SDL_GameControllerRumble` and `SDL_JoystickRumble` respectively.
 
+[PR #867](https://github.com/Rust-SDL2/rust-sdl2/pull/867):
+Added `Window::opacity` and `Window::set_opacity`, wrappers for `SDL_GetWindowOpacity` and `SDL_SetWindowOpacity` respectively. This bumps the minimum `SDL2` version requirement from `2.0.4` to `2.0.5`.
+
 ### v0.32
 
 [PR #790](https://github.com/Rust-SDL2/rust-sdl2/pull/790): Added missing `window_id` field to `Event::DropFile`


### PR DESCRIPTION
As of #867, this create no longer builds with `libsdl v2.0.4`.

> *This function is available since SDL 2.0.5.*
> https://wiki.libsdl.org/SDL_GetWindowOpacity

(I didn't realize at the time :sweat_smile:  I updated the README to reflect it)