### PR TITLE
Fix error building on Windows w/ 2019 Build Tools.

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -126,6 +126,7 @@ fn patch_sdl2(sdl2_source_path: &Path) {
     let patches: Vec<(&str, &'static str)> = vec![
         // No patches at this time. If needed, add them like this:
         // ("SDL-2.x.y-filename.patch", include_str!("patches/SDL-2.x.y-filename.patch")),
+        ("SDL2-2.0.9-CMakeLists.txt.patch", include_str!("patches/SDL2-2.0.9-CMakeLists.txt.patch")),
     ];
     let sdl_version = format!("SDL2-{}", LASTEST_SDL2_VERSION);
 

--- a/sdl2-sys/patches/SDL2-2.0.9-CMakeLists.txt.patch
+++ b/sdl2-sys/patches/SDL2-2.0.9-CMakeLists.txt.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt	2018-10-31 08:07:22.000000000 -0700
++++ CMakeLists.txt	2019-12-04 21:50:07.606700200 -0800
+@@ -1292,7 +1292,7 @@
+   endif()
+ 
+   # Libraries for Win32 native and MinGW
+-  list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32)
++  list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32 vcruntime)
+ 
+   # TODO: in configure.in the check for timers is set on
+   # cygwin | mingw32* - does this include mingw32CE?


### PR DESCRIPTION
When building on Windows with Visual Studio Build Tools 2019 using the `bundled` feature, I get this error:
```error LNK2019: unresolved external symbol memset referenced in function SDL_vsnprintf_REAL```

This [Stack Overflow](https://stackoverflow.com/questions/58288692/cant-build-solution-in-release-mode-for-sdl-library-on-vs-2019) provides a solution that works if I manually patch `CMakeLists.txt`.

This PR leverages the patching functionality of the `bundled` feature to automatically make this change as part of the build.