### PR TITLE
-Changed the datatype for 'which' to i32 according to the official sd…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### v0.32.1
+[PR #907](https://github.com/Rust-SDL2/rust-sdl2/pull/907)
+Changed the data type to i32 for the `which` field for the events `ControllerDeviceAdded` and `JoyDeviceAdded`.
+
 ### v0.32.2
 
 [PR #898](https://github.com/Rust-SDL2/rust-sdl2/pull/898):

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -557,7 +557,7 @@ pub enum Event {
     JoyDeviceAdded {
         timestamp: u32,
         /// The newly added joystick's `joystick_index`
-        which: u32
+        which: i32
     },
     JoyDeviceRemoved {
         timestamp: u32,
@@ -589,7 +589,7 @@ pub enum Event {
     ControllerDeviceAdded {
         timestamp: u32,
         /// The newly added controller's `joystick_index`
-        which: u32
+        which: i32
     },
     ControllerDeviceRemoved {
         timestamp: u32,
@@ -1405,7 +1405,7 @@ impl Event {
                 let event = raw.jdevice;
                 Event::JoyDeviceAdded {
                     timestamp: event.timestamp,
-                    which: event.which as u32
+                    which: event.which as i32
                 }
             }
             EventType::JoyDeviceRemoved => {
@@ -1451,7 +1451,7 @@ impl Event {
                 let event = raw.cdevice;
                 Event::ControllerDeviceAdded {
                     timestamp: event.timestamp,
-                    which: event.which as u32
+                    which: event.which as i32
                 }
             }
             EventType::ControllerDeviceRemoved => {


### PR DESCRIPTION
Changed the data type to `i32` for the which field for the events `ControllerDeviceAdded` and `JoyDeviceAdded` according to the official sdl documentation (https://wiki.libsdl.org/SDL_ControllerDeviceEvent, https://wiki.libsdl.org/SDL_JoyDeviceEvent).