### PR TITLE
Add metal framework

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -395,6 +395,7 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-link-lib=framework=CoreVideo");
             println!("cargo:rustc-link-lib=framework=CoreAudio");
             println!("cargo:rustc-link-lib=framework=AudioToolbox");
+            println!("cargo:rustc-link-lib=framework=Metal");
             println!("cargo:rustc-link-lib=iconv");
         } else {
             // TODO: Add other platform linker options here.


### PR DESCRIPTION
This change was missing in my previous PR #1030. It fixes these link errors:

```
            "_OBJC_CLASS_$_MTLSamplerDescriptor", referenced from:
                objc-class-ref in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
            "_OBJC_CLASS_$_MTLTextureDescriptor", referenced from:
                objc-class-ref in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
            "_OBJC_CLASS_$_MTLRenderPassDescriptor", referenced from:
                objc-class-ref in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
            "_OBJC_CLASS_$_MTLVertexDescriptor", referenced from:
                objc-class-ref in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
            "_OBJC_CLASS_$_MTLRenderPipelineDescriptor", referenced from:
                objc-class-ref in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
            "_MTLCreateSystemDefaultDevice", referenced from:
                _METAL_CreateRenderer in libsdl2_sys-c107b63fb2e1f32f.rlib(SDL_render_metal.m.o)
```

I think I had this change locally applied and didn't realize it was needed in addition to #1030. I'm not sure what changed between SDL 2.0.10 and 2.0.12 that made including this framework necessary.