### PR TITLE
Fix build on Linux to support sndio dynamic loading

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -134,6 +134,8 @@ fn patch_sdl2(sdl2_source_path: &Path) {
         // No patches at this time. If needed, add them like this:
         // ("SDL-2.x.y-filename.patch", include_str!("patches/SDL-2.x.y-filename.patch")),
         ("SDL2-2.0.10-CMakeLists.txt.patch", include_str!("patches/SDL2-2.0.10-CMakeLists.txt.patch")),
+        // https://bugzilla.libsdl.org/show_bug.cgi?id=5105
+        ("SDL2-2.0.10-sndio-shared-linux.patch", include_str!("patches/SDL2-2.0.10-sndio-shared-linux.patch")),
     ];
     let sdl_version = format!("SDL2-{}", LASTEST_SDL2_VERSION);
 
@@ -335,8 +337,6 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-link-lib=dinput8");
             println!("cargo:rustc-link-lib=dxguid");
             println!("cargo:rustc-link-lib=setupapi");
-        } else if target_os.contains("linux") {
-            println!("cargo:rustc-link-lib=sndio");
         } else if target_os == "darwin" {
             println!("cargo:rustc-link-lib=framework=Cocoa");
             println!("cargo:rustc-link-lib=framework=IOKit");

--- a/sdl2-sys/patches/SDL2-2.0.10-sndio-shared-linux.patch
+++ b/sdl2-sys/patches/SDL2-2.0.10-sndio-shared-linux.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 22e4c388b..6a9dad458 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -344,6 +344,7 @@ dep_option(ARTS_SHARED         "Dynamically load aRts audio support" ON "ARTS" O
+ set_option(NAS                 "Support the NAS audio API" ${UNIX_SYS})
+ set_option(NAS_SHARED          "Dynamically load NAS audio API" ${UNIX_SYS})
+ set_option(SNDIO               "Support the sndio audio API" ${UNIX_SYS})
++dep_option(SNDIO_SHARED        "Dynamically load the sndio audio API" ${UNIX_SYS} ON "SNDIO" OFF)
+ set_option(FUSIONSOUND         "Use FusionSound audio driver" OFF)
+ dep_option(FUSIONSOUND_SHARED  "Dynamically load fusionsound audio support" ON "FUSIONSOUND" OFF)
+ set_option(LIBSAMPLERATE       "Use libsamplerate for audio rate conversion" ${UNIX_SYS})


### PR DESCRIPTION
Current SDL2 versions have a bug: somebody forgot to declare
SNDIO_SHARED in CMakeLists.txt so even if the support for dynamically
loading sndio is fully implemented (like in all other audio backends),
it is never activated.

This in turns means that supporting sndio always requires linking at
link-time against libsndio, which in turns creates binaries that require
libsndio on the target system to even start (even if no audio support
is required, or if other audio options like PulseAudio or Jack are
available).

build.rs had a workaround for this bug: it always linked against
libsndio, but this created binaries with this dependency.

I've opened a bug upstream:
https://bugzilla.libsdl.org/show_bug.cgi?id=5105

and I'm including the one-line patch in this PR so that we can fix
rust-sdl2 immediately.