### PR TITLE
Fix cross compilation

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -355,7 +355,7 @@ fn link_sdl2(target_os: &str) {
                 println!("cargo:rustc-flags=-l SDL2_mixer");
             } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_mixer");
-            } else if target_os.contains("macos") {
+            } else if target_os.contains("darwin") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_mixer");
                 } else {
@@ -368,7 +368,7 @@ fn link_sdl2(target_os: &str) {
                 println!("cargo:rustc-flags=-l SDL2_image");
             } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_image");
-            } else if target_os.contains("macos") {
+            } else if target_os.contains("darwin") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_image");
                 } else {
@@ -381,7 +381,7 @@ fn link_sdl2(target_os: &str) {
                 println!("cargo:rustc-flags=-l SDL2_ttf");
             } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_ttf");
-            } else if target_os.contains("macos") {
+            } else if target_os.contains("darwin") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_ttf");
                 } else {
@@ -394,7 +394,7 @@ fn link_sdl2(target_os: &str) {
                 println!("cargo:rustc-flags=-l SDL2_gfx");
             } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_gfx");
-            } else if target_os.contains("macos") {
+            } else if target_os.contains("darwin") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_gfx");
                 } else {

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -351,11 +351,11 @@ fn link_sdl2(target_os: &str) {
     // -lSDL2_mixer can find it.
     #[cfg(all(not(feature = "use-pkgconfig"), not(feature = "static-link")))] {
         if cfg!(feature = "mixer") {
-            if cfg!(any(target_os="linux", target_os="freebsd", target_os="openbsd")) {
+            if target_os.contains("linux") || target_os.contains("freebsd") || target_os.contains("openbsd") {
                 println!("cargo:rustc-flags=-l SDL2_mixer");
-            } else if cfg!(target_os="windows") {
+            } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_mixer");
-            } else if cfg!(target_os="macos") {
+            } else if target_os.contains("macos") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_mixer");
                 } else {
@@ -364,11 +364,11 @@ fn link_sdl2(target_os: &str) {
             }
         }
         if cfg!(feature = "image") {
-            if cfg!(any(target_os="linux", target_os="freebsd", target_os="openbsd")) {
+            if target_os.contains("linux") || target_os.contains("freebsd") || target_os.contains("openbsd") {
                 println!("cargo:rustc-flags=-l SDL2_image");
-            } else if cfg!(target_os="windows") {
+            } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_image");
-            } else if cfg!(target_os="macos") {
+            } else if target_os.contains("macos") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_image");
                 } else {
@@ -377,11 +377,11 @@ fn link_sdl2(target_os: &str) {
             }
         }
         if cfg!(feature = "ttf") {
-            if cfg!(any(target_os="linux", target_os="freebsd", target_os="openbsd")) {
+            if target_os.contains("linux") || target_os.contains("freebsd") || target_os.contains("openbsd") {
                 println!("cargo:rustc-flags=-l SDL2_ttf");
-            } else if cfg!(target_os="windows") {
+            } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_ttf");
-            } else if cfg!(target_os="macos") {
+            } else if target_os.contains("macos") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_ttf");
                 } else {
@@ -390,11 +390,11 @@ fn link_sdl2(target_os: &str) {
             }
         }
         if cfg!(feature = "gfx") {
-            if cfg!(any(target_os="linux", target_os="freebsd", target_os="openbsd")) {
+            if target_os.contains("linux") || target_os.contains("freebsd") || target_os.contains("openbsd") {
                 println!("cargo:rustc-flags=-l SDL2_gfx");
-            } else if cfg!(target_os="windows") {
+            } else if target_os.contains("windows") {
                 println!("cargo:rustc-flags=-l SDL2_gfx");
-            } else if cfg!(target_os="macos") {
+            } else if target_os.contains("macos") {
                 if cfg!(any(mac_framework, feature="use_mac_framework")) {
                     println!("cargo:rustc-flags=-l framework=SDL2_gfx");
                 } else {


### PR DESCRIPTION
Remove cfg!(target_os="x") from build.rs

using the cfg macro breaks cross compilation. This is because the cfg
macro gets evaluated during compile time of the binary getting built. In
the case of build.rs, it gets built into it's own binary targeting the
local machine. (Which then gets run to evaluate build rules for the
primary project binary). So somewhat confusingly, the cfg(target_os..)
evaluates differently in build.rs than the rest of the project in the
case of cross compilation. Particularly for SDL, this is important for
targeting emscripten. The current build.rs breaks when trying to compile
for the web.