### PR TITLE
Conversion from PixelFormatEnum to PixelFormat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### v0.32.2
+
+[PR #898](https://github.com/Rust-SDL2/rust-sdl2/pull/898):
+Implements `TryFrom<PixelFormatEnum>` for `PixelFormat`
+
 ### v0.32.1
 
 [PR #868](https://github.com/Rust-SDL2/rust-sdl2/pull/868):

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -5,6 +5,7 @@ use self::rand::distributions::{Distribution, Standard};
 use libc::uint32_t;
 use num::FromPrimitive;
 use std::mem::transmute;
+use std::convert::TryFrom;
 use crate::sys;
 
 use crate::get_error;
@@ -458,6 +459,21 @@ impl FromPrimitive for PixelFormatEnum {
     }
 
     fn from_u64(n: u64) -> Option<PixelFormatEnum> { FromPrimitive::from_i64(n as i64) }
+}
+
+impl TryFrom<PixelFormatEnum> for PixelFormat {
+    type Error = String;
+
+    fn try_from(pfe: PixelFormatEnum) -> Result<Self, Self::Error> {
+        unsafe {
+            let pf_ptr = sys::SDL_AllocFormat(pfe as u32);
+            if pf_ptr.is_null() {
+                Err(get_error())
+            } else {
+                Ok(PixelFormat::from_ll(pf_ptr))
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
see issue #840

This commit implements the `TryFrom<PixelFormatEnum>` trait for `PixelFormat`.

There isn't any test yet, since I wasn't sure wich way you would like to go about it