### PR TITLE
Print Out SDL2 Include Directory in sdl2-sys Build Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,19 @@ If you don't have pkg-config or disabled the feature, it will try to get the hea
 If somehow you have your own headers that you want to use (use a beta version, an older version, ...),
 you can set the environment variable "SDL2_INCLUDE_PATH" and those headers will be used by bindgen instead.
 
+# Using sdl2-sys to provide SDL2 headers/library
+
+If you are creating a `*-sys` crate for a library which requires SDL2, you can use `sdl2-sys` to provide both the compiled library
+and the headers for SDL2. 
+
+Follow the following process to get the header directory. In the `Cargo.toml` for your crate, add `sdl2-sys` as a dependency (not a build-dependency).
+Cargo will then provide your build script with an environment variable `DEP_SDL2_INCLUDE` which is populated with the include directory for SDL2.
+If there is more than one directory, they are combined with `:` as a separator. Pass these directories to whatever is building your C/C++.
+
+Once everything is linked together, there will be a single copy of SDL2 (the one provided by `sdl2-sys`) for all C, C++, and Rust code.
+
+For more discussion see the corresponding [issue][dep-sdl2-include-issue]
+
 # OpenGL
 
 If you want to use OpenGL, you also need the
@@ -589,5 +602,6 @@ Any Pull Request is welcome, however small your contribution may be ! There are,
 [homebrew]: http://brew.sh/
 [crates]: http://crates.io/
 [examples]: https://github.com/jdeseno/rs-sdl2-examples
+[dep-sdl2-include-issue]: https://github.com/Rust-SDL2/rust-sdl2/pull/968
 [gl-rs]: https://github.com/bjz/gl-rs
 [pdev-issue]: https://github.com/PistonDevelopers/rust-empty/issues/175

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### unreleased
+
+[PR #968](https://github.com/Rust-SDL2/rust-sdl2/pull/968)
+Pass SDL2 include directories to `sdl2-sys`'s dependant crates through `DEP_SDL2_INCLUDE`.
+
 ### v0.33
 
 [PR #956](https://github.com/Rust-SDL2/rust-sdl2/pull/956) + [PR #960](https://github.com/Rust-SDL2/rust-sdl2/pull/960) + [PR #951](https://github.com/Rust-SDL2/rust-sdl2/pull/951):

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -36,6 +36,13 @@ macro_rules! add_msvc_includes_to_bindings {
     };
 }
 
+fn get_bundled_header_path() -> PathBuf {
+    let mut include_path: PathBuf = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    include_path.push(format!("SDL2-{}", SDL2_HEADERS_BUNDLED_VERSION));
+    include_path.push("include");
+    include_path
+}
+
 #[cfg(feature = "bundled")]
 fn run_command(cmd: &str, args: &[&str]) {
     use std::process::Command;
@@ -464,8 +471,6 @@ fn main() {
         let sdl2_downloaded_include_path = sdl2_source_path.join("include");
         let sdl2_compiled_lib_path = sdl2_compiled_path.join("lib");
 
-        println!("cargo:include={}", sdl2_downloaded_include_path.display());
-
         println!("cargo:rustc-link-search={}", sdl2_compiled_lib_path.display());
         
         #[cfg(feature = "bindgen")] {
@@ -473,16 +478,19 @@ fn main() {
             println!("cargo:include={}", include_paths.join(":"));
             generate_bindings(target.as_str(), host.as_str(), include_paths.as_slice())
         }
+        #[cfg(not(feature = "bindgen"))] {
+            println!("cargo:include={}", sdl2_downloaded_include_path.display());
+        }
     };
 
     #[cfg(all(not(feature = "bundled"), feature = "bindgen"))] {
         let include_paths: Vec<String> = compute_include_paths();
-        println!("cargo:include={}", include_paths.join(":"));
         generate_bindings(target.as_str(), host.as_str(), include_paths.as_slice())
     }
 
     #[cfg(not(feature = "bindgen"))] {
         copy_pregenerated_bindings();
+        println!("cargo:include={}", get_bundled_header_path().display());
     }
 
     link_sdl2(target_os);
@@ -530,7 +538,7 @@ fn copy_pregenerated_bindings() {
 #[cfg(feature = "bindgen")]
 // headers_path is a list of directories where the SDL2 headers are expected
 // to be found by bindgen (should point to the include/ directories)
-fn generate_bindings<S: AsRef<str> + ::std::fmt::Debug>(target: &str, host: &str, headers_paths: &[S]) {
+fn generate_bindings(target: &str, host: &str, headers_paths: &[String]) {
     let target_os = get_os_from_triple(target).unwrap();
     let mut bindings = bindgen::Builder::default()
         // enable no_std-friendly output by only using core definitions
@@ -604,9 +612,9 @@ fn generate_bindings<S: AsRef<str> + ::std::fmt::Debug>(target: &str, host: &str
 
     if headers_paths.len() == 0 {
         // if no paths are being provided, fall back to the headers included in this repo
-        let mut include_path: PathBuf = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-        include_path.push(format!("SDL2-{}", SDL2_HEADERS_BUNDLED_VERSION));
-        include_path.push("include");
+        let include_path = get_bundled_header_path();
+        println!("cargo:include={}", include_path.display());
+
         bindings = bindings.clang_arg(format!("-I{}", include_path.display()));
         if cfg!(feature = "image") {
             image_bindings = image_bindings.clang_arg(format!("-I{}", include_path.display()));
@@ -625,22 +633,23 @@ fn generate_bindings<S: AsRef<str> + ::std::fmt::Debug>(target: &str, host: &str
         }
     } else {
         // if paths are included, use them for bindgen. Bindgen should use the first one.
+        println!("cargo:include={}", headers_paths.join(":"));
         for headers_path in headers_paths {
-            bindings = bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
+            bindings = bindings.clang_arg(format!("-I{}", headers_path));
             if cfg!(feature = "image") {
-                image_bindings = image_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
+                image_bindings = image_bindings.clang_arg(format!("-I{}", headers_path));
             }
             if cfg!(feature = "ttf") {
-                ttf_bindings = ttf_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
+                ttf_bindings = ttf_bindings.clang_arg(format!("-I{}", headers_path));
             }
             if cfg!(feature = "mixer") {
-                mixer_bindings = mixer_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
+                mixer_bindings = mixer_bindings.clang_arg(format!("-I{}", headers_path));
             }
             if cfg!(feature = "gfx") {
-                gfx_framerate_bindings = gfx_framerate_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
-                gfx_primitives_bindings = gfx_primitives_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
-                gfx_imagefilter_bindings = gfx_imagefilter_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
-                gfx_rotozoom_bindings = gfx_rotozoom_bindings.clang_arg(format!("-I{}", headers_path.as_ref()));
+                gfx_framerate_bindings = gfx_framerate_bindings.clang_arg(format!("-I{}", headers_path));
+                gfx_primitives_bindings = gfx_primitives_bindings.clang_arg(format!("-I{}", headers_path));
+                gfx_imagefilter_bindings = gfx_imagefilter_bindings.clang_arg(format!("-I{}", headers_path));
+                gfx_rotozoom_bindings = gfx_rotozoom_bindings.clang_arg(format!("-I{}", headers_path));
             }
         }
     }

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -464,16 +464,20 @@ fn main() {
         let sdl2_downloaded_include_path = sdl2_source_path.join("include");
         let sdl2_compiled_lib_path = sdl2_compiled_path.join("lib");
 
+        println!("cargo:include={}", sdl2_downloaded_include_path.display());
+
         println!("cargo:rustc-link-search={}", sdl2_compiled_lib_path.display());
         
         #[cfg(feature = "bindgen")] {
             let include_paths = vec!(String::from(sdl2_downloaded_include_path.to_str().unwrap()));
+            println!("cargo:include={}", include_paths.join(":"));
             generate_bindings(target.as_str(), host.as_str(), include_paths.as_slice())
         }
     };
 
     #[cfg(all(not(feature = "bundled"), feature = "bindgen"))] {
         let include_paths: Vec<String> = compute_include_paths();
+        println!("cargo:include={}", include_paths.join(":"));
         generate_bindings(target.as_str(), host.as_str(), include_paths.as_slice())
     }
 


### PR DESCRIPTION
In order to facilitate using the includes provided/found by `sdl2-sys` in other `*-sys` crates, I have added print statements which set the "include" key to the path to the include folder that has either been provided or found.

This can be accessed through the environment variable `DEP_SDL2_INCLUDE` in all crate build scripts which _directly_ depend on `sdl2-sys`, transitives are not affected. 

If there are multiple include directories, they are separated by a `:`.

A use case can be found [here](https://github.com/BVE-Reborn/bve-reborn/blob/b3114b5a0a77ce779f8880b41c2c1f83b314b4d6/bve-rex-sys/build.rs#L132) where I must pass the header directory to `cc` to build c++ code which depends on SDL2.

I have tried to make as few changes as possible to the build script, however I did make two changes that shouldn't affect the usability of it at all:
- I factored the retrieval of the bundled header path into it's own function, so it can be called in two places.
- I changed `generate_bindings` to no longer be generic, as every single instance was being called with `S = String`. This started because I wanted to use `.join(":")` on the slice, but that requires something that is `Borrow<str>` not `AsRef<str>`. As borrow is a newer feature, I didn't know your minimum rustc version, and all invocations were with `String`, I just went ahead and removed the generic.

All of the particulars about the PR can be changed if needed to fit style, usability, etc. I have verified that my own fork works as expected for downstream crates.

It might be worthwhile to add this to documentation as well, though I don't know if that is deserving of its own PR.

Closes #967 