### PR TITLE
Fix build with mingw

### DIFF
--- a/sdl2-sys/patches/SDL2-2.0.9-CMakeLists.txt.patch
+++ b/sdl2-sys/patches/SDL2-2.0.9-CMakeLists.txt.patch
@@ -1,11 +1,13 @@
 --- CMakeLists.txt	2018-10-31 08:07:22.000000000 -0700
 +++ CMakeLists.txt	2019-12-04 21:50:07.606700200 -0800
-@@ -1292,7 +1292,7 @@
-   endif()
- 
+@@ -1294,6 +1294,10 @@
    # Libraries for Win32 native and MinGW
--  list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32)
-+  list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32 vcruntime)
- 
+   list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32)
+
++  if(MSVC AND NOT ${MSVC_VERSION} LESS 1920)
++    list(APPEND EXTRA_LIBS vcruntime)
++  endif()
++
    # TODO: in configure.in the check for timers is set on
    # cygwin | mingw32* - does this include mingw32CE?
+   if(SDL_TIMERS)


### PR DESCRIPTION
This fixes #953 (regression of #951). I tested with x86_64-pc-windows-msvc (VS2019) and x86_64-pc-windows-gnu and both seem to work now. It should also work with VS2017 but I can't test it.