### PR TITLE
Replace uses of deprecated mem::uninitialized with mem::MaybeUninit

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -724,7 +724,7 @@ where S: Into<Option<Scancode>>,
 // but Event::User's raw pointers kind of removes that possibility.
 impl Event {
     fn to_ll(&self) -> Option<sys::SDL_Event> {
-        let mut ret = unsafe { mem::uninitialized() };
+        let mut ret = mem::MaybeUninit::uninit();
         match *self {
             Event::User { window_id, type_, code, data1, data2, timestamp} => {
                 let event = sys::SDL_UserEvent {
@@ -736,9 +736,9 @@ impl Event {
                     data2
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_UserEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_UserEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::Quit{timestamp} => {
@@ -747,9 +747,9 @@ impl Event {
                     timestamp,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_QuitEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_QuitEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::Window{
@@ -770,9 +770,9 @@ impl Event {
                     data2,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_WindowEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_WindowEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::KeyDown{
@@ -795,9 +795,9 @@ impl Event {
                     keysym,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_KeyboardEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_KeyboardEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
             Event::KeyUp {
                 timestamp,
@@ -819,9 +819,9 @@ impl Event {
                     keysym,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_KeyboardEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_KeyboardEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
             Event::MouseMotion{
                 timestamp,
@@ -846,9 +846,9 @@ impl Event {
                     yrel,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseMotionEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_MouseMotionEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
             Event::MouseButtonDown{
@@ -873,9 +873,9 @@ impl Event {
                     y
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_MouseButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
             Event::MouseButtonUp{
                 timestamp,
@@ -899,9 +899,9 @@ impl Event {
                     y
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_MouseButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::MouseWheel{
@@ -922,9 +922,9 @@ impl Event {
                     direction : direction.to_ll(),
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_MouseWheelEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_MouseWheelEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
             Event::JoyAxisMotion{
                 timestamp,
@@ -944,9 +944,9 @@ impl Event {
                     padding4: 0
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyAxisEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyAxisEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
             Event::JoyBallMotion{
@@ -968,9 +968,9 @@ impl Event {
                     padding3: 0
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyBallEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyBallEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
             Event::JoyHatMotion{
@@ -990,9 +990,9 @@ impl Event {
                     padding2: 0
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyHatEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyHatEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
             Event::JoyButtonDown{
@@ -1010,9 +1010,9 @@ impl Event {
                     padding2: 0,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
 
@@ -1031,9 +1031,9 @@ impl Event {
                     padding2: 0,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
 
@@ -1047,9 +1047,9 @@ impl Event {
                     which: which as i32,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyDeviceEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyDeviceEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::JoyDeviceRemoved{
@@ -1062,9 +1062,9 @@ impl Event {
                     which,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_JoyDeviceEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyDeviceEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
             Event::ControllerAxisMotion{
@@ -1086,9 +1086,9 @@ impl Event {
                     padding4: 0,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerAxisEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerAxisEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
             Event::ControllerButtonDown{
                 timestamp,
@@ -1108,9 +1108,9 @@ impl Event {
                     padding2: 0,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::ControllerButtonUp{
@@ -1129,9 +1129,9 @@ impl Event {
                     padding2: 0,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerButtonEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerButtonEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
             },
 
             Event::ControllerDeviceAdded{
@@ -1144,9 +1144,9 @@ impl Event {
                     which: which as i32,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
 
@@ -1160,9 +1160,9 @@ impl Event {
                     which,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
 
@@ -1176,9 +1176,9 @@ impl Event {
                     which,
                 };
                 unsafe {
-                    ptr::copy(&event, &mut ret as *mut sys::SDL_Event as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerDeviceEvent, 1);
+                    Some(ret.assume_init())
                 }
-                Some(ret)
 
             },
 
@@ -1637,26 +1637,26 @@ impl Event {
 }
 
 unsafe fn poll_event() -> Option<Event> {
-    let mut raw = mem::uninitialized();
-    let has_pending = sys::SDL_PollEvent(&mut raw) == 1;
+    let mut raw = mem::MaybeUninit::uninit();
+    let has_pending = sys::SDL_PollEvent(raw.as_mut_ptr()) == 1;
 
-    if has_pending { Some(Event::from_ll(raw)) }
+    if has_pending { Some(Event::from_ll(raw.assume_init())) }
     else { None }
 }
 
 unsafe fn wait_event() -> Event {
-    let mut raw = mem::uninitialized();
-    let success = sys::SDL_WaitEvent(&mut raw) == 1;
+    let mut raw = mem::MaybeUninit::uninit();
+    let success = sys::SDL_WaitEvent(raw.as_mut_ptr()) == 1;
 
-    if success { Event::from_ll(raw) }
+    if success { Event::from_ll(raw.assume_init()) }
     else { panic!(get_error()) }
 }
 
 unsafe fn wait_event_timeout(timeout: u32) -> Option<Event> {
-    let mut raw = mem::uninitialized();
-    let success = sys::SDL_WaitEventTimeout(&mut raw, timeout as c_int) == 1;
+    let mut raw = mem::MaybeUninit::uninit();
+    let success = sys::SDL_WaitEventTimeout(raw.as_mut_ptr(), timeout as c_int) == 1;
 
-    if success { Some(Event::from_ll(raw)) }
+    if success { Some(Event::from_ll(raw.assume_init())) }
     else { None }
 }
 

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -520,10 +520,12 @@ impl SurfaceRef {
     ///
     /// Returns `None` if clipping is disabled.
     pub fn clip_rect(&self) -> Option<Rect> {
-        let mut raw = unsafe { mem::uninitialized() };
+        let mut raw = mem::MaybeUninit::uninit();
         unsafe {
-            sys::SDL_GetClipRect(self.raw(), &mut raw)
+            sys::SDL_GetClipRect(self.raw(), raw.as_mut_ptr())
         };
+        let raw = unsafe { raw.assume_init() };
+
         if raw.w == 0 || raw.h == 0 {
             None
         } else {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -620,10 +620,11 @@ impl VideoSubsystem {
     }
 
     pub fn display_bounds(&self, display_index: i32) -> Result<Rect, String> {
-        let mut out = unsafe { mem::uninitialized() };
-        let result = unsafe { sys::SDL_GetDisplayBounds(display_index as c_int, &mut out) == 0 };
+        let mut out = mem::MaybeUninit::uninit();
+        let result = unsafe { sys::SDL_GetDisplayBounds(display_index as c_int, out.as_mut_ptr()) == 0 };
 
         if result {
+            let out = unsafe { out.assume_init() };
             Ok(Rect::from_ll(out))
         } else {
             Err(get_error())
@@ -640,10 +641,11 @@ impl VideoSubsystem {
     }
 
     pub fn display_mode(&self, display_index: i32, mode_index: i32) -> Result<DisplayMode, String> {
-        let mut dm = unsafe { mem::uninitialized() };
-        let result = unsafe { sys::SDL_GetDisplayMode(display_index as c_int, mode_index as c_int, &mut dm) == 0};
+        let mut dm = mem::MaybeUninit::uninit();
+        let result = unsafe { sys::SDL_GetDisplayMode(display_index as c_int, mode_index as c_int, dm.as_mut_ptr()) == 0};
 
         if result {
+            let dm = unsafe { dm.assume_init() };
             Ok(DisplayMode::from_ll(&dm))
         } else {
             Err(get_error())
@@ -651,10 +653,11 @@ impl VideoSubsystem {
     }
 
     pub fn desktop_display_mode(&self, display_index: i32) -> Result<DisplayMode, String> {
-        let mut dm = unsafe { mem::uninitialized() };
-        let result = unsafe { sys::SDL_GetDesktopDisplayMode(display_index as c_int, &mut dm) == 0};
+        let mut dm = mem::MaybeUninit::uninit();
+        let result = unsafe { sys::SDL_GetDesktopDisplayMode(display_index as c_int, dm.as_mut_ptr()) == 0};
 
         if result {
+            let dm = unsafe { dm.assume_init() };
             Ok(DisplayMode::from_ll(&dm))
         } else {
             Err(get_error())
@@ -662,10 +665,11 @@ impl VideoSubsystem {
     }
 
     pub fn current_display_mode(&self, display_index: i32) -> Result<DisplayMode, String> {
-        let mut dm = unsafe { mem::uninitialized() };
-        let result = unsafe { sys::SDL_GetCurrentDisplayMode(display_index as c_int, &mut dm) == 0};
+        let mut dm = mem::MaybeUninit::uninit();
+        let result = unsafe { sys::SDL_GetCurrentDisplayMode(display_index as c_int, dm.as_mut_ptr()) == 0};
 
         if result {
+            let dm = unsafe { dm.assume_init() };
             Ok(DisplayMode::from_ll(&dm))
         } else {
             Err(get_error())
@@ -674,13 +678,14 @@ impl VideoSubsystem {
 
     pub fn closest_display_mode(&self, display_index: i32, mode: &DisplayMode) -> Result<DisplayMode, String> {
         let input = mode.to_ll();
-        let mut dm = unsafe { mem::uninitialized() };
+        let mut dm = mem::MaybeUninit::uninit();
 
-        let result = unsafe { sys::SDL_GetClosestDisplayMode(display_index as c_int, &input, &mut dm) };
+        let result = unsafe { sys::SDL_GetClosestDisplayMode(display_index as c_int, &input, dm.as_mut_ptr()) };
 
         if result.is_null() {
             Err(get_error())
         } else {
+            let dm = unsafe { dm.assume_init() };
             Ok(DisplayMode::from_ll(&dm))
         }
     }
@@ -1183,16 +1188,17 @@ impl Window {
     }
 
     pub fn display_mode(&self) -> Result<DisplayMode, String> {
-        let mut dm = unsafe { mem::uninitialized() };
+        let mut dm = mem::MaybeUninit::uninit();
 
         let result = unsafe {
             sys::SDL_GetWindowDisplayMode(
                 self.context.raw,
-                &mut dm
+                dm.as_mut_ptr(),
             ) == 0
         };
 
         if result {
+            let dm = unsafe { dm.assume_init() };
             Ok(DisplayMode::from_ll(&dm))
         } else {
             Err(get_error())


### PR DESCRIPTION
`core::mem::uninitialized` is deprecated in favor of the safer/more explicit `core::mem::MaybeUninit` wrapper type which is stable as of Rust 1.36. This PR replaces all of the uses of `uninitialized` with `MaybeUninit`.

One thing to note is that this will break dependents who target older stable versions of Rust. The README states that this project targets current stable so I doubt that should be much of an issue.