### PR TITLE
Fix for macOS with "bundled" and "static-link" features 

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -309,16 +309,8 @@ fn link_sdl2(target_os: &str) {
 
     #[cfg(feature = "static-link")] {
         if cfg!(feature = "bundled") || cfg!(feature = "use-pkgconfig") == false { 
-            if target_os == "darwin" {
-                println!("cargo:rustc-link-lib=static=libSDL2main");
-                println!("cargo:rustc-link-lib=static=libSDL2");
-            }
-            else {
-                println!("cargo:rustc-link-lib=static=SDL2main");
-                println!("cargo:rustc-link-lib=static=SDL2");        
-            }
-
-            
+            println!("cargo:rustc-link-lib=static=SDL2main");
+            println!("cargo:rustc-link-lib=static=SDL2");
         }
 
         // Also linked to any required libraries for each supported platform


### PR DESCRIPTION
Reverts a731b12f09015eab9486f7a8b0a90896f5d295a0 to fix #883. Have tested on macOS with both features on and everything appears to build and work fine :)