### PR TITLE
Add alternative to Window::vulkan_instance_extensions()

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1139,6 +1139,33 @@ impl Window {
         }
         Ok(names.iter().map(|&val| unsafe { CStr::from_ptr(val) }.to_str().unwrap()).collect())
     }
+	
+    /// Get the names of the Vulkan instance extensions needed to create a surface with.
+    ///
+    /// Pass &[] to `data` if you only wish to query size.
+    ///
+    /// If you want the function to write to `data`, the length of the `data` MUST be equal or greater than `extension_count`.
+    ///
+    /// Returns true on successful
+    pub fn vulkan_instance_extensions_raw(&self, extension_count: &mut u32, data: &mut [*const c_char]) -> bool {
+        if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, extension_count, ptr::null_mut()) } == sys::SDL_bool::SDL_FALSE {
+            return false;
+        }
+
+        if data.len() == 0 {
+            return true;
+        }
+
+        if data.len() < *extension_count as usize {
+            return false;
+        }
+
+        if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, extension_count, data.as_mut_ptr()) } == sys::SDL_bool::SDL_FALSE {
+            return false;
+        }
+
+        true
+    }
 
     /// Create a Vulkan rendering surface for a window.
     ///

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1146,25 +1146,25 @@ impl Window {
     ///
     /// If you want the function to write to `data`, the length of the `data` MUST be equal or greater than `extension_count`.
     ///
-    /// Returns `true` on successful
-    pub fn vulkan_instance_extensions_raw(&self, extension_count: &mut u32, data: &mut [*const c_char]) -> bool {
+    /// Returns Ok on success
+    pub fn vulkan_instance_extensions_raw(&self, extension_count: &mut u32, data: &mut [*const c_char]) -> Result<(), String> {
         if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, extension_count, ptr::null_mut()) } == sys::SDL_bool::SDL_FALSE {
-            return false;
+            return Err(get_error());
         }
 
-        if data.len() == 0 {
-            return true;
+        if data.is_empty() {
+            return Ok(());
         }
 
         if data.len() < *extension_count as usize {
-            return false;
+            return Err(get_error());
         }
 
         if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, extension_count, data.as_mut_ptr()) } == sys::SDL_bool::SDL_FALSE {
-            return false;
+            return Err(get_error());
         }
 
-        true
+        Ok(())
     }
 
     /// Create a Vulkan rendering surface for a window.

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1142,11 +1142,11 @@ impl Window {
 	
     /// Get the names of the Vulkan instance extensions needed to create a surface with.
     ///
-    /// Pass &[] to `data` if you only wish to query size.
+    /// Pass `&mut []` to `data` if you only wish to query size.
     ///
     /// If you want the function to write to `data`, the length of the `data` MUST be equal or greater than `extension_count`.
     ///
-    /// Returns true on successful
+    /// Returns `true` on successful
     pub fn vulkan_instance_extensions_raw(&self, extension_count: &mut u32, data: &mut [*const c_char]) -> bool {
         if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, extension_count, ptr::null_mut()) } == sys::SDL_bool::SDL_FALSE {
             return false;


### PR DESCRIPTION
This PR is about adding an alternative to the [`Window::vulkan_instance_extensions()`](https://docs.rs/sdl2/0.32.2/sdl2/video/struct.Window.html#method.vulkan_instance_extensions)

There are two issues with this function:

1. It returns a string that is not null-terminated. This means anyone wanting to pass the information to the Vulkan API will have to convert this string to a null-termainted string in order to do so, as Vulkan only accepts null-terminated. This means it actually requires more configuration than the corresponding sdl2-sys bindings.

2. It enforces the user to accept a Vec where they previously had the option to use their own memory (for example to avoid a malloc).

The solution to this should be fairly simple, introduce a new function
```rust
pub fn vulkan_instance_extensions_raw(
    &self, 
    extension_count: &mut u32, 
    data: &[*const std::os::raw::c_char]) -> Result<(), String>
```

Usage example:
```rust
let mut required_extension_count: u32 = 0;

let result_a = my_window.vulkan_instance_extensions_raw(
    &mut required_extension_count,
    &mut []);
assert!(result_a.is_ok());

let my_data = // Allocate data however you want.

let result_b = my_window.vulkan_instance_extensions_raw(
    &mut required_extension_count,
    my_data.as_slice_mut());
assert!(result_b.is_ok());
```
The data can then be passed directly to Vulkan without modification.

This will allow the flexibility present in the sdl2-sys bindings, while also allowing it to be used in a safe manner.

Names and types to use are up for debate.