### PR TITLE
 Use the num-traits crate directly instead of num 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,7 @@ path       = "src/sdl2/lib.rs"
 bitflags = "^1"
 libc = "^0.2"
 lazy_static = "^1"
-
-[dependencies.num]
-version = "^0.1"
-default-features = false
+num-traits = "^0.2"
 
 [dependencies.sdl2-sys]
 path = "sdl2-sys"

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -53,7 +53,7 @@
 //! ```
 
 use std::ffi::{CStr, CString};
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use libc::{c_int, c_void, c_char};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
@@ -810,13 +810,13 @@ impl AudioCVT {
         //! the conversion in place; then it is passed to the SDL library.
         //!
         //! Certain conversions may cause buffer overflows. See AngryLawyer/rust-sdl2 issue #270.
-        use num::traits as num;
         unsafe {
             if self.raw.needed != 0 {
                 let mut raw = self.raw;
 
                 // calculate the size of the dst buffer
-                raw.len = num::cast(src.len()).expect("Buffer length overflow");
+                use std::convert::TryInto;
+                raw.len = src.len().try_into().expect("Buffer length overflow");
                 let dst_size = self.capacity(src.len());
                 let needed = dst_size - src.len();
                 src.reserve_exact(needed);

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -5,7 +5,7 @@ Event Handling
 use std::ffi::CStr;
 use std::mem;
 use libc::c_int;
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use std::ptr;
 use std::borrow::ToOwned;
 use std::iter::FromIterator;

--- a/src/sdl2/gfx/primitives.rs
+++ b/src/sdl2/gfx/primitives.rs
@@ -3,7 +3,7 @@
 use std::mem;
 use std::ptr;
 use std::ffi::CString;
-use num::traits::ToPrimitive;
+use std::convert::TryFrom;
 use libc::{c_int, c_char};
 use libc::c_void;
 use render::Canvas;
@@ -57,12 +57,12 @@ impl ToColor for u32 {
 impl ToColor for isize {
     #[inline]
     fn as_rgba(&self) -> (u8, u8, u8, u8) {
-        unsafe { mem::transmute(self.to_u32().expect("Can't convert to Color Type")) }
+        unsafe { mem::transmute(u32::try_from(*self).expect("Can't convert to Color Type")) }
     }
 
     #[inline]
     fn as_u32(&self) -> u32 {
-        self.to_u32().expect("Can't convert to Color Type")
+        u32::try_from(*self).expect("Can't convert to Color Type")
     }
 }
 

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -50,7 +50,7 @@
 
 #![allow(clippy::cast_lossless, clippy::transmute_ptr_to_ref)]
 
-extern crate num;
+extern crate num_traits;
 pub extern crate libc;
 
 #[macro_use]

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -1,4 +1,4 @@
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use std::mem::transmute;
 use std::convert::TryFrom;
 use crate::sys;

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -46,7 +46,7 @@ use libc::{c_int, c_double};
 use crate::rect::Point;
 use crate::rect::Rect;
 use std::ffi::CStr;
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use std::vec::Vec;
 use crate::common::{validate_int, IntegerOrSdlError};
 use std::mem::{transmute, MaybeUninit};

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -8,7 +8,7 @@ use crate::rect::Rect;
 use crate::get_error;
 use std::ptr;
 use libc::c_int;
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use crate::pixels;
 use crate::render::{BlendMode, Canvas};
 use crate::rwops::RWops;

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -11,7 +11,7 @@ use crate::surface::SurfaceRef;
 use crate::pixels::PixelFormatEnum;
 use crate::VideoSubsystem;
 use crate::EventPump;
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 use crate::common::{validate_int, IntegerOrSdlError};
 
 use crate::get_error;


### PR DESCRIPTION
I noticed that this crate uses only two features of `num-traits`:

1. `num::FromPrimitive` - used to convert raw integers to Rust enums. Is using an external library for this really necessary?
2. `num::ToPrimitive` - used to convert colors `isize` values to colors, replaced it with `std::convert::TryFrom`.
2. `num::traits::cast` - used in literally only one place, so I replaced it with `std::convert::TryInto`.

The `FromPrimitive` trait is located in the `num-traits` crate, so by depending on it instead of all of `num` I managed to reduce the total number of dependencies from 25 to 18. Also I took the opportunity and upgraded it from v0.1 to v0.2.

If using `num-traits` for `int <-> enum` conversions is an overkill in your opinion, I can also open a PR to remove it from dependencies altogether.