### PR TITLE
Clean up clippy warnings

### DIFF
--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -224,8 +224,8 @@ impl Axis {
         })
     }
 
-    pub fn to_ll(&self) -> sys::SDL_GameControllerAxis {
-        match *self {
+    pub fn to_ll(self) -> sys::SDL_GameControllerAxis {
+        match self {
             Axis::LeftX => sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTX,
             Axis::LeftY => sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTY,
             Axis::RightX => sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_RIGHTX,
@@ -302,8 +302,8 @@ impl Button {
         })
     }
 
-    pub fn to_ll(&self) -> sys::SDL_GameControllerButton {
-        match *self {
+    pub fn to_ll(self) -> sys::SDL_GameControllerButton {
+        match self {
             Button::A             => sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_A,
             Button::B             => sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_B,
             Button::X             => sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_X,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -380,7 +380,7 @@ pub enum WindowEvent {
 }
 
 impl WindowEvent {
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     fn from_ll(id: u8, data1: i32, data2: i32) -> WindowEvent {
         match id {
             0  => WindowEvent::None,

--- a/src/sdl2/hint.rs
+++ b/src/sdl2/hint.rs
@@ -2,7 +2,7 @@ use std::ffi::{CString, CStr};
 use crate::sys;
 use libc::c_char;
 
-const VIDEO_MINIMIZE_ON_FOCUS_LOSS: &'static str = "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS";
+const VIDEO_MINIMIZE_ON_FOCUS_LOSS: &str = "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS";
 
 pub enum Hint {
     Default,

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -115,8 +115,8 @@ impl PowerLevel {
         }
     }
 
-    pub fn to_ll(&self) -> SDL_JoystickPowerLevel {
-        match *self {
+    pub fn to_ll(self) -> SDL_JoystickPowerLevel {
+        match self {
             PowerLevel::Unknown => SDL_JoystickPowerLevel::SDL_JOYSTICK_POWER_UNKNOWN,
             PowerLevel::Empty   => SDL_JoystickPowerLevel::SDL_JOYSTICK_POWER_EMPTY,
             PowerLevel::Low     => SDL_JoystickPowerLevel::SDL_JOYSTICK_POWER_LOW,
@@ -497,8 +497,8 @@ impl HatState {
         }
     }
 
-    pub fn to_raw(&self) -> u8 {
-        match *self {
+    pub fn to_raw(self) -> u8 {
+        match self {
             HatState::Centered => 0,
             HatState::Up => 1,
             HatState::Right => 2,

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -48,7 +48,7 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless, transmute_ptr_to_ref))]
+#![allow(clippy::cast_lossless, clippy::transmute_ptr_to_ref)]
 
 extern crate num;
 pub extern crate libc;

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -118,8 +118,8 @@ impl MouseWheelDirection {
         }
     }
     #[inline]
-    pub fn to_ll(&self) -> u32 {
-        match *self {
+    pub fn to_ll(self) -> u32 {
+        match self {
             MouseWheelDirection::Normal => 0,
             MouseWheelDirection::Flipped => 1,
             MouseWheelDirection::Unknown(direction) => direction,

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -116,7 +116,7 @@ impl Color {
         Color { r, g, b, a }
     }
 
-    pub fn to_u32(&self, format: &PixelFormat) -> u32 {
+    pub fn to_u32(self, format: &PixelFormat) -> u32 {
         unsafe { sys::SDL_MapRGBA(format.raw, self.r, self.g, self.b, self.a) }
     }
 
@@ -130,18 +130,18 @@ impl Color {
     }
 
     #[inline]
-    pub fn rgb(&self) -> (u8, u8, u8) {
+    pub fn rgb(self) -> (u8, u8, u8) {
         (self.r, self.g, self.b)
     }
 
     #[inline]
-    pub fn rgba(&self) -> (u8, u8, u8, u8) {
+    pub fn rgba(self) -> (u8, u8, u8, u8) {
         (self.r, self.g, self.b, self.a)
     }
 
     // Implemented manually and kept private, because reasons
     #[inline]
-    fn raw(&self) -> sys::SDL_Color {
+    fn raw(self) -> sys::SDL_Color {
         sys::SDL_Color { r: self.r, g: self.g, b: self.b, a: self.a }
     }
 }
@@ -293,8 +293,8 @@ impl PixelFormatEnum {
 
     /// Calculates the total byte size of an image buffer, given its pitch
     /// and height.
-    pub fn byte_size_from_pitch_and_height(&self, pitch: usize, height: usize) -> usize {
-        match *self {
+    pub fn byte_size_from_pitch_and_height(self, pitch: usize, height: usize) -> usize {
+        match self {
             PixelFormatEnum::YV12 | PixelFormatEnum::IYUV => {
                 // YUV is 4:2:0.
                 // `pitch` is the width of the Y component, and
@@ -306,9 +306,9 @@ impl PixelFormatEnum {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-    pub fn byte_size_of_pixels(&self, num_of_pixels: usize) -> usize {
-        match *self {
+    #[allow(clippy::match_same_arms)]
+    pub fn byte_size_of_pixels(self, num_of_pixels: usize) -> usize {
+        match self {
             PixelFormatEnum::RGB332
                 => num_of_pixels,
             PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
@@ -340,13 +340,13 @@ impl PixelFormatEnum {
             PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
             PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
             PixelFormatEnum::Index4MSB
-                => panic!("not supported format: {:?}", *self),
+                => panic!("not supported format: {:?}", self),
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-    pub fn byte_size_per_pixel(&self) -> usize {
-        match *self {
+    #[allow(clippy::match_same_arms)]
+    pub fn byte_size_per_pixel(self) -> usize {
+        match self {
             PixelFormatEnum::RGB332
                 => 1,
             PixelFormatEnum::RGB444 | PixelFormatEnum::RGB555 |
@@ -377,13 +377,13 @@ impl PixelFormatEnum {
             PixelFormatEnum::Unknown | PixelFormatEnum::Index1LSB |
             PixelFormatEnum::Index1MSB | PixelFormatEnum::Index4LSB |
             PixelFormatEnum::Index4MSB
-                => panic!("not supported format: {:?}", *self),
+                => panic!("not supported format: {:?}", self),
         }
     }
 
-    pub fn supports_alpha(&self) -> bool {
+    pub fn supports_alpha(self) -> bool {
         use crate::pixels::PixelFormatEnum::*;
-        match *self {
+        match self {
             ARGB4444 | ARGB1555 | ARGB8888 | ARGB2101010 |
             ABGR4444 | ABGR1555 | ABGR8888 |
             BGRA4444 | BGRA5551 | BGRA8888 |
@@ -396,7 +396,7 @@ impl PixelFormatEnum {
 impl From<PixelFormat> for PixelFormatEnum {
     fn from(pf: PixelFormat) -> PixelFormatEnum {
         unsafe {
-            let ref sdl_pf = *pf.raw;
+            let sdl_pf = *pf.raw;
             match PixelFormatEnum::from_u64(sdl_pf.format as u64) {
                 Some(pfe) => pfe,
                 None => panic!("Unknown pixel format: {:?}", sdl_pf.format)

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -430,9 +430,7 @@ impl Rect {
     }
 
     pub fn raw_slice(slice: &[Rect]) -> *const sys::SDL_Rect {
-        unsafe {
-            mem::transmute(slice.as_ptr())
-        }
+        slice.as_ptr() as *const sys::SDL_Rect
     }
 
     pub fn from_ll(raw: sys::SDL_Rect) -> Rect {
@@ -626,7 +624,7 @@ impl Into<(i32, i32, u32, u32)> for Rect {
 
 impl From<sys::SDL_Rect> for Rect {
     fn from(raw: sys::SDL_Rect) -> Rect {
-        Rect { raw: raw }
+        Rect { raw }
     }
 }
 
@@ -768,18 +766,16 @@ impl Point {
     }
 
     pub fn raw_slice(slice: &[Point]) -> *const sys::SDL_Point {
-        unsafe {
-            mem::transmute(slice.as_ptr())
-        }
+        slice.as_ptr() as *const sys::SDL_Point
     }
 
-    pub fn raw(&self) -> *const sys::SDL_Point {
+    pub fn raw(self) -> *const sys::SDL_Point {
         &self.raw
     }
 
     /// Returns a new point by shifting this point's coordinates by the given
     /// x and y values.
-    pub fn offset(&self, x: i32, y: i32) -> Point {
+    pub fn offset(self, x: i32, y: i32) -> Point {
         let x = match self.raw.x.checked_add(x) {
             Some(val) => val,
             None => {
@@ -805,18 +801,18 @@ impl Point {
 
     /// Returns a new point by multiplying this point's coordinates by the
     /// given scale factor.
-    pub fn scale(&self, f: i32) -> Point {
+    pub fn scale(self, f: i32) -> Point {
         Point::new(clamped_mul(self.raw.x, f),
                    clamped_mul(self.raw.y, f))
     }
 
     /// Returns the x-coordinate of this point.
-    pub fn x(&self) -> i32 {
+    pub fn x(self) -> i32 {
         self.raw.x
     }
 
     /// Returns the y-coordinate of this point.
-    pub fn y(&self) -> i32 {
+    pub fn y(self) -> i32 {
         self.raw.y
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -508,10 +508,10 @@ impl<T: RenderTarget> Canvas<T> {
         if self.render_target_supported() {
             let target = unsafe { self.get_raw_target() };
             unsafe { self.set_raw_target(texture.raw) }
-                .map_err(|e| TargetRenderError::SdlError(e))?;
+                .map_err(TargetRenderError::SdlError)?;
             f(self);
             unsafe { self.set_raw_target(target) }
-                .map_err(|e| TargetRenderError::SdlError(e))?;
+                .map_err(TargetRenderError::SdlError)?;
             Ok(())
         } else {
             Err(TargetRenderError::NotSupported)
@@ -582,12 +582,12 @@ impl<T: RenderTarget> Canvas<T> {
             let target = unsafe { self.get_raw_target() };
             for &(ref texture, ref user_context) in textures {
                 unsafe { self.set_raw_target(texture.raw) }
-                    .map_err(|e| TargetRenderError::SdlError(e))?;
+                    .map_err(TargetRenderError::SdlError)?;
                 f(self, user_context);
             }
             // reset the target to its source
             unsafe { self.set_raw_target(target) }
-                .map_err(|e| TargetRenderError::SdlError(e))?;
+                .map_err(TargetRenderError::SdlError)?;
             Ok(())
         } else {
             Err(TargetRenderError::NotSupported)
@@ -1778,19 +1778,16 @@ impl InternalTexture {
         match format {
             PixelFormatEnum::YV12 |
             PixelFormatEnum::IYUV => {
-                match rect {
-                    Some(r) => {
-                        if r.x() % 2 != 0 {
-                            return Err(XMustBeMultipleOfTwoForFormat(r.x(), format));
-                        } else if r.y() % 2 != 0 {
-                            return Err(YMustBeMultipleOfTwoForFormat(r.y(), format));
-                        } else if r.width() % 2 != 0 {
-                            return Err(WidthMustBeMultipleOfTwoForFormat(r.width(), format));
-                        } else if r.height() % 2 != 0 {
-                            return Err(HeightMustBeMultipleOfTwoForFormat(r.height(), format));
-                        }
+                if let Some(r) = rect {
+                    if r.x() % 2 != 0 {
+                        return Err(XMustBeMultipleOfTwoForFormat(r.x(), format));
+                    } else if r.y() % 2 != 0 {
+                        return Err(YMustBeMultipleOfTwoForFormat(r.y(), format));
+                    } else if r.width() % 2 != 0 {
+                        return Err(WidthMustBeMultipleOfTwoForFormat(r.width(), format));
+                    } else if r.height() % 2 != 0 {
+                        return Err(HeightMustBeMultipleOfTwoForFormat(r.height(), format));
                     }
-                    _ => {}
                 };
                 if pitch % 2 != 0 {
                     return Err(PitchMustBeMultipleOfTwoForFormat(pitch, format));
@@ -1838,19 +1835,16 @@ impl InternalTexture {
             None => ptr::null(),
         };
 
-        match rect {
-            Some(ref r) => {
-                if r.x() % 2 != 0 {
-                    return Err(XMustBeMultipleOfTwoForFormat(r.x()));
-                } else if r.y() % 2 != 0 {
-                    return Err(YMustBeMultipleOfTwoForFormat(r.y()));
-                } else if r.width() % 2 != 0 {
-                    return Err(WidthMustBeMultipleOfTwoForFormat(r.width()));
-                } else if r.height() % 2 != 0 {
-                    return Err(HeightMustBeMultipleOfTwoForFormat(r.height()));
-                }
+        if let Some(ref r) = rect {
+            if r.x() % 2 != 0 {
+                return Err(XMustBeMultipleOfTwoForFormat(r.x()));
+            } else if r.y() % 2 != 0 {
+                return Err(YMustBeMultipleOfTwoForFormat(r.y()));
+            } else if r.width() % 2 != 0 {
+                return Err(WidthMustBeMultipleOfTwoForFormat(r.width()));
+            } else if r.height() % 2 != 0 {
+                return Err(HeightMustBeMultipleOfTwoForFormat(r.height()));
             }
-            _ => {}
         };
 
         // If the destination rectangle lies outside the texture boundaries,

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -203,14 +203,16 @@ macro_rules! subsystem {
         }
         unsafe impl Sync for $name {}
 
-        impl $name {
+        impl std::clone::Clone for $name {
             #[inline]
-            pub fn clone(&self) -> $name {
+            fn clone(&self) -> $name {
                 $name {
                     _subsystem_drop: self._subsystem_drop.clone()
                 }
             }
+        }
 
+        impl $name {
             /// Obtain an SDL context.
             #[inline]
             pub fn sdl(&self) -> Sdl {
@@ -328,9 +330,10 @@ pub fn get_error() -> String {
 
 pub fn set_error(err: &str) -> Result<(), NulError> {
     let c_string = CString::new(err)?;
-    Ok(unsafe {
+    unsafe {
         sys::SDL_SetError(c_string.as_ptr() as *const c_char);
-    })
+    }
+    Ok(())
 }
 
 pub fn set_error_from_code(err: Error) {

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -439,7 +439,7 @@ impl SurfaceRef {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clone_on_copy))]
+    #[allow(clippy::clone_on_copy)]
     pub fn fill_rects(&mut self, rects: &[Rect], color: pixels::Color) -> Result<(), String>
     {
         for rect in rects.iter() {

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -80,8 +80,8 @@ impl<'b, 'a> Drop for Timer<'b, 'a> {
 }
 
 extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> u32 {
+    let f = param as *mut std::boxed::Box<dyn std::ops::Fn() -> u32>;
     unsafe {
-        let f: *mut Box<dyn Fn() -> u32> = mem::transmute(param);
         (*f)()
     }
 }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1217,9 +1217,10 @@ impl Window {
 
     pub fn set_title(&mut self, title: &str) -> Result<(), NulError> {
         let title = CString::new(title)?;
-        Ok(unsafe {
+        unsafe {
             sys::SDL_SetWindowTitle(self.context.raw, title.as_ptr() as *const c_char);
-        })
+        }
+        Ok(())
     }
 
     pub fn title(&self) -> &str {
@@ -1286,9 +1287,10 @@ impl Window {
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
         let h = validate_int(height, "height")?;
-        Ok(unsafe {
-            sys::SDL_SetWindowSize(self.context.raw, w, h)
-        })
+        unsafe {
+            sys::SDL_SetWindowSize(self.context.raw, w, h);
+        }
+        Ok(())
     }
 
     pub fn size(&self) -> (u32, u32) {
@@ -1316,9 +1318,10 @@ impl Window {
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
         let h = validate_int(height, "height")?;
-        Ok(unsafe {
-            sys::SDL_SetWindowMinimumSize(self.context.raw, w, h)
-        })
+        unsafe {
+            sys::SDL_SetWindowMinimumSize(self.context.raw, w, h);
+        }
+        Ok(())
     }
 
     pub fn minimum_size(&self) -> (u32, u32) {
@@ -1332,9 +1335,10 @@ impl Window {
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
         let h = validate_int(height, "height")?;
-        Ok(unsafe {
-            sys::SDL_SetWindowMaximumSize(self.context.raw, w, h)
-        })
+        unsafe {
+            sys::SDL_SetWindowMaximumSize(self.context.raw, w, h);
+        }
+        Ok(())
     }
 
     pub fn maximum_size(&self) -> (u32, u32) {
@@ -1471,7 +1475,7 @@ impl Window {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    #[allow(clippy::type_complexity)]
     pub fn gamma_ramp(&self) -> Result<(Vec<u16>, Vec<u16>, Vec<u16>), String> {
         let mut red: Vec<u16> = vec![0; 256];
         let mut green: Vec<u16> = vec![0; 256];


### PR DESCRIPTION
Following up on #919, I fixed up the warnings from `clippy` lints as well.

- A lot of methods on "trivially copyable" small structs/enums had `self` by reference rather than value, which is less efficient. They can still be called the same way when taken by value.
- A few uses of unsafe `mem::transmute` could be replaced by safe `as` casts
- The `subsystem` macro actually implements the `Clone` trait rather than just a method named `clone`
- `clippy` is now an official component, so the `clippy::` namespace can be used instead of the `#[cfg_attr(feature = "cargo-clippy",  ...)]` guard
- Plus a few miscellaneous idiomatic style fixes