### PR TITLE
revert undefined behavior introduction (recommended by clippy?)

### DIFF
--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -3,6 +3,9 @@ macro_rules! impl_raw_accessors(
         $(
         impl $t {
             #[inline]
+            // can prevent introducing UB until
+            // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+            #[allow(clippy::trivially_copy_pass_by_ref)]
             pub const unsafe fn raw(&self) -> $raw { self.raw }
         }
         )+

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -4,7 +4,7 @@ macro_rules! impl_raw_accessors(
         impl $t {
             #[inline]
             // can prevent introducing UB until
-            // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+            // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
             #[allow(clippy::trivially_copy_pass_by_ref)]
             pub const unsafe fn raw(&self) -> $raw { self.raw }
         }

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -739,7 +739,7 @@ impl Point {
         slice.as_ptr() as *const sys::SDL_Point
     }
 
-    pub fn raw(self) -> *const sys::SDL_Point {
+    pub fn raw(&self) -> *const sys::SDL_Point {
         &self.raw
     }
 

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -391,6 +391,9 @@ impl Rect {
     }
 
     /// Returns the underlying C Rect.
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *const sys::SDL_Rect {
         &self.raw
     }
@@ -738,7 +741,9 @@ impl Point {
     pub fn raw_slice(slice: &[Point]) -> *const sys::SDL_Point {
         slice.as_ptr() as *const sys::SDL_Point
     }
-
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *const sys::SDL_Point {
         &self.raw
     }

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -392,7 +392,7 @@ impl Rect {
 
     /// Returns the underlying C Rect.
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *const sys::SDL_Rect {
         &self.raw
@@ -742,7 +742,7 @@ impl Point {
         slice.as_ptr() as *const sys::SDL_Point
     }
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *const sys::SDL_Point {
         &self.raw

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -219,6 +219,9 @@ impl<T> RendererContext<T> {
     }
 
     /// Gets the raw pointer to the SDL_Renderer
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.raw
     }
@@ -784,6 +787,9 @@ fn ll_create_texture(context: *mut sys::SDL_Renderer,
 
 /// Texture-creating methods for the renderer
 impl<T> TextureCreator<T> {
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.context.raw()
     }
@@ -922,6 +928,9 @@ impl<T> TextureCreator<T> {
 
 /// Drawing methods
 impl<T: RenderTarget> Canvas<T> {
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.context.raw()
     }
@@ -2148,6 +2157,9 @@ impl<'r> Texture<'r> {
     }
 
     #[inline]
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw
     }
@@ -2328,6 +2340,9 @@ impl<> Texture<> {
     }
 
     #[inline]
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -220,7 +220,7 @@ impl<T> RendererContext<T> {
 
     /// Gets the raw pointer to the SDL_Renderer
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.raw
@@ -788,7 +788,7 @@ fn ll_create_texture(context: *mut sys::SDL_Renderer,
 /// Texture-creating methods for the renderer
 impl<T> TextureCreator<T> {
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.context.raw()
@@ -929,7 +929,7 @@ impl<T> TextureCreator<T> {
 /// Drawing methods
 impl<T: RenderTarget> Canvas<T> {
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Renderer {
         self.context.raw()
@@ -2158,7 +2158,7 @@ impl<'r> Texture<'r> {
 
     #[inline]
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw
@@ -2341,7 +2341,7 @@ impl<> Texture<> {
 
     #[inline]
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub const fn raw(&self) -> *mut sys::SDL_Texture {
         self.raw

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -17,7 +17,7 @@ pub struct RWops<'a> {
 
 impl<'a> RWops<'a> {
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub unsafe fn raw(&self) -> *mut sys::SDL_RWops { self.raw }
 

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -16,6 +16,9 @@ pub struct RWops<'a> {
 }
 
 impl<'a> RWops<'a> {
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub unsafe fn raw(&self) -> *mut sys::SDL_RWops { self.raw }
 
     pub unsafe fn from_ll<'b>(raw: *mut sys::SDL_RWops) -> RWops<'b> {

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -282,7 +282,7 @@ impl SurfaceRef {
 
     #[inline]
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Surface {
         self as *const SurfaceRef as *mut SurfaceRef as *mut () as *mut sys::SDL_Surface

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -281,6 +281,9 @@ impl SurfaceRef {
     }
 
     #[inline]
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Surface {
         self as *const SurfaceRef as *mut SurfaceRef as *mut () as *mut sys::SDL_Surface
     }

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -302,7 +302,7 @@ pub fn internal_load_font_at_index<'ttf,P: AsRef<Path>>(path: P, index: u32, pts
 impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the underlying C font object.
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     unsafe fn raw(&self) -> *mut ttf::TTF_Font {
         self.raw

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -301,6 +301,9 @@ pub fn internal_load_font_at_index<'ttf,P: AsRef<Path>>(path: P, index: u32, pts
 
 impl<'ttf,'r> Font<'ttf,'r> {
     /// Returns the underlying C font object.
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     unsafe fn raw(&self) -> *mut ttf::TTF_Font {
         self.raw
     }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1075,6 +1075,9 @@ impl From<Window> for CanvasBuilder {
 
 impl Window {
     #[inline]
+    // this can prevent introducing UB until
+    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Window { self.context.raw }
 
     #[inline]

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1076,7 +1076,7 @@ impl From<Window> for CanvasBuilder {
 impl Window {
     #[inline]
     // this can prevent introducing UB until
-    // https://github.com/rust-lang/rust-clippy/issues/3992 is fixed
+    // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn raw(&self) -> *mut sys::SDL_Window { self.context.raw }
 


### PR DESCRIPTION
Hi folks
In a recent revision of rust-sdl2 my art tool ( https://github.com/danielrh/stamps ) was beginning to get increasingly difficult to track undefined behavior, especially on release.

After trying everything I knew of with the SDL 2.0.10 upgrade--I determined it was likely to be in the rust layer.
So I bisected the code and found the offending diff was a9893f0c0d42f012c312280ed3b0a785fcf9abcc which returned the address of a local variable when getting the raw data out of a rect

I've attached a reverting change here which restores my program to normal operations