### PR TITLE
Link Readme for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 authors = [ "Tony Aldridge <tony@angry-lawyer.com>", "Cobrand <cobrandw@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "api", "engine"]
 categories = ["rendering","api-bindings","game-engines","multimedia"]
+readme = "README.md"
 
 [lib]
 name = "sdl2"


### PR DESCRIPTION
This should show the README on crates.io, which currently does not display anything useful

![image](https://user-images.githubusercontent.com/66464105/83851498-fc6c8e00-a701-11ea-99be-a24d1cf9e479.png)
