### PR TITLE
Allows compiling with emscripten

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -301,7 +301,7 @@ fn link_sdl2(target_os: &str) {
         if cfg!(feature = "bundled") || cfg!(not(feature = "use-pkgconfig")) { 
             if cfg!(feature = "use_mac_framework") && target_os == "darwin" {
                 println!("cargo:rustc-flags=-l framework=SDL2");
-            } else {
+            } else if target_os != "emscripten" {
                 println!("cargo:rustc-flags=-l SDL2");
             }
         }


### PR DESCRIPTION
This PR simply allows compiling any project using SDL2 with cargo web. It's just a matter of avoiding linking the SDL2 library as the port from emscripten will be used instead.
