### PR TITLE
Constify some inlined functions

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -184,25 +184,25 @@ impl AudioFormat {
 #[cfg(target_endian = "little")]
 impl AudioFormat {
     /// Unsigned 16-bit samples, native endian
-    #[inline] pub fn u16_sys() -> AudioFormat { AudioFormat::U16LSB }
+    #[inline] pub const fn u16_sys() -> AudioFormat { AudioFormat::U16LSB }
     /// Signed 16-bit samples, native endian
-    #[inline] pub fn s16_sys() -> AudioFormat { AudioFormat::S16LSB }
+    #[inline] pub const fn s16_sys() -> AudioFormat { AudioFormat::S16LSB }
     /// Signed 32-bit samples, native endian
-    #[inline] pub fn s32_sys() -> AudioFormat { AudioFormat::S32LSB }
+    #[inline] pub const fn s32_sys() -> AudioFormat { AudioFormat::S32LSB }
     /// 32-bit floating point samples, native endian
-    #[inline] pub fn f32_sys() -> AudioFormat { AudioFormat::F32LSB }
+    #[inline] pub const fn f32_sys() -> AudioFormat { AudioFormat::F32LSB }
 }
 
 #[cfg(target_endian = "big")]
 impl AudioFormat {
     /// Unsigned 16-bit samples, native endian
-    #[inline] pub fn u16_sys() -> AudioFormat { AudioFormat::U16MSB }
+    #[inline] pub const fn u16_sys() -> AudioFormat { AudioFormat::U16MSB }
     /// Signed 16-bit samples, native endian
-    #[inline] pub fn s16_sys() -> AudioFormat { AudioFormat::S16MSB }
+    #[inline] pub const fn s16_sys() -> AudioFormat { AudioFormat::S16MSB }
     /// Signed 32-bit samples, native endian
-    #[inline] pub fn s32_sys() -> AudioFormat { AudioFormat::S32MSB }
+    #[inline] pub const fn s32_sys() -> AudioFormat { AudioFormat::S32MSB }
     /// 32-bit floating point samples, native endian
-    #[inline] pub fn f32_sys() -> AudioFormat { AudioFormat::F32MSB }
+    #[inline] pub const fn f32_sys() -> AudioFormat { AudioFormat::F32MSB }
 }
 
 #[repr(i32)]

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -136,7 +136,7 @@ pub struct Joystick {
 
 impl Joystick {
     #[inline]
-    pub fn subsystem(&self) -> &JoystickSubsystem { &self.subsystem }
+    pub const fn subsystem(&self) -> &JoystickSubsystem { &self.subsystem }
 
     /// Return the name of the joystick or an empty string if no name
     /// is found.

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_raw_accessors(
         $(
         impl $t {
             #[inline]
-            pub unsafe fn raw(&self) -> $raw { self.raw }
+            pub const unsafe fn raw(&self) -> $raw { self.raw }
         }
         )+
     )
@@ -14,7 +14,7 @@ macro_rules! impl_raw_constructor(
         $(
         impl $t {
             #[inline]
-            pub unsafe fn from_ll($($r:$rt),+) -> $t {
+            pub const unsafe fn from_ll($($r:$rt),+) -> $t {
                 $te { $($r: $r),+ }
             }
         }

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -102,13 +102,13 @@ pub struct Color {
 impl Color {
     #[inline]
     #[allow(non_snake_case)]
-    pub fn RGB(r: u8, g: u8, b: u8) -> Color {
+    pub const fn RGB(r: u8, g: u8, b: u8) -> Color {
         Color { r, g, b, a: 0xff }
     }
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn RGBA(r: u8, g: u8, b: u8, a: u8) -> Color {
+    pub const fn RGBA(r: u8, g: u8, b: u8, a: u8) -> Color {
         Color { r, g, b, a }
     }
 
@@ -126,18 +126,18 @@ impl Color {
     }
 
     #[inline]
-    pub fn rgb(self) -> (u8, u8, u8) {
+    pub const fn rgb(self) -> (u8, u8, u8) {
         (self.r, self.g, self.b)
     }
 
     #[inline]
-    pub fn rgba(self) -> (u8, u8, u8, u8) {
+    pub const fn rgba(self) -> (u8, u8, u8, u8) {
         (self.r, self.g, self.b, self.a)
     }
 
     // Implemented manually and kept private, because reasons
     #[inline]
-    fn raw(self) -> sys::SDL_Color {
+    const fn raw(self) -> sys::SDL_Color {
         sys::SDL_Color { r: self.r, g: self.g, b: self.b, a: self.a }
     }
 }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -884,7 +884,7 @@ impl<T> TextureCreator<T> {
     /// Create a texture from its raw `SDL_Texture`.
     #[cfg(not(feature = "unsafe_textures"))]
     #[inline]
-    pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
+    pub const unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture {
             raw,
             _marker: PhantomData,
@@ -893,7 +893,7 @@ impl<T> TextureCreator<T> {
 
     /// Create a texture from its raw `SDL_Texture`. Should be used with care.
     #[cfg(feature = "unsafe_textures")]
-    pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
+    pub const unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture {
             raw,
         }
@@ -2129,7 +2129,7 @@ impl<'r> Texture<'r> {
     }
 
     #[inline]
-    pub fn raw(&self) -> *mut sys::SDL_Texture {
+    pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw
     }
 }
@@ -2247,7 +2247,7 @@ impl<> Texture<> {
     }
 
     #[inline]
-    pub fn raw(&self) -> *mut sys::SDL_Texture {
+    pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw
     }
 }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -358,16 +358,16 @@ pub mod gl_attr {
 
     impl ContextFlags {
         #[inline]
-        pub fn has_debug(&self) -> bool { self.flags & 0x0001 != 0 }
+        pub const fn has_debug(&self) -> bool { self.flags & 0x0001 != 0 }
 
         #[inline]
-        pub fn has_forward_compatible(&self) -> bool { self.flags & 0x0002 != 0 }
+        pub const fn has_forward_compatible(&self) -> bool { self.flags & 0x0002 != 0 }
 
         #[inline]
-        pub fn has_robust_access(&self) -> bool { self.flags & 0x0004 != 0 }
+        pub const fn has_robust_access(&self) -> bool { self.flags & 0x0004 != 0 }
 
         #[inline]
-        pub fn has_reset_isolation(&self) -> bool { self.flags & 0x0008 != 0 }
+        pub const fn has_reset_isolation(&self) -> bool { self.flags & 0x0008 != 0 }
     }
 
     impl<'a> GLAttr<'a> {
@@ -1076,7 +1076,7 @@ impl Window {
 
     #[inline]
     /// Create a new `Window` without taking ownership of the `WindowContext`
-    pub unsafe fn from_ref(context: Rc<WindowContext>) -> Window {
+    pub const unsafe fn from_ref(context: Rc<WindowContext>) -> Window {
         Window { context }
     }
 


### PR DESCRIPTION
Right now it's not possible to create a color in a constant context using: https://github.com/Rust-SDL2/rust-sdl2/blob/e865c8f4643e7f333c94e2cff8abd9497736ca4b/src/sdl2/pixels.rs#L103-L107

This PR changes functions marked with `#[inline]` to be constant, where possible.

What do you think?