### PR TITLE
Remove redundant field names

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -302,8 +302,8 @@ impl AudioSpecWAV {
                     freq: desired.freq,
                     format: AudioFormat::from_ll(desired.format).unwrap(),
                     channels: desired.channels,
-                    audio_buf: audio_buf,
-                    audio_len: audio_len
+                    audio_buf,
+                    audio_len
                 })
             }
         }
@@ -544,9 +544,9 @@ impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
 
                     Ok(AudioQueue {
                         subsystem: a.clone(),
-                        device_id: device_id,
+                        device_id,
                         phantom: PhantomData::default(),
-                        spec: spec,
+                        spec,
                     })
                 }
             }
@@ -637,9 +637,9 @@ impl<CB: AudioCallback> AudioDevice<CB> {
 
                     Ok(AudioDevice {
                         subsystem: a.clone(),
-                        device_id: device_id,
-                        userdata: userdata,
-                        spec: spec,
+                        device_id,
+                        userdata,
+                        spec,
                     })
                 }
             }
@@ -748,7 +748,7 @@ impl AudioCVT {
                                             src_format.to_ll(), src_channels, src_rate as c_int,
                                             dst_format.to_ll(), dst_channels, dst_rate as c_int);
             if ret == 1 || ret == 0 {
-                Ok(AudioCVT { raw: raw })
+                Ok(AudioCVT { raw })
             } else {
                 Err(get_error())
             }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -736,7 +736,7 @@ where S: Into<Option<Scancode>>,
         .unwrap_or(sys::SDLK_UNKNOWN as i32);
     let keymod = keymod.bits() as u16;
     sys::SDL_Keysym {
-        scancode: scancode,
+        scancode,
         sym: keycode,
         mod_: keymod,
         unused: 0,
@@ -753,11 +753,11 @@ impl Event {
             Event::User { window_id, type_, code, data1, data2, timestamp} => {
                 let event = sys::SDL_UserEvent {
                     type_: type_ as uint32_t,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
                     code: code as i32,
-                    data1: data1,
-                    data2: data2
+                    data1,
+                    data2
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_UserEvent, 1);
@@ -768,7 +768,7 @@ impl Event {
             Event::Quit{timestamp} => {
                 let event = sys::SDL_QuitEvent {
                     type_: SDL_EventType::SDL_QUIT as u32,
-                    timestamp: timestamp,
+                    timestamp,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_QuitEvent, 1);
@@ -784,14 +784,14 @@ impl Event {
                 let (win_event_id, data1, data2) = win_event.to_ll();
                 let event = sys::SDL_WindowEvent {
                     type_: SDL_EventType::SDL_WINDOWEVENT as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
                     event: win_event_id,
                     padding1: 0,
                     padding2: 0,
                     padding3: 0,
-                    data1: data1,
-                    data2: data2,
+                    data1,
+                    data2,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_WindowEvent, 1);
@@ -810,13 +810,13 @@ impl Event {
                 let keysym = mk_keysym(scancode, keycode, keymod);
                 let event = sys::SDL_KeyboardEvent{
                     type_: SDL_EventType::SDL_KEYDOWN as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
                     state: sys::SDL_PRESSED as u8,
                     repeat: repeat as u8,
                     padding2: 0,
                     padding3: 0,
-                    keysym: keysym,
+                    keysym,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_KeyboardEvent, 1);
@@ -834,13 +834,13 @@ impl Event {
                 let keysym = mk_keysym(scancode, keycode, keymod);
                 let event = sys::SDL_KeyboardEvent{
                     type_: SDL_EventType::SDL_KEYUP as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
                     state: sys::SDL_RELEASED as u8,
                     repeat: repeat as u8,
                     padding2: 0,
                     padding3: 0,
-                    keysym: keysym,
+                    keysym,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_KeyboardEvent, 1);
@@ -860,14 +860,14 @@ impl Event {
                 let state = mousestate.to_sdl_state();
                 let event = sys::SDL_MouseMotionEvent {
                     type_: SDL_EventType::SDL_MOUSEMOTION as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
-                    which: which,
-                    state: state,
-                    x: x,
-                    y: y,
-                    xrel: xrel,
-                    yrel: yrel,
+                    which,
+                    state,
+                    x,
+                    y,
+                    xrel,
+                    yrel,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseMotionEvent, 1);
@@ -886,15 +886,15 @@ impl Event {
             } => {
                 let event = sys::SDL_MouseButtonEvent {
                     type_: SDL_EventType::SDL_MOUSEBUTTONDOWN as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
-                    which: which,
+                    which,
                     button: mouse_btn as u8,
                     state: sys::SDL_PRESSED as u8,
-                    clicks: clicks,
+                    clicks,
                     padding1: 0,
-                    x: x,
-                    y: y
+                    x,
+                    y
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseButtonEvent, 1);
@@ -912,15 +912,15 @@ impl Event {
             } => {
                 let event = sys::SDL_MouseButtonEvent {
                     type_: SDL_EventType::SDL_MOUSEBUTTONUP as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
-                    which: which,
+                    which,
                     button: mouse_btn as u8,
                     state: sys::SDL_RELEASED as u8,
-                    clicks: clicks,
+                    clicks,
                     padding1: 0,
-                    x: x,
-                    y: y
+                    x,
+                    y
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseButtonEvent, 1);
@@ -938,11 +938,11 @@ impl Event {
             } => {
                 let event = sys::SDL_MouseWheelEvent {
                     type_: SDL_EventType::SDL_MOUSEWHEEL as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     windowID: window_id,
-                    which: which,
-                    x: x,
-                    y: y,
+                    which,
+                    x,
+                    y,
                     direction : direction.to_ll(),
                 };
                 unsafe {
@@ -958,10 +958,10 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyAxisEvent {
                     type_: SDL_EventType::SDL_JOYAXISMOTION as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     axis: axis_idx,
-                    value: value,
+                    value,
                     padding1: 0,
                     padding2: 0,
                     padding3: 0,
@@ -982,11 +982,11 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyBallEvent {
                     type_: SDL_EventType::SDL_JOYBALLMOTION as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     ball: ball_idx,
-                    xrel: xrel,
-                    yrel: yrel,
+                    xrel,
+                    yrel,
                     padding1: 0,
                     padding2: 0,
                     padding3: 0
@@ -1006,8 +1006,8 @@ impl Event {
                 let hatvalue = state.to_raw();
                 let event = sys::SDL_JoyHatEvent {
                     type_: SDL_EventType::SDL_JOYHATMOTION as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     hat: hat_idx,
                     value: hatvalue,
                     padding1: 0,
@@ -1026,8 +1026,8 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyButtonEvent {
                     type_: SDL_EventType::SDL_JOYBUTTONDOWN as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     button: button_idx,
                     state: sys::SDL_PRESSED as u8,
                     padding1: 0,
@@ -1047,8 +1047,8 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyButtonEvent {
                     type_: SDL_EventType::SDL_JOYBUTTONUP as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     button: button_idx,
                     state: sys::SDL_RELEASED as u8,
                     padding1: 0,
@@ -1067,7 +1067,7 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyDeviceEvent {
                     type_: SDL_EventType::SDL_JOYDEVICEADDED as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     which: which as i32,
                 };
                 unsafe {
@@ -1082,8 +1082,8 @@ impl Event {
             } => {
                 let event = sys::SDL_JoyDeviceEvent {
                     type_: SDL_EventType::SDL_JOYDEVICEREMOVED as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyDeviceEvent, 1);
@@ -1100,10 +1100,10 @@ impl Event {
                 let axisval = axis.to_ll();
                 let event = sys::SDL_ControllerAxisEvent {
                     type_: SDL_EventType::SDL_CONTROLLERAXISMOTION as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     axis: axisval as u8,
-                    value: value,
+                    value,
                     padding1: 0,
                     padding2: 0,
                     padding3: 0,
@@ -1122,8 +1122,8 @@ impl Event {
                 let buttonval = button.to_ll();
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONDOWN as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     // This conversion turns an i32 into a u8; signed-to-unsigned conversions
                     // are a bit of a code smell, but that appears to be how SDL defines it.
                     button: buttonval as u8,
@@ -1145,8 +1145,8 @@ impl Event {
                 let buttonval = button.to_ll();
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONUP as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                     button: buttonval as u8,
                     state: sys::SDL_RELEASED as u8,
                     padding1: 0,
@@ -1164,7 +1164,7 @@ impl Event {
             } => {
                 let event = sys::SDL_ControllerDeviceEvent {
                     type_: SDL_EventType::SDL_CONTROLLERDEVICEADDED as u32,
-                    timestamp: timestamp,
+                    timestamp,
                     which: which as i32,
                 };
                 unsafe {
@@ -1180,8 +1180,8 @@ impl Event {
             } => {
                 let event = sys::SDL_ControllerDeviceEvent {
                     type_: SDL_EventType::SDL_CONTROLLERDEVICEREMOVED as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerDeviceEvent, 1);
@@ -1196,8 +1196,8 @@ impl Event {
             } => {
                 let event = sys::SDL_ControllerDeviceEvent {
                     type_: SDL_EventType::SDL_CONTROLLERDEVICEREMAPPED as u32,
-                    timestamp: timestamp,
-                    which: which,
+                    timestamp,
+                    which,
                 };
                 unsafe {
                     ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerDeviceEvent, 1);
@@ -1307,7 +1307,7 @@ impl Event {
                 Event::TextEditing {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    text: text,
+                    text,
                     start: event.start,
                     length: event.length
                 }
@@ -1324,7 +1324,7 @@ impl Event {
                 Event::TextInput {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    text: text
+                    text
                 }
             }
 
@@ -1447,7 +1447,7 @@ impl Event {
                 Event::ControllerAxisMotion {
                     timestamp: event.timestamp,
                     which: event.which,
-                    axis: axis,
+                    axis,
                     value: event.value
                 }
             }
@@ -1458,7 +1458,7 @@ impl Event {
                 Event::ControllerButtonDown {
                     timestamp: event.timestamp,
                     which: event.which,
-                    button: button
+                    button
                 }
             }
             EventType::ControllerButtonUp => {
@@ -1468,7 +1468,7 @@ impl Event {
                 Event::ControllerButtonUp {
                     timestamp: event.timestamp,
                     which: event.which,
-                    button: button
+                    button
                 }
             }
             EventType::ControllerDeviceAdded => {
@@ -1766,7 +1766,7 @@ impl crate::EventPump {
     pub fn wait_timeout_iter(&mut self, timeout: u32) -> EventWaitTimeoutIterator {
         EventWaitTimeoutIterator {
             _marker: PhantomData,
-            timeout: timeout
+            timeout
         }
     }
 

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -62,7 +62,7 @@ impl JoystickSubsystem {
 
         let raw = unsafe { sys::SDL_JoystickGetDeviceGUID(joystick_index) };
 
-        let guid = Guid { raw: raw };
+        let guid = Guid { raw };
 
         if guid.is_zero() {
             Err(SdlError(get_error()))
@@ -167,7 +167,7 @@ impl Joystick {
     pub fn guid(&self) -> Guid {
         let raw = unsafe { sys::SDL_JoystickGetGUID(self.raw) };
 
-        let guid = Guid { raw: raw };
+        let guid = Guid { raw };
 
         if guid.is_zero() {
             // Should only fail if the joystick is NULL.
@@ -408,7 +408,7 @@ impl Guid {
 
         let raw = unsafe { sys::SDL_JoystickGetGUIDFromString(guid.as_ptr() as *const c_char) };
 
-        Ok(Guid { raw: raw })
+        Ok(Guid { raw })
     }
 
     /// Return `true` if GUID is full 0s

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -50,7 +50,7 @@ impl<'a> KeyboardState<'a> {
         };
 
         KeyboardState {
-            keyboard_state: keyboard_state
+            keyboard_state
         }
     }
 

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -49,7 +49,7 @@ impl Cursor {
             if raw.is_null() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw })
+                Ok(Cursor{ raw })
             }
         }
     }
@@ -62,7 +62,7 @@ impl Cursor {
             if raw.is_null() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw })
+                Ok(Cursor{ raw })
             }
         }
     }
@@ -74,7 +74,7 @@ impl Cursor {
             if raw.is_null() {
                 Err(get_error())
             } else {
-                Ok(Cursor{ raw: raw })
+                Ok(Cursor{ raw })
             }
         }
     }
@@ -168,7 +168,7 @@ impl MouseState {
         };
 
         MouseState {
-            mouse_state: mouse_state,
+            mouse_state,
             x: x as i32,
             y: y as i32
         }

--- a/src/sdl2/mouse/relative.rs
+++ b/src/sdl2/mouse/relative.rs
@@ -21,7 +21,7 @@ impl RelativeMouseState {
         };
 
         RelativeMouseState {
-            mouse_state: mouse_state,
+            mouse_state,
             x: x as i32,
             y: y as i32
         }

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -38,7 +38,7 @@ impl Palette {
             Err(get_error())
         } else {
             Ok(Palette {
-                raw: raw,
+                raw,
             })
         }
     }
@@ -107,13 +107,13 @@ impl Color {
     #[inline]
     #[allow(non_snake_case)]
     pub fn RGB(r: u8, g: u8, b: u8) -> Color {
-        Color { r: r, g: g, b: b, a: 0xff }
+        Color { r, g, b, a: 0xff }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     pub fn RGBA(r: u8, g: u8, b: u8, a: u8) -> Color {
-        Color { r: r, g: g, b: b, a: a }
+        Color { r, g, b, a }
     }
 
     pub fn to_u32(&self, format: &PixelFormat) -> u32 {
@@ -283,10 +283,10 @@ impl PixelFormatEnum {
         } else {
             Ok(PixelMasks {
                 bpp: bpp as u8,
-                rmask: rmask,
-                gmask: gmask,
-                bmask: bmask,
-                amask: amask
+                rmask,
+                gmask,
+                bmask,
+                amask
             })
         }
     }

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -115,7 +115,7 @@ impl Rect {
             w: clamp_size(width) as i32,
             h: clamp_size(height) as i32,
         };
-        Rect { raw: raw }
+        Rect { raw }
     }
 
     /// Creates a new rectangle centered on the given position.
@@ -136,7 +136,7 @@ impl Rect {
             w: clamp_size(width) as i32,
             h: clamp_size(height) as i32,
         };
-        let mut rect = Rect { raw: raw };
+        let mut rect = Rect { raw };
         rect.center_on(center.into());
         rect
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -181,9 +181,9 @@ impl RendererInfo {
         let name = CStr::from_ptr(info.name as *const _).to_str().unwrap();
 
         RendererInfo {
-            name: name,
+            name,
             flags: info.flags,
-            texture_formats: texture_formats,
+            texture_formats,
             max_texture_width: info.max_texture_width as u32,
             max_texture_height: info.max_texture_height as u32,
         }
@@ -227,7 +227,7 @@ impl<T> RendererContext<T> {
 
     pub unsafe fn from_ll(raw: *mut sys::SDL_Renderer, target: Rc<T>) -> Self {
         RendererContext {
-            raw: raw,
+            raw,
             _target: target,
         }
     }
@@ -344,8 +344,8 @@ impl<'s> Canvas<Surface<'s>> {
             let default_pixel_format = surface.pixel_format_enum();
             Ok(Canvas {
                    target: surface,
-                   context: context,
-                   default_pixel_format: default_pixel_format,
+                   context,
+                   default_pixel_format,
                })
         } else {
             Err(get_error())
@@ -409,7 +409,7 @@ impl Canvas<Window> {
     pub fn into_window(self) -> Window {
         self.target
     }
-    
+
     #[inline]
     pub fn default_pixel_format(&self) -> PixelFormatEnum {
         self.window().window_pixel_format()
@@ -590,7 +590,7 @@ impl<T: RenderTarget> Canvas<T> {
             Err(TargetRenderError::NotSupported)
         }
     }
-    
+
     #[cfg(feature = "unsafe_textures")]
     pub fn with_multiple_texture_canvas<'a : 's, 's, I, F, U: 's>(&mut self, textures: I, mut f: F)
         -> Result<(), TargetRenderError>
@@ -642,7 +642,7 @@ impl CanvasBuilder {
     /// Initializes a new `CanvasBuilder`.
     pub fn new(window: Window) -> CanvasBuilder {
         CanvasBuilder {
-            window: window,
+            window,
             // -1 means to initialize the first rendering driver supporting the
             // renderer flags
             index: None,
@@ -667,9 +667,9 @@ impl CanvasBuilder {
             let context = Rc::new(unsafe { RendererContext::from_ll(raw, self.window.context()) });
             let default_pixel_format = self.window.window_pixel_format();
             Ok(Canvas {
-                   context: context,
+                   context,
                    target: self.window,
-                   default_pixel_format: default_pixel_format,
+                   default_pixel_format,
                })
         }
     }
@@ -883,16 +883,16 @@ impl<T> TextureCreator<T> {
     #[inline]
     pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture {
-            raw: raw,
+            raw,
             _marker: PhantomData,
         }
     }
-    
+
     /// Create a texture from its raw `SDL_Texture`. Should be used with care.
     #[cfg(feature = "unsafe_textures")]
     pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture {
-            raw: raw,
+            raw,
         }
     }
 }
@@ -1428,7 +1428,7 @@ impl<T: RenderTarget> Canvas<T> {
             unsafe { Ok(self.raw_create_texture(result)) }
         }
     }
-    
+
     #[cfg(feature = "unsafe_textures")]
     /// Create a texture from its raw `SDL_Texture`. Should be used with care.
     ///
@@ -1437,7 +1437,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Note that this method is only accessible in Canvas with the `unsafe_textures` feature.
     pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture {
-            raw: raw,
+            raw,
         }
     }
 }
@@ -1875,7 +1875,7 @@ impl InternalTexture {
                            plane: "y",
                            length: y_plane.len(),
                            pitch: y_pitch,
-                           height: height,
+                           height,
                        });
         }
         if u_plane.len() != (u_pitch * height / 2) {
@@ -2029,7 +2029,7 @@ impl<'r> Texture<'r> {
     pub fn set_color_mod(&mut self, red: u8, green: u8, blue: u8) {
         InternalTexture{ raw: self.raw }.set_color_mod(red, green, blue)
     }
-  
+
     /// Gets the additional color value multiplied into render copy operations.
     #[inline]
     pub fn color_mod(&self) -> (u8, u8, u8) {
@@ -2108,7 +2108,7 @@ impl<'r> Texture<'r> {
     {
         InternalTexture { raw: self.raw }.with_lock(rect, func)
     }
-    
+
     /// Binds an OpenGL/ES/ES2 texture to the current
     /// context for use with when rendering OpenGL primitives directly.
     #[inline]
@@ -2226,7 +2226,7 @@ impl<> Texture<> {
     {
         InternalTexture { raw: self.raw }.with_lock(rect, func)
     }
-    
+
     /// Binds an OpenGL/ES/ES2 texture to the current
     /// context for use with when rendering OpenGL primitives directly.
     #[inline]

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -20,7 +20,7 @@ impl<'a> RWops<'a> {
 
     pub unsafe fn from_ll<'b>(raw: *mut sys::SDL_RWops) -> RWops<'b> {
         RWops {
-            raw: raw,
+            raw,
             _marker: PhantomData
         }
     }
@@ -37,7 +37,7 @@ impl<'a> RWops<'a> {
             Err(get_error())
         } else {
             Ok(RWops {
-                raw: raw,
+                raw,
                 _marker: PhantomData
             })
         }
@@ -55,7 +55,7 @@ impl<'a> RWops<'a> {
             Err(get_error())
         } else {
             Ok(RWops {
-                raw: raw,
+                raw,
                 _marker: PhantomData
             })
         }
@@ -88,7 +88,7 @@ impl<'a> RWops<'a> {
             Err(get_error())
         } else {
             Ok(RWops {
-                raw: raw,
+                raw,
                 _marker: PhantomData
             })
         }

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -99,7 +99,7 @@ impl<'a> AsMut<SurfaceRef> for Surface<'a> {
 impl<'a> Surface<'a> {
     pub unsafe fn from_ll<'b>(raw: *mut sys::SDL_Surface) -> Surface<'b> {
         let context = SurfaceContext {
-            raw: raw,
+            raw,
             _marker: PhantomData,
         };
         Surface { context: Rc::new(context) }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -409,7 +409,7 @@ pub mod gl_attr {
         let flags = gl_get_attribute!(SDL_GL_CONTEXT_FLAGS);
 
         ContextFlags {
-            flags: flags
+            flags
         }
     }
 
@@ -427,10 +427,10 @@ pub struct DisplayMode {
 impl DisplayMode {
     pub fn new(format: PixelFormatEnum, w: i32, h: i32, refresh_rate: i32) -> DisplayMode {
         DisplayMode {
-            format: format,
-            w: w,
-            h: h,
-            refresh_rate: refresh_rate
+            format,
+            w,
+            h,
+            refresh_rate
         }
     }
 
@@ -529,7 +529,7 @@ impl WindowContext {
     pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window) -> WindowContext {
         WindowContext {
             subsystem: subsystem.clone(),
-            raw: raw,
+            raw,
         }
     }
 }
@@ -919,8 +919,8 @@ impl WindowBuilder {
     pub fn new(v: &VideoSubsystem, title: &str, width: u32, height: u32) -> WindowBuilder {
         WindowBuilder {
             title: title.to_owned(),
-            width: width,
-            height: height,
+            width,
+            height,
             x: WindowPos::Undefined,
             y: WindowPos::Undefined,
             window_flags: 0,
@@ -1072,7 +1072,7 @@ impl Window {
     #[inline]
     /// Create a new `Window` without taking ownership of the `WindowContext`
     pub unsafe fn from_ref(context: Rc<WindowContext>) -> Window {
-        Window { context: context }
+        Window { context }
     }
 
     #[inline]
@@ -1248,7 +1248,7 @@ impl Window {
         unsafe { sys::SDL_GetWindowPosition(self.context.raw, &mut x, &mut y) };
         (x as i32, y as i32)
     }
-    
+
     /// Use this function to get the size of a window's borders (decorations) around the client area.
     ///
     /// # Remarks


### PR DESCRIPTION
This will remove redundant field names as described in it's [lint](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names)