### PR TITLE
Install libgl1-mesa-dev when testing with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,14 @@ env:
     - secure: MJhmVnQ2IM7+sVmc3vU4ndKOcQgLLeHUPW3qaQBQHKQmvoswCwQK60N17uSgWn1Ln8teqvSRHq4KclIjdMHI+VuQXJHQKHDgjcYbHxwmc3AM1Whnp0XB44ksKUmD109BGWSfZQxzF+6dA+YNOQ+mti+bpydMu8n2FMVjA/SXwQ8=
 
 install:
-  - if [[ $CI_BUILD_FEATURES != *"bundled"* ]]; then bash scripts/travis-install-sdl2.sh; fi
+  - |
+    if [[ $CI_BUILD_FEATURES != *"bundled"* ]]; then
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get update
+        sudo apt-get install --assume-yes libgl1-mesa-dev
+      fi
+      bash scripts/travis-install-sdl2.sh
+    fi
 
 before_script:
   - shopt -s expand_aliases


### PR DESCRIPTION
Compiling `SDL2_ttf`  on Ubuntu in Travis CI requires `libGL.so`, which is included in `libgl1-mesa-dev`. Refer to https://discourse.libsdl.org/t/cross-compiling-sdl-ttf/18773.

This patch will resolve the recent issues of pull requests with the Travis CI check: [Build #1534](https://travis-ci.org/Rust-SDL2/rust-sdl2/builds/562923003), [#1535](https://travis-ci.org/Rust-SDL2/rust-sdl2/builds/569402827), ..., [#1542](https://travis-ci.org/Rust-SDL2/rust-sdl2/builds/577492109).