### PR TITLE
Fix for panic upon invalid hat state reported by xinput driver

### DIFF
--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -489,7 +489,11 @@ impl HatState {
             6  => HatState::RightDown,
             9  => HatState::LeftUp,
             12 => HatState::LeftDown,
-            _  => panic!("Unexpected hat position: {}", raw),
+
+            // The Xinput driver on Windows can report hat states on certain hardware that don't
+            // make any sense from a gameplay perspective, and so aren't worth putting in the
+            // HatState enumeration.
+            _  => HatState::Centered,
         }
     }
 

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -54,7 +54,7 @@ impl TimerSubsystem {
     }
 }
 
-pub type TimerCallback<'a> = Box<FnMut() -> u32+'a+Sync>;
+pub type TimerCallback<'a> = Box<dyn FnMut() -> u32+'a+Sync>;
 
 pub struct Timer<'b, 'a> {
     callback: Option<Box<TimerCallback<'a>>>,
@@ -82,7 +82,7 @@ impl<'b, 'a> Drop for Timer<'b, 'a> {
 
 extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> uint32_t {
     unsafe {
-        let f: *mut Box<Fn() -> u32> = mem::transmute(param);
+        let f: *mut Box<dyn Fn() -> u32> = mem::transmute(param);
         (*f)() as uint32_t
     }
 }


### PR DESCRIPTION
The Logitech F310 gamepad has a direction pad that must have no central pivot point or something - you can press in the middle of the d-pad and it will register all four hat switches at the same time. When it's set to Xinput mode, the hat state reported by SDL2 is not in rust-sdl2's HatState enum. Interestingly, DirectInput doesn't do this, and the third party xinput adapter for MacOS doesn't do this either.

Also I added some missing `dyn` keywords because in recent versions of Rust, that's warn by default.