### PR TITLE
Update raw-window-handle-with-wgpu example to use wgpu 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,9 @@ optional = true
 
 [dev-dependencies]
 rand = "^0.7"
-wgpu = "^0.4.0"
+wgpu = "^0.5.0"
 glsl-to-spirv = "^0.1.7"
-
-[target.'cfg(target_os = "macos")'.dev-dependencies.objc]
-version = "^0.2.7"
+futures = "^0.3"
 
 [dependencies.raw-window-handle]
 version = "0.3.3"

--- a/examples/raw-window-handle-with-wgpu/shader.vert
+++ b/examples/raw-window-handle-with-wgpu/shader.vert
@@ -5,9 +5,9 @@ out gl_PerVertex {
 };
 
 const vec2 positions[3] = vec2[3](
-    vec2(0.0, -0.5),
-    vec2(0.5, 0.5),
-    vec2(-0.5, 0.5)
+    vec2(0.0, 0.5),
+    vec2(0.5, -0.5),
+    vec2(-0.5, -0.5)
 );
 
 void main() {


### PR DESCRIPTION
* Remove WindowWrapper since wgpu now uses raw-window-handle correctly on OSX which also lets us remove the objc dependency
* Add futures dependency to handle parts of the wgpu API that are now asynchronous
* Flip y coords in vertex shader to keep triangle oriented the same way since wgpu flipped their y-axis
* Fix various other errors resulting from breaking API changes in wgpu

I'm new to Rust so please review accordingly. The only thing I'm really unsure of is if I picked the most idiomatic way to handle the `Result` returned by `swap_chain.get_next_texture()` since the `TimeOut` error doesn't implement `Display`.