### PR TITLE
Fix obsolete bitflags_rs absolute paths workaround

### DIFF
--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -14,7 +14,6 @@ use ::get_error;
 use ::pixels::Color;
 use ::rwops::RWops;
 
-// Absolute paths are a workaround for https://github.com/rust-lang-nursery/bitflags/issues/39 .
 bitflags! {
     /// The styling of a font.
     pub struct FontStyle: i32 {

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use ::surface::Surface;
 use sys;
+use sys::ttf;
 use sys::SDL_Surface;
 use ::get_error;
 use ::pixels::Color;
@@ -17,11 +18,11 @@ use ::rwops::RWops;
 bitflags! {
     /// The styling of a font.
     pub struct FontStyle: i32 {
-        const NORMAL        = sys::ttf::TTF_STYLE_NORMAL as i32;
-        const BOLD          = sys::ttf::TTF_STYLE_BOLD as i32;
-        const ITALIC        = sys::ttf::TTF_STYLE_ITALIC as i32;
-        const UNDERLINE     = sys::ttf::TTF_STYLE_UNDERLINE as i32;
-        const STRIKETHROUGH = sys::ttf::TTF_STYLE_STRIKETHROUGH as i32;
+        const NORMAL        = ttf::TTF_STYLE_NORMAL as i32;
+        const BOLD          = ttf::TTF_STYLE_BOLD as i32;
+        const ITALIC        = ttf::TTF_STYLE_ITALIC as i32;
+        const UNDERLINE     = ttf::TTF_STYLE_UNDERLINE as i32;
+        const STRIKETHROUGH = ttf::TTF_STYLE_STRIKETHROUGH as i32;
     }
 }
 
@@ -30,10 +31,10 @@ bitflags! {
 #[repr(i32)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Hinting {
-    Normal = sys::ttf::TTF_HINTING_NORMAL as i32,
-    Light  = sys::ttf::TTF_HINTING_LIGHT  as i32,
-    Mono   = sys::ttf::TTF_HINTING_MONO   as i32,
-    None   = sys::ttf::TTF_HINTING_NONE   as i32,
+    Normal = ttf::TTF_HINTING_NORMAL as i32,
+    Light  = ttf::TTF_HINTING_LIGHT  as i32,
+    Mono   = ttf::TTF_HINTING_MONO   as i32,
+    None   = ttf::TTF_HINTING_NONE   as i32,
 }
 
 /// Information about a specific glyph (character) in a font face.
@@ -155,11 +156,11 @@ impl<'f,'text> PartialRendering<'f,'text> {
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
-                    sys::ttf::TTF_RenderUTF8_Solid(self.font.raw(),
+                    ttf::TTF_RenderUTF8_Solid(self.font.raw(),
                         source.as_ptr(), color)
                 },
                 RenderableText::Latin1(_) => {
-                    sys::ttf::TTF_RenderText_Solid(self.font.raw(),
+                    ttf::TTF_RenderText_Solid(self.font.raw(),
                         source.as_ptr(), color)
                 },
             }
@@ -178,11 +179,11 @@ impl<'f,'text> PartialRendering<'f,'text> {
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
-                    sys::ttf::TTF_RenderUTF8_Shaded(self.font.raw(),
+                    ttf::TTF_RenderUTF8_Shaded(self.font.raw(),
                         source.as_ptr(), foreground, background)
                 },
                 RenderableText::Latin1(_) => {
-                    sys::ttf::TTF_RenderText_Shaded(self.font.raw(),
+                    ttf::TTF_RenderText_Shaded(self.font.raw(),
                         source.as_ptr(), foreground, background)
                 },
             }
@@ -200,11 +201,11 @@ impl<'f,'text> PartialRendering<'f,'text> {
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
-                    sys::ttf::TTF_RenderUTF8_Blended(self.font.raw(),
+                    ttf::TTF_RenderUTF8_Blended(self.font.raw(),
                         source.as_ptr(), color)
                 },
                 RenderableText::Latin1(_) => {
-                    sys::ttf::TTF_RenderText_Blended(self.font.raw(),
+                    ttf::TTF_RenderText_Blended(self.font.raw(),
                         source.as_ptr(), color)
                 },
             }
@@ -223,11 +224,11 @@ impl<'f,'text> PartialRendering<'f,'text> {
         let raw = unsafe {
             match self.text {
                 RenderableText::Utf8(_) | RenderableText::Char(_) => {
-                    sys::ttf::TTF_RenderUTF8_Blended_Wrapped(self.font.raw(),
+                    ttf::TTF_RenderUTF8_Blended_Wrapped(self.font.raw(),
                         source.as_ptr(), color, wrap_max_width)
                 },
                 RenderableText::Latin1(_) => {
-                    sys::ttf::TTF_RenderText_Blended_Wrapped(self.font.raw(),
+                    ttf::TTF_RenderText_Blended_Wrapped(self.font.raw(),
                         source.as_ptr(), color, wrap_max_width)
                 },
             }
@@ -238,7 +239,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
 
 /// A loaded TTF font.
 pub struct Font<'ttf_module,'rwops> {
-    raw: *mut sys::ttf::TTF_Font,
+    raw: *mut ttf::TTF_Font,
     // RWops is only stored here because it must not outlive
     // the Font struct, and this RWops should not be used by
     // anything else
@@ -257,8 +258,8 @@ impl<'ttf,'r> Drop for Font<'ttf,'r> {
     fn drop(&mut self) {
         unsafe {
             // avoid close font after quit()
-            if sys::ttf::TTF_WasInit() == 1 {
-                sys::ttf::TTF_CloseFont(self.raw);
+            if ttf::TTF_WasInit() == 1 {
+                ttf::TTF_CloseFont(self.raw);
             }
         }
     }
@@ -268,7 +269,7 @@ impl<'ttf,'r> Drop for Font<'ttf,'r> {
 pub fn internal_load_font<'ttf,P:AsRef<Path>>(path: P, ptsize: u16) -> Result<Font<'ttf,'static>, String> {
     unsafe {
         let cstring = CString::new(path.as_ref().to_str().unwrap()).unwrap();
-        let raw = sys::ttf::TTF_OpenFont(cstring.as_ptr(), ptsize as c_int);
+        let raw = ttf::TTF_OpenFont(cstring.as_ptr(), ptsize as c_int);
         if raw.is_null() {
             Err(get_error())
         } else {
@@ -278,7 +279,7 @@ pub fn internal_load_font<'ttf,P:AsRef<Path>>(path: P, ptsize: u16) -> Result<Fo
 }
 
 /// Internally used to load a font (for internal visibility).
-pub fn internal_load_font_from_ll<'ttf,'r, R>(raw: *mut sys::ttf::TTF_Font, rwops: R)
+pub fn internal_load_font_from_ll<'ttf,'r, R>(raw: *mut ttf::TTF_Font, rwops: R)
         -> Font<'ttf,'r>
 where R: Into<Option<RWops<'r>>> {
     Font { raw: raw, rwops: rwops.into(), _marker: PhantomData }
@@ -290,7 +291,7 @@ pub fn internal_load_font_at_index<'ttf,P: AsRef<Path>>(path: P, index: u32, pts
     unsafe {
         let cstring = CString::new(path.as_ref().to_str().unwrap().as_bytes())
             .unwrap();
-        let raw = sys::ttf::TTF_OpenFontIndex(cstring.as_ptr(),
+        let raw = ttf::TTF_OpenFontIndex(cstring.as_ptr(),
             ptsize as c_int, index as c_long);
         if raw.is_null() {
             Err(get_error())
@@ -302,7 +303,7 @@ pub fn internal_load_font_at_index<'ttf,P: AsRef<Path>>(path: P, index: u32, pts
 
 impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the underlying C font object.
-    unsafe fn raw(&self) -> *mut sys::ttf::TTF_Font {
+    unsafe fn raw(&self) -> *mut ttf::TTF_Font {
         self.raw
     }
 
@@ -339,7 +340,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
         let (res, size) = unsafe {
             let mut w = 0; // mutated by C code
             let mut h = 0; // mutated by C code
-            let ret = sys::ttf::TTF_SizeUTF8(self.raw, c_string.as_ptr(), &mut w, &mut h);
+            let ret = ttf::TTF_SizeUTF8(self.raw, c_string.as_ptr(), &mut w, &mut h);
             (ret, (w as u32, h as u32))
         };
         if res == 0 {
@@ -358,7 +359,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
         let (res, size) = unsafe {
             let mut w : i32 = 0; // mutated by C code
             let mut h : i32 = 0; // mutated by C code
-            let ret = sys::ttf::TTF_SizeText(self.raw, c_string.as_ptr(), &w as *const _ as *mut i32, &h as *const _ as *mut i32);
+            let ret = ttf::TTF_SizeText(self.raw, c_string.as_ptr(), &w as *const _ as *mut i32, &h as *const _ as *mut i32);
             (ret, (w as u32, h as u32))
         };
         if res == 0 {
@@ -379,7 +380,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the font's style flags.
     pub fn get_style(&self) -> FontStyle {
         unsafe {
-            let raw = sys::ttf::TTF_GetFontStyle(self.raw);
+            let raw = ttf::TTF_GetFontStyle(self.raw);
             FontStyle::from_bits_truncate(raw as i32)
         }
     }
@@ -387,32 +388,32 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Sets the font's style flags.
     pub fn set_style(&mut self, styles: FontStyle) {
         unsafe {
-            sys::ttf::TTF_SetFontStyle(self.raw, styles.bits() as c_int)
+            ttf::TTF_SetFontStyle(self.raw, styles.bits() as c_int)
         }
     }
 
     /// Returns the width of the font's outline.
     pub fn get_outline_width(&self) -> u16 {
         unsafe {
-            sys::ttf::TTF_GetFontOutline(self.raw) as u16
+            ttf::TTF_GetFontOutline(self.raw) as u16
         }
     }
 
     /// Sets the width of the font's outline.
     pub fn set_outline_width(&mut self, width: u16) {
         unsafe {
-            sys::ttf::TTF_SetFontOutline(self.raw, width as c_int)
+            ttf::TTF_SetFontOutline(self.raw, width as c_int)
         }
     }
 
     /// Returns the font's freetype hints.
     pub fn get_hinting(&self) -> Hinting {
         unsafe {
-            match sys::ttf::TTF_GetFontHinting(self.raw) as c_uint {
-                sys::ttf::TTF_HINTING_NORMAL   => Hinting::Normal,
-                sys::ttf::TTF_HINTING_LIGHT    => Hinting::Light,
-                sys::ttf::TTF_HINTING_MONO     => Hinting::Mono,
-                sys::ttf::TTF_HINTING_NONE | _ => Hinting::None
+            match ttf::TTF_GetFontHinting(self.raw) as c_uint {
+                ttf::TTF_HINTING_NORMAL   => Hinting::Normal,
+                ttf::TTF_HINTING_LIGHT    => Hinting::Light,
+                ttf::TTF_HINTING_MONO     => Hinting::Mono,
+                ttf::TTF_HINTING_NONE | _ => Hinting::None
             }
         }
     }
@@ -420,35 +421,35 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Sets the font's freetype hints.
     pub fn set_hinting(&mut self, hinting: Hinting) {
         unsafe {
-            sys::ttf::TTF_SetFontHinting(self.raw, hinting as c_int)
+            ttf::TTF_SetFontHinting(self.raw, hinting as c_int)
         }
     }
 
     /// Returns whether the font is kerning.
     pub fn get_kerning(&self) -> bool {
         unsafe {
-            sys::ttf::TTF_GetFontKerning(self.raw) != 0
+            ttf::TTF_GetFontKerning(self.raw) != 0
         }
     }
 
     /// Sets whether the font should use kerning.
     pub fn set_kerning(&mut self, kerning: bool) {
         unsafe {
-            sys::ttf::TTF_SetFontKerning(self.raw, kerning as c_int)
+            ttf::TTF_SetFontKerning(self.raw, kerning as c_int)
         }
     }
 
     pub fn height(&self) -> i32 {
         //! Get font maximum total height.
         unsafe {
-            sys::ttf::TTF_FontHeight(self.raw) as i32
+            ttf::TTF_FontHeight(self.raw) as i32
         }
     }
 
     /// Returns the font's highest ascent (height above base).
     pub fn ascent(&self) -> i32 {
         unsafe {
-            sys::ttf::TTF_FontAscent(self.raw) as i32
+            ttf::TTF_FontAscent(self.raw) as i32
         }
     }
 
@@ -456,28 +457,28 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// This is a negative number.
     pub fn descent(&self) -> i32 {
         unsafe {
-            sys::ttf::TTF_FontDescent(self.raw) as i32
+            ttf::TTF_FontDescent(self.raw) as i32
         }
     }
 
     /// Returns the recommended line spacing for text rendered with this font.
     pub fn recommended_line_spacing(&self) -> i32 {
         unsafe {
-            sys::ttf::TTF_FontLineSkip(self.raw) as i32
+            ttf::TTF_FontLineSkip(self.raw) as i32
         }
     }
 
     /// Returns the number of faces in this font.
     pub fn face_count(&self) -> u16 {
         unsafe {
-            sys::ttf::TTF_FontFaces(self.raw) as u16
+            ttf::TTF_FontFaces(self.raw) as u16
         }
     }
 
     /// Returns whether the font is monospaced.
     pub fn face_is_fixed_width(&self) -> bool {
         unsafe {
-            sys::ttf::TTF_FontFaceIsFixedWidth(self.raw) != 0
+            ttf::TTF_FontFaceIsFixedWidth(self.raw) != 0
         }
     }
 
@@ -485,7 +486,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     pub fn face_family_name(&self) -> Option<String> {
         unsafe {
             // not owns buffer
-            let cname = sys::ttf::TTF_FontFaceFamilyName(self.raw);
+            let cname = ttf::TTF_FontFaceFamilyName(self.raw);
             if cname.is_null() {
                 None
             } else {
@@ -497,7 +498,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the name of the current font face.
     pub fn face_style_name(&self) -> Option<String> {
         unsafe {
-            let cname = sys::ttf::TTF_FontFaceStyleName(self.raw);
+            let cname = ttf::TTF_FontFaceStyleName(self.raw);
             if cname.is_null() {
                 None
             } else {
@@ -509,7 +510,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the index of the given character in this font face.
     pub fn find_glyph(&self, ch: char) -> Option<u16> {
         unsafe {
-            let ret = sys::ttf::TTF_GlyphIsProvided(self.raw, ch as u16);
+            let ret = ttf::TTF_GlyphIsProvided(self.raw, ch as u16);
             if ret == 0 {
                 None
             } else {
@@ -526,7 +527,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
         let maxy = 0;
         let advance = 0;
         let ret = unsafe {
-            sys::ttf::TTF_GlyphMetrics(
+            ttf::TTF_GlyphMetrics(
                 self.raw,
                 ch as u16,
                 &minx as *const _ as *mut _,


### PR DESCRIPTION
The namespacing workaround required for `bitflags!` is no longer required as per https://github.com/bitflags/bitflags/issues/39. Resolves #880 