### PR TITLE
Feature: Added support for loading Opus format sound files in mixer

### DIFF
--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -103,6 +103,7 @@ bitflags!(
         const MP3  = mixer::MIX_InitFlags_MIX_INIT_MP3 as u32;
         const OGG  = mixer::MIX_InitFlags_MIX_INIT_OGG as u32;
         const MID  = mixer::MIX_InitFlags_MIX_INIT_MID as u32;
+        const OPUS = mixer::MIX_InitFlags_MIX_INIT_OPUS as u32;
     }
 );
 
@@ -123,6 +124,9 @@ impl ToString for InitFlag {
         }
         if self.contains(InitFlag::MID) {
             string = string + &"INIT_MID ".to_string();
+        }
+        if self.contains(InitFlag::OPUS) {
+            string = string + &"INIT_OPUS ".to_string();
         }
         string
     }


### PR DESCRIPTION
Now the following line would compile and load the opus dll files (which are already included in the SDL2 downloads, and the bindings already included it):

mixer::init(mixer::InitFlag::OPUS)

Tested, works,  and I'm using opus music files in my program now.