### PR TITLE
Enable features for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
-
-name    = "sdl2"
+name = "sdl2"
 description = "SDL2 bindings for Rust"
 repository = "https://github.com/Rust-SDL2/rust-sdl2"
 documentation = "https://rust-sdl2.github.io/rust-sdl2/sdl2/"
@@ -11,9 +10,8 @@ keywords = ["SDL", "windowing", "graphics", "api", "engine"]
 categories = ["rendering","api-bindings","game-engines","multimedia"]
 
 [lib]
-
-name       = "sdl2"
-path       = "src/sdl2/lib.rs"
+name = "sdl2"
+path = "src/sdl2/lib.rs"
 
 [dependencies]
 bitflags = "^1"
@@ -41,7 +39,6 @@ version = "0.3.3"
 optional = true
 
 [features]
-
 unsafe_textures = []
 default = []
 gfx = ["c_vec", "sdl2-sys/gfx"]
@@ -53,7 +50,10 @@ use-bindgen = ["sdl2-sys/use-bindgen"]
 use-pkgconfig = ["sdl2-sys/use-pkgconfig"]
 use_mac_framework = ["sdl2-sys/use_mac_framework"]
 bundled = ["sdl2-sys/bundled"]
-static-link= ["sdl2-sys/static-link"]
+static-link = ["sdl2-sys/static-link"]
+
+[package.metadata.docs.rs]
+features = ["default", "gfx", "mixer", "image", "ttf"]
 
 [[example]]
 name = "animation"


### PR DESCRIPTION
This PR will make the docs.rs generated documentation complete. No need to host your documentation anymore.

Also, it'd be very nice to expand the documentation to make life of users a bit easier (I had a really hard time with textures...). Adding more code examples or explaining a bit more what a function/type is for. I can help for that if needed. Don't forget that you can use the "no_run" attribute on code blocks to prevent having the full run. It also has the advantage to check that the examples are up-to-date.