### PR TITLE
Clean up compiler warnings

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -54,7 +54,7 @@
 
 use std::ffi::{CStr, CString};
 use num::FromPrimitive;
-use libc::{c_int, c_void, uint8_t, c_char};
+use libc::{c_int, c_void, c_char};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::marker::PhantomData;
@@ -281,7 +281,7 @@ pub struct AudioSpecWAV {
 impl AudioSpecWAV {
     /// Loads a WAVE from the file path.
     pub fn load_wav<P: AsRef<Path>>(path: P) -> Result<AudioSpecWAV, String> {
-        let mut file = r#try!(RWops::from_file(path, "rb"));
+        let mut file = RWops::from_file(path, "rb")?;
         AudioSpecWAV::load_wav_rw(&mut file)
     }
 
@@ -373,7 +373,7 @@ impl AudioFormatNum for f32 {
 }
 
 extern "C" fn audio_callback_marshall<CB: AudioCallback>
-(userdata: *mut c_void, stream: *mut uint8_t, len: c_int) {
+(userdata: *mut c_void, stream: *mut u8, len: c_int) {
     use std::slice::from_raw_parts_mut;
     use std::mem::size_of;
     unsafe {
@@ -429,7 +429,7 @@ impl AudioSpecDesired {
             callback: Some(audio_callback_marshall::<CB>
                     as extern "C" fn
                         (arg1: *mut c_void,
-                            arg2: *mut uint8_t,
+                            arg2: *mut u8,
                             arg3: c_int)),
             userdata: userdata as *mut _,
         }

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -74,7 +74,7 @@ impl GameControllerSubsystem {
     /// be retrieved using the `SDL_NumJoysticks` function.
     pub fn open(&self, joystick_index: u32) -> Result<GameController, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
         let controller = unsafe { sys::SDL_GameControllerOpen(joystick_index) };
 
         if controller.is_null() {
@@ -90,7 +90,7 @@ impl GameControllerSubsystem {
     /// Return the name of the controller at index `joystick_index`.
     pub fn name_for_index(&self, joystick_index: u32) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
         let c_str = unsafe { sys::SDL_GameControllerNameForIndex(joystick_index) };
 
         if c_str.is_null() {

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -4,7 +4,7 @@ Event Handling
 
 use std::ffi::CStr;
 use std::mem;
-use libc::{c_int, uint32_t};
+use libc::c_int;
 use num::FromPrimitive;
 use std::ptr;
 use std::borrow::ToOwned;
@@ -51,7 +51,7 @@ lazy_static! {
 impl crate::EventSubsystem {
     /// Removes all events in the event queue that match the specified event type.
     pub fn flush_event(&self, event_type: EventType) {
-        unsafe { sys::SDL_FlushEvent(event_type as uint32_t) };
+        unsafe { sys::SDL_FlushEvent(event_type as u32) };
     }
 
     /// Removes all events in the event queue that match the specified type range.
@@ -145,7 +145,7 @@ impl crate::EventSubsystem {
     /// ```
     #[inline(always)]
     pub unsafe fn register_event(&self) -> Result<u32, String> {
-        Ok(*r#try!(self.register_events(1)).first().unwrap())
+        Ok(*self.register_events(1)?.first().unwrap())
     }
 
     /// Registers custom SDL events.
@@ -177,7 +177,7 @@ impl crate::EventSubsystem {
     pub fn register_custom_event<T: ::std::any::Any>(&self)
             -> Result<(), String> {
         use ::std::any::TypeId;
-        let event_id = *r#try!(unsafe { self.register_events(1) }).first().unwrap();
+        let event_id = *(unsafe { self.register_events(1) })?.first().unwrap();
         let mut cet = CUSTOM_EVENT_TYPES.lock().unwrap();
         let type_id = TypeId::of::<Box<T>>();
 
@@ -728,7 +728,7 @@ impl Event {
         match *self {
             Event::User { window_id, type_, code, data1, data2, timestamp} => {
                 let event = sys::SDL_UserEvent {
-                    type_: type_ as uint32_t,
+                    type_: type_ as u32,
                     timestamp,
                     windowID: window_id,
                     code: code as i32,
@@ -2034,7 +2034,7 @@ mod test {
         }.to_ll().unwrap();
 
         // Simulate SDL setting bits unknown to us, see PR #780
-        unsafe { raw_event.key.keysym.mod_ = 0xffff; }
+        raw_event.key.keysym.mod_ = 0xffff;
 
         if let Event::KeyDown { keymod, .. } = Event::from_ll(raw_event) {
             assert_eq!(keymod, Mod::all());
@@ -2055,7 +2055,7 @@ mod test {
         }.to_ll().unwrap();
 
         // Simulate SDL setting bits unknown to us, see PR #780
-        unsafe { raw_event.key.keysym.mod_ = 0xffff; }
+        raw_event.key.keysym.mod_ = 0xffff;
 
         if let Event::KeyUp { keymod, .. } = Event::from_ll(raw_event) {
             assert_eq!(keymod, Mod::all());
@@ -2140,7 +2140,7 @@ impl EventSender {
            data2: ::std::ptr::null_mut()
         };
 
-        r#try!(self.push_event(event));
+        self.push_event(event)?;
 
         Ok(())
     }

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -9,7 +9,7 @@ impl HapticSubsystem {
     /// Attempt to open the joystick at index `joystick_index` and return its haptic device.
     pub fn open_from_joystick_id(&self, joystick_index: u32) -> Result<Haptic, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
 
         let haptic = unsafe {
             let joystick = sys::SDL_JoystickOpen(joystick_index);

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -25,7 +25,7 @@ impl JoystickSubsystem {
     pub fn open(&self, joystick_index: u32)
             -> Result<Joystick, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
 
         let joystick = unsafe { sys::SDL_JoystickOpen(joystick_index) };
 
@@ -42,7 +42,7 @@ impl JoystickSubsystem {
     /// Return the name of the joystick at index `joystick_index`.
     pub fn name_for_index(&self, joystick_index: u32) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
 
         let c_str = unsafe { sys::SDL_JoystickNameForIndex(joystick_index) };
 
@@ -58,7 +58,7 @@ impl JoystickSubsystem {
     /// Get the GUID for the joystick at index `joystick_index`
     pub fn device_guid(&self, joystick_index: u32) -> Result<Guid, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick_index = r#try!(validate_int(joystick_index, "joystick_index"));
+        let joystick_index = validate_int(joystick_index, "joystick_index")?;
 
         let raw = unsafe { sys::SDL_JoystickGetDeviceGUID(joystick_index) };
 
@@ -222,7 +222,7 @@ impl Joystick {
         // get_error() returns a non-empty string.
         clear_error();
 
-        let axis = r#try!(validate_int(axis, "axis"));
+        let axis = validate_int(axis, "axis")?;
         let pos = unsafe { sys::SDL_JoystickGetAxis(self.raw, axis) };
 
         if pos != 0 {
@@ -259,7 +259,7 @@ impl Joystick {
         // error...
         clear_error();
 
-        let button = r#try!(validate_int(button, "button"));
+        let button = validate_int(button, "button")?;
         let pressed = unsafe { sys::SDL_JoystickGetButton(self.raw, button) };
 
         match pressed {
@@ -298,7 +298,7 @@ impl Joystick {
         let mut dx = 0;
         let mut dy = 0;
 
-        let ball = r#try!(validate_int(ball, "ball"));
+        let ball = validate_int(ball, "ball")?;
         let result = unsafe { sys::SDL_JoystickGetBall(self.raw, ball, &mut dx, &mut dy) };
 
         if result == 0 {
@@ -328,7 +328,7 @@ impl Joystick {
         // have to use the same hack as `axis`...
         clear_error();
 
-        let hat = r#try!(validate_int(hat, "hat"));
+        let hat = validate_int(hat, "hat")?;
         let result = unsafe { sys::SDL_JoystickGetHat(self.raw, hat) };
 
         let state = HatState::from_raw(result as u8);
@@ -404,7 +404,7 @@ impl Eq for Guid {}
 impl Guid {
     /// Create a GUID from a string representation.
     pub fn from_string(guid: &str) -> Result<Guid, NulError> {
-        let guid = r#try!(CString::new(guid));
+        let guid = CString::new(guid)?;
 
         let raw = unsafe { sys::SDL_JoystickGetGUIDFromString(guid.as_ptr() as *const c_char) };
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -2,7 +2,6 @@ extern crate rand;
 use self::rand::Rng;
 use self::rand::distributions::{Distribution, Standard};
 
-use libc::uint32_t;
 use num::FromPrimitive;
 use std::mem::transmute;
 use std::convert::TryFrom;
@@ -46,7 +45,7 @@ impl Palette {
 
     /// Creates a palette from the provided colors
     pub fn with_colors(colors: &[Color]) -> Result<Self, String> {
-        let pal = r#try!(Self::new(colors.len()));
+        let pal = Self::new(colors.len())?;
 
         // Already validated, so don't check again
         let ncolors = colors.len() as ::libc::c_int;
@@ -391,12 +390,6 @@ impl PixelFormatEnum {
             RGBA4444 | RGBA5551 | RGBA8888 => true,
             _ => false
         }
-    }
-}
-
-impl Into<uint32_t> for PixelFormatEnum {
-    fn into(self) -> uint32_t {
-        self as uint32_t
     }
 }
 

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -2,7 +2,7 @@ use std::error;
 use std::ffi::{CStr, CString, NulError};
 use std::fmt;
 use std::rc::Rc;
-use libc::{c_char, uint32_t};
+use libc::c_char;
 use std::mem::transmute;
 
 use crate::sys;
@@ -227,7 +227,7 @@ macro_rules! subsystem {
 #[derive(Debug, Clone)]
 struct SubsystemDrop {
     _sdldrop: Rc<SdlDrop>,
-    flag: uint32_t
+    flag: u32
 }
 
 impl Drop for SubsystemDrop {
@@ -327,7 +327,7 @@ pub fn get_error() -> String {
 }
 
 pub fn set_error(err: &str) -> Result<(), NulError> {
-    let c_string = r#try!(CString::new(err));
+    let c_string = CString::new(err)?;
     Ok(unsafe {
         sys::SDL_SetError(c_string.as_ptr() as *const c_char);
     })

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -115,7 +115,7 @@ impl<'a> Surface<'a> {
     /// let surface = Surface::new(512, 512, PixelFormatEnum::RGB24).unwrap();
     /// ```
     pub fn new(width: u32, height: u32, format: pixels::PixelFormatEnum) -> Result<Surface<'static>, String> {
-        let masks = r#try!(format.into_masks());
+        let masks = format.into_masks()?;
         Surface::from_pixelmasks(width, height, masks)
     }
 
@@ -148,7 +148,7 @@ impl<'a> Surface<'a> {
 
     /// Creates a new surface from an existing buffer, using a pixel format.
     pub fn from_data(data: &'a mut [u8], width: u32, height: u32, pitch: u32, format: pixels::PixelFormatEnum) -> Result<Surface<'a>, String> {
-        let masks = r#try!(format.into_masks());
+        let masks = format.into_masks()?;
         Surface::from_data_pixelmasks(data, width, height, pitch, masks)
     }
 
@@ -186,7 +186,7 @@ impl<'a> Surface<'a> {
     }
 
     pub fn load_bmp<P: AsRef<Path>>(path: P) -> Result<Surface<'static>, String> {
-        let mut file = r#try!(RWops::from_file(path, "rb"));
+        let mut file = RWops::from_file(path, "rb")?;
         Surface::load_bmp_rw(&mut file)
     }
 
@@ -332,7 +332,7 @@ impl SurfaceRef {
     }
 
     pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
-        let mut file = r#try!(RWops::from_file(path, "wb"));
+        let mut file = RWops::from_file(path, "wb")?;
         self.save_bmp_rw(&mut file)
     }
 

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -1,4 +1,3 @@
-use libc::uint32_t;
 use libc::c_void;
 use std::marker::PhantomData;
 use std::mem;
@@ -80,10 +79,10 @@ impl<'b, 'a> Drop for Timer<'b, 'a> {
     }
 }
 
-extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> uint32_t {
+extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> u32 {
     unsafe {
         let f: *mut Box<dyn Fn() -> u32> = mem::transmute(param);
-        (*f)() as uint32_t
+        (*f)()
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_uint, c_float, uint32_t, c_char};
+use libc::{c_int, c_uint, c_float, c_char};
 use std::ffi::{CStr, CString, NulError};
 use std::{mem, ptr, fmt};
 use std::rc::Rc;
@@ -445,7 +445,7 @@ impl DisplayMode {
 
     pub fn to_ll(&self) -> sys::SDL_DisplayMode {
         sys::SDL_DisplayMode {
-            format: self.format as uint32_t,
+            format: self.format as u32,
             w: self.w as c_int,
             h: self.h as c_int,
             refresh_rate: self.refresh_rate as c_int,
@@ -1216,7 +1216,7 @@ impl Window {
     }
 
     pub fn set_title(&mut self, title: &str) -> Result<(), NulError> {
-        let title = r#try!(CString::new(title));
+        let title = CString::new(title)?;
         Ok(unsafe {
             sys::SDL_SetWindowTitle(self.context.raw, title.as_ptr() as *const c_char);
         })
@@ -1284,8 +1284,8 @@ impl Window {
 
     pub fn set_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
-        let w = r#try!(validate_int(width, "width"));
-        let h = r#try!(validate_int(height, "height"));
+        let w = validate_int(width, "width")?;
+        let h = validate_int(height, "height")?;
         Ok(unsafe {
             sys::SDL_SetWindowSize(self.context.raw, w, h)
         })
@@ -1314,8 +1314,8 @@ impl Window {
 
     pub fn set_minimum_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
-        let w = r#try!(validate_int(width, "width"));
-        let h = r#try!(validate_int(height, "height"));
+        let w = validate_int(width, "width")?;
+        let h = validate_int(height, "height")?;
         Ok(unsafe {
             sys::SDL_SetWindowMinimumSize(self.context.raw, w, h)
         })
@@ -1330,8 +1330,8 @@ impl Window {
 
     pub fn set_maximum_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
-        let w = r#try!(validate_int(width, "width"));
-        let h = r#try!(validate_int(height, "height"));
+        let w = validate_int(width, "width")?;
+        let h = validate_int(height, "height")?;
         Ok(unsafe {
             sys::SDL_SetWindowMaximumSize(self.context.raw, w, h)
         })
@@ -1387,7 +1387,7 @@ impl Window {
             -> Result<(), String> {
         unsafe {
             let result = sys::SDL_SetWindowFullscreen(
-                self.context.raw, fullscreen_type as uint32_t
+                self.context.raw, fullscreen_type as u32
             );
             if result == 0 {
                 Ok(())


### PR DESCRIPTION
I was taking a stab at another issue and noticed there were a lot of compiler warnings in the way - I've updated them to compile cleanly now.

There were 3 different types of warnings that I fixed:

- `uint8_t` and `uint32_t` are deprecated and were changed to the builtin `u8` or `u32`, respectively

- The `try!` macro is deprecated and was replaced by the `?` operator

- There were 2 field accesses in tests from `src/sdl2/event.rs` that were unnecessarily wrapped in `unsafe` blocks, which have been simplified