### PR TITLE
Fix compiler warnings

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -220,7 +220,7 @@ fn patch_sdl2(sdl2_source_path: &Path) {
             // ever have more than one hunk.
             assert!(added_file.len() == 1);
             let file_path = sdl2_source_path.join(added_file.path());
-            let mut dst_file = fs::File::create(&file_path)
+            let dst_file = fs::File::create(&file_path)
                 .expect(&format!(
                     "Failed to create file {}",
                     file_path.to_string_lossy()));

--- a/src/sdl2/gfx/framerate.rs
+++ b/src/sdl2/gfx/framerate.rs
@@ -1,7 +1,7 @@
 //! Framerate control
 
 use libc;
-use libc::{c_void, uint32_t, size_t};
+use libc::{c_void, size_t};
 use std::mem;
 use ::get_error;
 use sys::gfx;
@@ -24,7 +24,7 @@ impl FPSManager {
 
     /// Set the framerate in Hz.
     pub fn set_framerate(&mut self, rate: u32) -> Result<(), String> {
-        let ret = unsafe { gfx::framerate::SDL_setFramerate(self.raw, rate as uint32_t) };
+        let ret = unsafe { gfx::framerate::SDL_setFramerate(self.raw, rate as u32) };
         match ret {
             0 => Ok(()),
             _ => Err(get_error())

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -31,9 +31,9 @@ use get_error;
 use sys;
 use sys::image;
 
-/// InitFlags are passed to init() to control which subsystem
-/// functionality to load.
 bitflags! {
+    /// InitFlags are passed to init() to control which subsystem
+    /// functionality to load.
     pub struct InitFlag : u32 {
         const JPG  = image::IMG_InitFlags_IMG_INIT_JPG as u32;
         const PNG  = image::IMG_InitFlags_IMG_INIT_PNG as u32;

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -46,16 +46,16 @@ bitflags! {
 impl ::std::fmt::Display for InitFlag {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         if self.contains(InitFlag::JPG) {
-            try!(f.write_str("INIT_JPG "));
+            f.write_str("INIT_JPG ")?;
         }
         if self.contains(InitFlag::PNG) {
-            try!(f.write_str("INIT_PNG "));
+            f.write_str("INIT_PNG ")?;
         }
         if self.contains(InitFlag::TIF) {
-            try!(f.write_str("INIT_TIF "));
+            f.write_str("INIT_TIF ")?;
         }
         if self.contains(InitFlag::WEBP) {
-            try!(f.write_str("INIT_WEBP "));
+            f.write_str("INIT_WEBP ")?;
         }
         Ok(())
     }

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -28,7 +28,7 @@ use std::str::from_utf8;
 use std::borrow::ToOwned;
 use std::path::Path;
 use libc::c_void;
-use libc::{c_int, uint16_t, c_double, c_uint};
+use libc::{c_int, c_double, c_uint};
 use ::get_error;
 use ::rwops::RWops;
 use ::version::Version;
@@ -38,29 +38,27 @@ use sys::mixer;
 // This comes from SDL_audio.h
 #[allow(non_camel_case_types)]
 mod ll {
-    use libc::uint16_t;
-
-    pub const AUDIO_U8: uint16_t = 0x0008;
-    pub const AUDIO_S8: uint16_t = 0x8008;
-    pub const AUDIO_U16LSB: uint16_t = 0x0010;
-    pub const AUDIO_S16LSB: uint16_t = 0x8010;
-    pub const AUDIO_U16MSB: uint16_t = 0x1010;
-    pub const AUDIO_S16MSB: uint16_t = 0x9010;
-    pub const AUDIO_U16: uint16_t = AUDIO_U16LSB;
-    pub const AUDIO_S16: uint16_t = AUDIO_S16LSB;
-    pub const AUDIO_S32LSB: uint16_t = 0x8020;
-    pub const AUDIO_S32MSB: uint16_t = 0x9020;
-    pub const AUDIO_S32: uint16_t = AUDIO_S32LSB;
-    pub const AUDIO_F32LSB: uint16_t = 0x8120;
-    pub const AUDIO_F32MSB: uint16_t = 0x9120;
-    pub const AUDIO_F32: uint16_t = AUDIO_F32LSB;
-    pub const AUDIO_U16SYS: uint16_t = AUDIO_U16LSB;
-    pub const AUDIO_S16SYS: uint16_t = AUDIO_S16LSB;
-    pub const AUDIO_S32SYS: uint16_t = AUDIO_S32LSB;
-    pub const AUDIO_F32SYS: uint16_t = AUDIO_F32LSB;
+    pub const AUDIO_U8: u16 = 0x0008;
+    pub const AUDIO_S8: u16 = 0x8008;
+    pub const AUDIO_U16LSB: u16 = 0x0010;
+    pub const AUDIO_S16LSB: u16 = 0x8010;
+    pub const AUDIO_U16MSB: u16 = 0x1010;
+    pub const AUDIO_S16MSB: u16 = 0x9010;
+    pub const AUDIO_U16: u16 = AUDIO_U16LSB;
+    pub const AUDIO_S16: u16 = AUDIO_S16LSB;
+    pub const AUDIO_S32LSB: u16 = 0x8020;
+    pub const AUDIO_S32MSB: u16 = 0x9020;
+    pub const AUDIO_S32: u16 = AUDIO_S32LSB;
+    pub const AUDIO_F32LSB: u16 = 0x8120;
+    pub const AUDIO_F32MSB: u16 = 0x9120;
+    pub const AUDIO_F32: u16 = AUDIO_F32LSB;
+    pub const AUDIO_U16SYS: u16 = AUDIO_U16LSB;
+    pub const AUDIO_S16SYS: u16 = AUDIO_S16LSB;
+    pub const AUDIO_S32SYS: u16 = AUDIO_S32LSB;
+    pub const AUDIO_F32SYS: u16 = AUDIO_F32LSB;
 }
 
-pub type AudioFormat = uint16_t;
+pub type AudioFormat = u16;
 
 pub const AUDIO_U8: AudioFormat = ll::AUDIO_U8;
 pub const AUDIO_S8: AudioFormat = ll::AUDIO_S8;
@@ -196,7 +194,7 @@ pub fn close_audio() {
 /// Get the actual audio format in use by the opened audio device.
 pub fn query_spec() -> Result<(i32, AudioFormat, i32), String> {
     let mut frequency: c_int = 0;
-    let mut format: uint16_t = 0;
+    let mut format: u16 = 0;
     let mut channels: c_int = 0;
     let ret = unsafe { mixer::Mix_QuerySpec(&mut frequency, &mut format, &mut channels) };
     if ret == 0 {

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -239,7 +239,7 @@ impl Drop for Chunk {
 impl Chunk {
     /// Load file for use as a sample.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Chunk, String> {
-        let raw = unsafe { mixer::Mix_LoadWAV_RW(try!(RWops::from_file(path, "rb")).raw(), 0) };
+        let raw = unsafe { mixer::Mix_LoadWAV_RW(RWops::from_file(path, "rb")?.raw(), 0) };
         if raw.is_null() {
             Err(get_error())
         } else {

--- a/src/sdl2/ttf/context.rs
+++ b/src/sdl2/ttf/context.rs
@@ -96,7 +96,7 @@ impl error::Error for InitError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             InitError::AlreadyInitializedError => {
                 None

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -69,7 +69,7 @@ impl error::Error for FontError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             FontError::InvalidLatin1Text(ref error) => {
                 Some(error)

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -149,7 +149,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     /// for an explanation.
     pub fn solid<'b, T>(self, color: T )
             -> FontResult<Surface<'b>> where T: Into<Color> {
-        let source = try!(self.text.convert());
+        let source = self.text.convert()?;
         let color = color.into().into();
         let raw = unsafe {
             match self.text {
@@ -171,7 +171,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     /// for an explanation.
     pub fn shaded<'b, T>(self, color: T, background: T)
             -> FontResult<Surface<'b>> where T: Into<Color> {
-        let source = try!(self.text.convert());
+        let source = self.text.convert()?;
         let foreground = color.into().into();
         let background = background.into().into();
         let raw = unsafe {
@@ -194,7 +194,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     /// for an explanation.
     pub fn blended<'b, T>(self, color: T)
             -> FontResult<Surface<'b>> where T: Into<Color> {
-        let source = try!(self.text.convert());
+        let source = self.text.convert()?;
         let color = color.into().into();
         let raw = unsafe {
             match self.text {
@@ -217,7 +217,7 @@ impl<'f,'text> PartialRendering<'f,'text> {
     /// for an explanation of the mode.
     pub fn blended_wrapped<'b, T>(self, color: T, wrap_max_width: u32)
             -> FontResult<Surface<'b>> where T: Into<Color> {
-        let source = try!(self.text.convert());
+        let source = self.text.convert()?;
         let color = color.into().into();
         let raw = unsafe {
             match self.text {
@@ -334,7 +334,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the width and height of the given text when rendered using this
     /// font.
     pub fn size_of(&self, text: &str) -> FontResult<(u32, u32)> {
-        let c_string = try!(RenderableText::Utf8(text).convert());
+        let c_string = RenderableText::Utf8(text).convert()?;
         let (res, size) = unsafe {
             let mut w = 0; // mutated by C code
             let mut h = 0; // mutated by C code
@@ -353,7 +353,7 @@ impl<'ttf,'r> Font<'ttf,'r> {
     #[allow(unused_mut)]
     pub fn size_of_latin1(&self, text: &[u8])
         -> FontResult<(u32, u32)> {
-        let c_string = try!(RenderableText::Latin1(text).convert());
+        let c_string = RenderableText::Latin1(text).convert()?;
         let (res, size) = unsafe {
             let mut w : i32 = 0; // mutated by C code
             let mut h : i32 = 0; // mutated by C code


### PR DESCRIPTION
When compiling the project, different compiler warnings show up:

```
$ cargo build --features "bundled"            
   [...]
warning: variable does not need to be mutable
   --> sdl2-sys/build.rs:223:17
    |
223 |             let mut dst_file = fs::File::create(&file_path)
    |                 ----^^^^^^^^
    |                 |
    |                 help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
   [...]
```

and

```
$ cargo build --features "gfx image ttf mixer"
   [...]
warning: unused doc comment
  --> src/sdl2/image/mod.rs:34:1
   |
34 | / /// InitFlags are passed to init() to control which subsystem
35 | | /// functionality to load.
   | |__________________________^
36 | / bitflags! {
37 | |     pub struct InitFlag : u32 {
38 | |         const JPG  = image::IMG_InitFlags_IMG_INIT_JPG as u32;
39 | |         const PNG  = image::IMG_InitFlags_IMG_INIT_PNG as u32;
...  |
42 | |     }
43 | | }
   | |_- rustdoc does not generate documentation for macro expansions
   |
   = note: `#[warn(unused_doc_comments)]` on by default
   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:152:22
    |
152 |         let source = try!(self.text.convert());
    |                      ^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:174:22
    |
174 |         let source = try!(self.text.convert());
    |                      ^^^

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:197:22
    |
197 |         let source = try!(self.text.convert());
    |                      ^^^

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:220:22
    |
220 |         let source = try!(self.text.convert());
    |                      ^^^

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:337:24
    |
337 |         let c_string = try!(RenderableText::Utf8(text).convert());
    |                        ^^^

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/ttf/font.rs:356:24
    |
356 |         let c_string = try!(RenderableText::Latin1(text).convert());
    |                        ^^^

warning: use of deprecated item 'try': use the `?` operator instead
  --> src/sdl2/image/mod.rs:49:13
   |
49 |             try!(f.write_str("INIT_JPG "));
   |             ^^^

warning: use of deprecated item 'try': use the `?` operator instead
  --> src/sdl2/image/mod.rs:52:13
   |
52 |             try!(f.write_str("INIT_PNG "));
   |             ^^^

warning: use of deprecated item 'try': use the `?` operator instead
  --> src/sdl2/image/mod.rs:55:13
   |
55 |             try!(f.write_str("INIT_TIF "));
   |             ^^^

warning: use of deprecated item 'try': use the `?` operator instead
  --> src/sdl2/image/mod.rs:58:13
   |
58 |             try!(f.write_str("INIT_WEBP "));
   |             ^^^

warning: use of deprecated item 'try': use the `?` operator instead
   --> src/sdl2/mixer/mod.rs:242:50
    |
242 |         let raw = unsafe { mixer::Mix_LoadWAV_RW(try!(RWops::from_file(path, "rb")).raw(), 0) };
    |                                                  ^^^

warning: trait objects without an explicit `dyn` are deprecated
  --> src/sdl2/ttf/font.rs:72:32
   |
72 |     fn cause(&self) -> Option<&error::Error> {
   |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
   |
   = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
  --> src/sdl2/ttf/context.rs:99:32
   |
99 |     fn cause(&self) -> Option<&error::Error> {
   |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:31:19
   |
31 | use libc::{c_int, uint16_t, c_double, c_uint};
   |                   ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:63:24
   |
63 | pub type AudioFormat = uint16_t;
   |                        ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
   --> src/sdl2/mixer/mod.rs:199:21
    |
199 |     let mut format: uint16_t = 0;
    |                     ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:41:9
   |
41 |     use libc::uint16_t;
   |         ^^^^^^^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:43:25
   |
43 |     pub const AUDIO_U8: uint16_t = 0x0008;
   |                         ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:44:25
   |
44 |     pub const AUDIO_S8: uint16_t = 0x8008;
   |                         ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:45:29
   |
45 |     pub const AUDIO_U16LSB: uint16_t = 0x0010;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:46:29
   |
46 |     pub const AUDIO_S16LSB: uint16_t = 0x8010;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:47:29
   |
47 |     pub const AUDIO_U16MSB: uint16_t = 0x1010;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:48:29
   |
48 |     pub const AUDIO_S16MSB: uint16_t = 0x9010;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:49:26
   |
49 |     pub const AUDIO_U16: uint16_t = AUDIO_U16LSB;
   |                          ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:50:26
   |
50 |     pub const AUDIO_S16: uint16_t = AUDIO_S16LSB;
   |                          ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:51:29
   |
51 |     pub const AUDIO_S32LSB: uint16_t = 0x8020;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:52:29
   |
52 |     pub const AUDIO_S32MSB: uint16_t = 0x9020;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:53:26
   |
53 |     pub const AUDIO_S32: uint16_t = AUDIO_S32LSB;
   |                          ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:54:29
   |
54 |     pub const AUDIO_F32LSB: uint16_t = 0x8120;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:55:29
   |
55 |     pub const AUDIO_F32MSB: uint16_t = 0x9120;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:56:26
   |
56 |     pub const AUDIO_F32: uint16_t = AUDIO_F32LSB;
   |                          ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:57:29
   |
57 |     pub const AUDIO_U16SYS: uint16_t = AUDIO_U16LSB;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:58:29
   |
58 |     pub const AUDIO_S16SYS: uint16_t = AUDIO_S16LSB;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:59:29
   |
59 |     pub const AUDIO_S32SYS: uint16_t = AUDIO_S32LSB;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint16_t': Use u16 instead.
  --> src/sdl2/mixer/mod.rs:60:29
   |
60 |     pub const AUDIO_F32SYS: uint16_t = AUDIO_F32LSB;
   |                             ^^^^^^^^

warning: use of deprecated item 'libc::uint32_t': Use u32 instead.
 --> src/sdl2/gfx/framerate.rs:4:20
  |
4 | use libc::{c_void, uint32_t, size_t};
  |                    ^^^^^^^^

warning: use of deprecated item 'libc::uint32_t': Use u32 instead.
  --> src/sdl2/gfx/framerate.rs:27:79
   |
27 |         let ret = unsafe { gfx::framerate::SDL_setFramerate(self.raw, rate as uint32_t) };
   |                                                                               ^^^^^^^^
   [...]
```

This PR resolves all of them.