### PR TITLE
Provide memory buffer -> mixer Chunk conversion methods

### DIFF
--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -232,10 +232,9 @@ impl Drop for Chunk {
     fn drop(&mut self) {
         if self.owned {
             unsafe {
-                // Mix_QuickLoad_* functions don't set the allocated flag, but
-                // from_wav_buffer and from_raw_buffer *do* take ownership of the data,
-                // so we need to deallocate the buffers here, because Mix_FreeChunk won't
-                // and we'd be leaking memory otherwise.
+                // Mix_QuickLoad_* functions don't set the allocated flag, but from_raw_buffer
+                // *does* take ownership of the data, so we need to deallocate the buffers here,
+                // because Mix_FreeChunk won't and we'd be leaking memory otherwise.
                 if (*self.raw).allocated == 0 {
                     drop(Box::from_raw((*self.raw).abuf));
                 }
@@ -249,13 +248,6 @@ impl Chunk {
     /// Load file for use as a sample.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Chunk, String> {
         let raw = unsafe { mixer::Mix_LoadWAV_RW(RWops::from_file(path, "rb")?.raw(), 0) };
-        Self::from_owned_raw(raw)
-    }
-
-    /// Get chunk based on a buffer containing WAV data in the mixer format. The chunk takes
-    /// ownership of the buffer.
-    pub fn from_wav_buffer(buffer: Box<[u8]>) -> Result<Chunk, String> {
-        let raw = unsafe { mixer::Mix_QuickLoad_WAV(Box::into_raw(buffer) as *mut u8) };
         Self::from_owned_raw(raw)
     }
 


### PR DESCRIPTION
This basically provides an API to access Mix_QuickLoad_WAV and
Mix_QuickLoad_RAW with one caveat – thie API takes ownership of the
buffers, while Mix_QuickLoad_* functions don't. Since Rust-SDL2 wraps
Mix_Chunks in its own structure with its own buffer ownership flag it's
easy to work around that and deallocate the buffer when Chunk is
dropped.

There are few design considerations here:

* Taking ownership of the buffer. I couldn't come up with a way to
  get a Chunk based on a buffer while still keeping the code safe and
  making sure that as long as Chunk is alive the buffer is also alive
  *and* not making the change be terribly involved and disruptive
* What's the best way to take an ownership of a buffer passed as a
  parameter? I came up with Box<[T]> as it seems universal enough,
  but I expect a more idiomatic Rust way may exist.

I modified the mixer demo to show how the API is used, a beep is
generated when no sound file is passed to the example.