### PR TITLE
Remove empty `gesture` module, hide `macros` module

### DIFF
--- a/src/sdl2/gesture.rs
+++ b/src/sdl2/gesture.rs
@@ -1,2 +1,0 @@
-#![allow(unused)]
-use crate::sys;

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -66,10 +66,9 @@ pub use crate::sdl::*;
 
 pub mod clipboard;
 pub mod cpuinfo;
-#[macro_use] pub mod macros;
+#[macro_use] mod macros;
 pub mod event;
 pub mod filesystem;
-pub mod gesture;
 pub mod touch;
 pub mod joystick;
 pub mod controller;


### PR DESCRIPTION
`gesture` module is an empty public module, and it was empty since 2015 (#295)
`macros` is a module that contains private utility macros, there's no point in making it public