### PR TITLE
support linking to libraries from a vcpkg installation

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,0 +1,31 @@
+name: vcpkg
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-vcpkg
+        run: cargo install cargo-vcpkg
+      - name: Install dependencies
+        run: cargo vcpkg build
+      - name: Build SDL2
+        shell: bash
+        env:
+          CI_BUILD_FEATURES: "use-vcpkg static-link gfx image ttf mixer"
+          RUST_TEST_THREADS: 1
+        run: |
+          set -xeuo pipefail
+          rustc --version
+          cargo --version
+          cargo build --features "${CI_BUILD_FEATURES}"
+          cargo build --examples --features "${CI_BUILD_FEATURES}"
+          cargo test --features "${CI_BUILD_FEATURES}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ttf = ["sdl2-sys/ttf"]
 
 use-bindgen = ["sdl2-sys/use-bindgen"]
 use-pkgconfig = ["sdl2-sys/use-pkgconfig"]
+use-vcpkg = ["sdl2-sys/use-vcpkg"]
 use_mac_framework = ["sdl2-sys/use_mac_framework"]
 bundled = ["sdl2-sys/bundled"]
 static-link = ["sdl2-sys/static-link"]
@@ -148,3 +149,14 @@ name = "window-properties"
 [[example]]
 required-features = ["raw-window-handle"]
 name = "raw-window-handle-with-wgpu"
+
+[package.metadata.vcpkg]
+dependencies = ["sdl2"]
+
+# dependencies required when building examples and tests for this crate
+dev-dependencies = ["sdl2", "sdl2-image[libjpeg-turbo,tiff,libwebp]", "sdl2-ttf", "sdl2-gfx", "sdl2-mixer"]
+git = "https://github.com/microsoft/vcpkg"
+rev = "a0518036077baa4"
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ You might also need a C compiler (`gcc`).
 #### Static linking in Linux
 
 You can choose to link SDL2 statically instead of dynamically with the `static-link` feature.
-However on Linux, unless you use the "bundled" feature, your operating system has no built-in way to find the resources needed to link statically SDL2 from your system.
-
-You need to add the feature `use-pkgconfig`, so that rustc knows where to look for your SDL2 libraries and its dependencies for static linking.
+On Linux, you will need to additionally do one of the following:
+* use the `bundled` feature
+* use the feature `use-pkgconfig` so that rustc knows where to look for your SDL2 libraries and its dependencies for static linking. This is required because there is no built-in way to find the resources needed to link statically SDL2 from your system
+* install development libraries with [vcpkg][vcpkg]. Instructions to generate a static binary on Linux and other operating systems using vcpkg are [here][cargo-vcpkg-usage]
 
 ### Mac OS X
 #### If you are using homebrew
@@ -116,6 +117,10 @@ following in your `Cargo.toml` file:
 default = []
 use_sdl2_mac_framework = ["sdl2/use_mac_framework"]
 ```
+
+#### Static linking on macOS using vcpkg
+
+Instructions to generate a static binary on macOS and other operating systems using [vcpkg][vcpkg] are [here][cargo-vcpkg-usage].
 
 ### Windows with build script
 
@@ -248,7 +253,7 @@ These files are not currently included with the windows-gnu toolchain, but can b
 You will find the aforementioned libraries under `mingw64/x86_64-w64-mingw32/lib/` (for x86_64) or `mingw32/i686-w64-mingw32/lib/` (for i686). Copy them to your toolchain's `lib` directory (the same one you copied the SDL .a files to).
 
 ### Windows (MSVC with vcpkg)
-1. Install [MS build tools](https://visualstudio.microsoft.com/downloads/) and [vcpkg](https://github.com/microsoft/vcpkg)
+1. Install [MS build tools](https://visualstudio.microsoft.com/downloads/) and [vcpkg][vcpkg]
 2. Install the needed SDL2 libs: `vcpkg.exe install sdl2-ttf:x64-windows sdl2:x64-windows`
 3. Open a x64 native tools prompt (x64 Native Tools Command Prompt for VS 2019)
 4. set env vars:
@@ -289,10 +294,39 @@ SET LIB=%LIB%;C:\Users\my_user\dev\vcpkg\installed\x64-windows\lib
 
 #### Static linking with MSVC
 
-The MSVC development libraries provided by http://libsdl.org/ don't include a static library. This means that if you want to use the `static-link` feature with the windows-msvc toolchain, you have to either
+The MSVC development libraries provided by http://libsdl.org/ don't include a static library. This means that if you want to use the `static-link` feature with the windows-msvc toolchain, you have to do one of
 
 - build an SDL2 static library yourself and copy it to your toolchain's `lib` directory; or
-- also enable the `bundled` feature, which will build a static library for you.
+- also enable the `bundled` feature, which will build a static library for you; or
+- use a static SDL2 library from vcpkg as described below.
+
+### Windows, Linux and macOS with vcpkg
+
+Another method of getting the development libraries is with [vcpkg][vcpkg]. To set up a project to build a static binary on Windows (MSVC), Linux or macOS that is buildable like this:
+```sh
+cargo install cargo-vcpkg
+cargo vcpkg build
+cargo build
+```
+
+add the following your `Cargo.toml`:
+
+```toml
+[dependencies.sdl2]
+version = "0.34"
+default-features = false
+features = ["ttf","image","gfx","mixer","static-link","use-vcpkg"]
+
+[package.metadata.vcpkg]
+dependencies = ["sdl2", "sdl2-image[libjpeg-turbo,tiff,libwebp]", "sdl2-ttf", "sdl2-gfx", "sdl2-mixer"]
+git = "https://github.com/microsoft/vcpkg"
+rev = "a0518036077baa4"
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }
+```
+
+More information on the `cargo vcpkg` tool is [here][cargo-vcpkg].
 
 # Installation
 
@@ -629,3 +663,6 @@ Any Pull Request is welcome, however small your contribution may be ! There are,
 [dep-sdl2-include-issue]: https://github.com/Rust-SDL2/rust-sdl2/pull/968
 [gl-rs]: https://github.com/bjz/gl-rs
 [pdev-issue]: https://github.com/PistonDevelopers/rust-empty/issues/175
+[vcpkg]: https://github.com/microsoft/vcpkg
+[cargo-vcpkg]: https://crates.io/crates/cargo-vcpkg
+[cargo-vcpkg-usage]: #Windows,-Linux-and-macOS-with-vcpkg

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### Unreleased
+
+[PR #1009](https://github.com/Rust-SDL2/rust-sdl2/pull/1009)
+Add support for linking to development libraries from vcpkg, and automatically setting up a vcpkg installation using `cargo-vcpkg`.
+
 ### v0.34.1
 
 [PR #1004](https://github.com/Rust-SDL2/rust-sdl2/pull/1004) + [PR #1005](https://github.com/Rust-SDL2/rust-sdl2/pull/1005):

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -27,6 +27,10 @@ optional = true
 version = "^0.3"
 optional = true
 
+[build-dependencies.vcpkg]
+version = "^0.2.10"
+optional = true
+
 [build-dependencies.cmake]
 version = "^0.1"
 optional = true
@@ -50,6 +54,7 @@ cfg-if = "^0.1"
 
 default = []
 use-pkgconfig = ["pkg-config"]
+use-vcpkg = ["vcpkg"]
 use-bindgen = ["bindgen"]
 static-link = []
 use_mac_framework = []


### PR DESCRIPTION
I'm not sure if you are interested in merging this but I thought it might be useful. It allows building static binaries with dynamic libc/crt on macOS, Linux and Windows. (There are other configurations available on Windows - fully static and fully dynamic.) The workflow is the same on each of the three operating systems above. This should be enough to get it going in a rust-sdl2 checkout:

```
cargo install cargo-vcpkg
cargo vcpkg build
cargo test --features "use-vcpkg static-link gfx image ttf mixer"
```

