### PR TITLE
Remove num-traits altogether

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ path       = "src/sdl2/lib.rs"
 bitflags = "^1"
 libc = "^0.2"
 lazy_static = "^1"
-num-traits = "^0.2"
 
 [dependencies.sdl2-sys]
 path = "sdl2-sys"

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -50,7 +50,6 @@
 
 #![allow(clippy::cast_lossless, clippy::transmute_ptr_to_ref)]
 
-extern crate num_traits;
 pub extern crate libc;
 
 #[macro_use]

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -8,7 +8,7 @@ use crate::rect::Rect;
 use crate::get_error;
 use std::ptr;
 use libc::c_int;
-use num_traits::FromPrimitive;
+use std::convert::TryFrom;
 use crate::pixels;
 use crate::render::{BlendMode, Canvas};
 use crate::rwops::RWops;
@@ -495,7 +495,7 @@ impl SurfaceRef {
         };
 
         match result {
-            0 => FromPrimitive::from_i32(mode as i32).unwrap(),
+            0 => BlendMode::try_from(mode as u32).unwrap(),
             // Should only fail on a null Surface
             _ => panic!(get_error())
         }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -4,6 +4,7 @@ use std::{mem, ptr, fmt};
 use std::rc::Rc;
 use std::error::Error;
 use std::ops::{Deref, DerefMut};
+use std::convert::TryFrom;
 
 use crate::rect::Rect;
 use crate::render::CanvasBuilder;
@@ -11,7 +12,6 @@ use crate::surface::SurfaceRef;
 use crate::pixels::PixelFormatEnum;
 use crate::VideoSubsystem;
 use crate::EventPump;
-use num_traits::FromPrimitive;
 use crate::common::{validate_int, IntegerOrSdlError};
 
 use crate::get_error;
@@ -436,7 +436,7 @@ impl DisplayMode {
 
     pub fn from_ll(raw: &sys::SDL_DisplayMode) -> DisplayMode {
         DisplayMode::new(
-            PixelFormatEnum::from_u32(raw.format as u32).unwrap_or(PixelFormatEnum::Unknown),
+            PixelFormatEnum::try_from(raw.format as u32).unwrap_or(PixelFormatEnum::Unknown),
             raw.w as i32,
             raw.h as i32,
             raw.refresh_rate as i32
@@ -1206,7 +1206,7 @@ impl Window {
     }
 
     pub fn window_pixel_format(&self) -> PixelFormatEnum {
-        unsafe{ FromPrimitive::from_u64(sys::SDL_GetWindowPixelFormat(self.context.raw) as u64).unwrap() }
+        unsafe{ PixelFormatEnum::try_from(sys::SDL_GetWindowPixelFormat(self.context.raw) as u32).unwrap() }
     }
 
     pub fn window_flags(&self) -> u32 {


### PR DESCRIPTION
I replaced every occurrence of `FromPrimitive` with `TryFrom` with `()` as the error type.

I also noticed a recurring pattern of casting C enums to uints and then converting uints to Rust enums, perhaps this can be avoided by adding `From`/`TryFrom` traits for converting C enums directly to Rust ones? And some `TryFrom` implementations can be converted to `From` by assuming default values, e.g. `PixelFormatEnum::Unknown` when the pixel format is unknown.