### PR TITLE
Joy/controller Events all have `which` member of type u32

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -986,7 +986,7 @@ impl Event {
                 let event = sys::SDL_JoyAxisEvent {
                     type_: SDL_EventType::SDL_JOYAXISMOTION as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     axis: axis_idx,
                     value,
                     padding1: 0,
@@ -1010,7 +1010,7 @@ impl Event {
                 let event = sys::SDL_JoyBallEvent {
                     type_: SDL_EventType::SDL_JOYBALLMOTION as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     ball: ball_idx,
                     xrel,
                     yrel,
@@ -1034,7 +1034,7 @@ impl Event {
                 let event = sys::SDL_JoyHatEvent {
                     type_: SDL_EventType::SDL_JOYHATMOTION as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     hat: hat_idx,
                     value: hatvalue,
                     padding1: 0,
@@ -1054,7 +1054,7 @@ impl Event {
                 let event = sys::SDL_JoyButtonEvent {
                     type_: SDL_EventType::SDL_JOYBUTTONDOWN as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     button: button_idx,
                     state: sys::SDL_PRESSED as u8,
                     padding1: 0,
@@ -1075,7 +1075,7 @@ impl Event {
                 let event = sys::SDL_JoyButtonEvent {
                     type_: SDL_EventType::SDL_JOYBUTTONUP as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     button: button_idx,
                     state: sys::SDL_RELEASED as u8,
                     padding1: 0,
@@ -1110,7 +1110,7 @@ impl Event {
                 let event = sys::SDL_JoyDeviceEvent {
                     type_: SDL_EventType::SDL_JOYDEVICEREMOVED as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                 };
                 unsafe {
                     ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_JoyDeviceEvent, 1);
@@ -1128,7 +1128,7 @@ impl Event {
                 let event = sys::SDL_ControllerAxisEvent {
                     type_: SDL_EventType::SDL_CONTROLLERAXISMOTION as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     axis: axisval as u8,
                     value,
                     padding1: 0,
@@ -1150,7 +1150,7 @@ impl Event {
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONDOWN as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     // This conversion turns an i32 into a u8; signed-to-unsigned conversions
                     // are a bit of a code smell, but that appears to be how SDL defines it.
                     button: buttonval as u8,
@@ -1173,7 +1173,7 @@ impl Event {
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONUP as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                     button: buttonval as u8,
                     state: sys::SDL_RELEASED as u8,
                     padding1: 0,
@@ -1208,7 +1208,7 @@ impl Event {
                 let event = sys::SDL_ControllerDeviceEvent {
                     type_: SDL_EventType::SDL_CONTROLLERDEVICEREMOVED as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                 };
                 unsafe {
                     ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerDeviceEvent, 1);
@@ -1224,7 +1224,7 @@ impl Event {
                 let event = sys::SDL_ControllerDeviceEvent {
                     type_: SDL_EventType::SDL_CONTROLLERDEVICEREMAPPED as u32,
                     timestamp,
-                    which,
+                    which: which as i32,
                 };
                 unsafe {
                     ptr::copy(&event, ret.as_mut_ptr() as *mut sys::SDL_ControllerDeviceEvent, 1);
@@ -1361,7 +1361,7 @@ impl Event {
                 Event::MouseMotion {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    which: event.which,
+                    which: event.which as u32,
                     mousestate: mouse::MouseState::from_sdl_state(event.state),
                     x: event.x,
                     y: event.y,
@@ -1375,7 +1375,7 @@ impl Event {
                 Event::MouseButtonDown {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    which: event.which,
+                    which: event.which as u32,
                     mouse_btn: mouse::MouseButton::from_ll(event.button),
                     clicks: event.clicks,
                     x: event.x,
@@ -1388,7 +1388,7 @@ impl Event {
                 Event::MouseButtonUp {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    which: event.which,
+                    which: event.which as u32,
                     mouse_btn: mouse::MouseButton::from_ll(event.button),
                     clicks: event.clicks,
                     x: event.x,
@@ -1401,7 +1401,7 @@ impl Event {
                 Event::MouseWheel {
                     timestamp: event.timestamp,
                     window_id: event.windowID,
-                    which: event.which,
+                    which: event.which as u32,
                     x: event.x,
                     y: event.y,
                     direction: mouse::MouseWheelDirection::from_ll(event.direction),
@@ -1412,7 +1412,7 @@ impl Event {
                 let event = raw.jaxis;
                 Event::JoyAxisMotion {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     axis_idx: event.axis,
                     value: event.value
                 }
@@ -1421,7 +1421,7 @@ impl Event {
                 let event = raw.jball;
                 Event::JoyBallMotion {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     ball_idx: event.ball,
                     xrel: event.xrel,
                     yrel: event.yrel
@@ -1431,7 +1431,7 @@ impl Event {
                 let event = raw.jhat;
                 Event::JoyHatMotion {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     hat_idx: event.hat,
                     state: joystick::HatState::from_raw(event.value),
                 }
@@ -1440,7 +1440,7 @@ impl Event {
                 let event = raw.jbutton;
                 Event::JoyButtonDown {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     button_idx: event.button
                 }
             }
@@ -1448,7 +1448,7 @@ impl Event {
                 let event = raw.jbutton;
                 Event::JoyButtonUp {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     button_idx: event.button
                 }
             }
@@ -1456,14 +1456,14 @@ impl Event {
                 let event = raw.jdevice;
                 Event::JoyDeviceAdded {
                     timestamp: event.timestamp,
-                    which: event.which as i32
+                    which: event.which as u32,
                 }
             }
             EventType::JoyDeviceRemoved => {
                 let event = raw.jdevice;
                 Event::JoyDeviceRemoved {
                     timestamp: event.timestamp,
-                    which: event.which
+                    which: event.which as u32,
                 }
             }
 
@@ -1473,7 +1473,7 @@ impl Event {
 
                 Event::ControllerAxisMotion {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     axis,
                     value: event.value
                 }
@@ -1484,7 +1484,7 @@ impl Event {
 
                 Event::ControllerButtonDown {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     button
                 }
             }
@@ -1494,7 +1494,7 @@ impl Event {
 
                 Event::ControllerButtonUp {
                     timestamp: event.timestamp,
-                    which: event.which,
+                    which: event.which as u32,
                     button
                 }
             }
@@ -1502,21 +1502,21 @@ impl Event {
                 let event = raw.cdevice;
                 Event::ControllerDeviceAdded {
                     timestamp: event.timestamp,
-                    which: event.which as i32
+                    which: event.which as u32,
                 }
             }
             EventType::ControllerDeviceRemoved => {
                 let event = raw.cdevice;
                 Event::ControllerDeviceRemoved {
                     timestamp: event.timestamp,
-                    which: event.which
+                    which: event.which as u32,
                 }
             }
             EventType::ControllerDeviceRemapped => {
                 let event = raw.cdevice;
                 Event::ControllerDeviceRemapped {
                     timestamp: event.timestamp,
-                    which: event.which
+                    which: event.which as u32,
                 }
             }
 

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -539,7 +539,7 @@ pub enum Event {
     JoyAxisMotion {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32,
+        which: u32,
         axis_idx: u8,
         value: i16
     },
@@ -547,7 +547,7 @@ pub enum Event {
     JoyBallMotion {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32,
+        which: u32,
         ball_idx: u8,
         xrel: i16,
         yrel: i16
@@ -556,7 +556,7 @@ pub enum Event {
     JoyHatMotion {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32,
+        which: u32,
         hat_idx: u8,
         state: HatState
     },
@@ -564,31 +564,31 @@ pub enum Event {
     JoyButtonDown {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32,
+        which: u32,
         button_idx: u8
     },
     JoyButtonUp {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32,
+        which: u32,
         button_idx: u8
     },
 
     JoyDeviceAdded {
         timestamp: u32,
         /// The newly added joystick's `joystick_index`
-        which: i32
+        which: u32
     },
     JoyDeviceRemoved {
         timestamp: u32,
         /// The joystick's `id`
-        which: i32
+        which: u32
     },
 
     ControllerAxisMotion {
         timestamp: u32,
         /// The controller's joystick `id`
-        which: i32,
+        which: u32,
         axis: Axis,
         value: i16
     },
@@ -596,30 +596,30 @@ pub enum Event {
     ControllerButtonDown {
         timestamp: u32,
         /// The controller's joystick `id`
-        which: i32,
+        which: u32,
         button: Button
     },
     ControllerButtonUp {
         timestamp: u32,
         /// The controller's joystick `id`
-        which: i32,
+        which: u32,
         button: Button
     },
 
     ControllerDeviceAdded {
         timestamp: u32,
         /// The newly added controller's `joystick_index`
-        which: i32
+        which: u32
     },
     ControllerDeviceRemoved {
         timestamp: u32,
         /// The controller's joystick `id`
-        which: i32
+        which: u32
     },
     ControllerDeviceRemapped {
         timestamp: u32,
         /// The controller's joystick `id`
-        which: i32
+        which: u32
     },
 
     FingerDown {


### PR DESCRIPTION
Some were i32, others (for mouse) were u32. It cannot be negative because it's not an error variable, so it's always positive and thus safe to use u32 here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-sdl2/rust-sdl2/955)
<!-- Reviewable:end -->
