### PR TITLE
Changed ticks function from `&mut self` to `&self`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ when upgrading from a version of rust-sdl2 to another.
 ### Unreleased
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
+ * Changed signature of `TimerSubsystem::ticks to accept `&self`.
 
 ### v0.34.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ when upgrading from a version of rust-sdl2 to another.
 ### Unreleased
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
- * Changed signature of `TimerSubsystem::ticks to accept `&self`.
+ * Changed signature of TimerSubsystem::ticks to accept `&self`.
 
 ### v0.34.3
 

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -31,7 +31,7 @@ impl TimerSubsystem {
     /// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
     ///
     /// It's recommended that you use another library for timekeeping, such as `time`.
-    pub fn ticks(&mut self) -> u32 {
+    pub fn ticks(&self) -> u32 {
         // Google says this is probably not thread-safe (TODO: prove/disprove this).
         unsafe { sys::SDL_GetTicks() }
     }


### PR DESCRIPTION
Hi there,

Currently, the [ticks](https://docs.rs/sdl2/0.34.3/sdl2/struct.TimerSubsystem.html#method.ticks) method requires a `&mut self`, which this PR downgrades to a `&self`.

Please let me know if I've made a mistake in my understanding here. I _think_ `&self` should be fairly benign; AFAIK `ticks` doesn't do anything mutable under the hood.

What motivated this change is I can't check the elapsed `ticks` while I have a living `Timer` object due to the borrow checker. If I have missed a good reason this function is marked as mutable then please let me know.