### PR TITLE
Fix linking on FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    #[cfg(target_os="openbsd")]
+    #[cfg(any(target_os="openbsd", target_os="freebsd"))]
     println!(r"cargo:rustc-link-search=/usr/local/lib");
 }


### PR DESCRIPTION
Apply the linking fix of OpenBSD to FreeBSD, else it will not find system wide SDL2. 