### PR TITLE
Add support for SDL_GL_CONTEXT_NO_ERROR.

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -294,7 +294,7 @@ pub mod gl_attr {
             "OpenGL context sharing; defaults to false"),
 
         (SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, set_framebuffer_srgb_compatible, framebuffer_srgb_compatible, bool,
-            "requests sRGB capable visual; defaults to false (>= SDL 2.0.1)")
+            "requests sRGB capable visual; defaults to false (>= SDL 2.0.1)"),
 
         (SDL_GL_CONTEXT_NO_ERROR, set_context_no_error, context_no_error, bool,
             "disables OpenGL error checking; defaults to false (>= SDL 2.0.6)")

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -295,6 +295,9 @@ pub mod gl_attr {
 
         (SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, set_framebuffer_srgb_compatible, framebuffer_srgb_compatible, bool,
             "requests sRGB capable visual; defaults to false (>= SDL 2.0.1)")
+
+        (SDL_GL_CONTEXT_NO_ERROR, set_context_no_error, context_no_error, bool,
+            "disables OpenGL error checking; defaults to false (>= SDL 2.0.6)")
     }
 
     /// **Sets** the OpenGL context major and minor versions.


### PR DESCRIPTION
Allows graphics drivers to run with reduced overhead.

[https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_no_error.txt](https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_no_error.txt)

>
    With this extension enabled any behavior that generates a GL error will
    have undefined behavior.  The reason this extension exists is performance
    can be increased and power usage decreased.  When this mode is used, a GL
    driver can have undefined behavior where it would have generated a GL error
    without this extension.  This could include application termination.  In
    general this extension should be used after you have verified all the GL
    errors are removed, and an application is not the kind that would check
    for GL errors and adjust behavior based on those errors.

I hope this file is all I needed to modify :crossed_fingers: 