### PR TITLE
Add SDL2 patch to fix metal detection for macOS/iOS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### Unreleased
+
+ * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
+
 ### v0.34.3
 
 [PR #1027](https://github.com/Rust-SDL2/rust-sdl2/pull/1027): upgrade "bundled" version of SDL2 to 2.0.12

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -154,6 +154,10 @@ fn patch_sdl2(sdl2_source_path: &Path) {
         // https://bugzilla.libsdl.org/show_bug.cgi?id=5105
         // Expected to be fixed in 2.0.14
         ("SDL2-2.0.12-sndio-shared-linux.patch", include_str!("patches/SDL2-2.0.12-sndio-shared-linux.patch")),
+
+        // https://bugzilla.libsdl.org/show_bug.cgi?id=4988
+        // Expected to be fixed in 2.0.14
+        ("SDL2-2.0.12-metal-detection-macos-ios.patch", include_str!("patches/SDL2-2.0.12-metal-detection-macos-ios.patch"))
     ];
     let sdl_version = format!("SDL2-{}", LASTEST_SDL2_VERSION);
 

--- a/sdl2-sys/patches/SDL2-2.0.12-metal-detection-macos-ios.patch
+++ b/sdl2-sys/patches/SDL2-2.0.12-metal-detection-macos-ios.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1f086fb70..0f2e74efb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1667,7 +1667,7 @@ elseif(APPLE)
+ 
+     if(VIDEO_VULKAN OR VIDEO_METAL OR RENDER_METAL)
+       set(ORIG_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+-      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -x objective-c")
++      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -ObjC")
+       check_c_source_compiles("
+         #include <AvailabilityMacros.h>
+         #import <Metal/Metal.h>


### PR DESCRIPTION
This fixes #1028 by patching in a change that is upstreamed but not in 2.0.12
https://hg.libsdl.org/SDL/rev/e7828d3a7576