### PR TITLE
[WIP] Conversion fn prefixes: change to fit Rust's convention

### DIFF
--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -224,7 +224,12 @@ impl Axis {
         })
     }
 
+    #[deprecated(since="0.34.4", note="please, use `into_ll()` instead")]
     pub fn to_ll(self) -> sys::SDL_GameControllerAxis {
+        self.into_ll()
+    }
+
+    pub fn into_ll(self) -> sys::SDL_GameControllerAxis {
         match self {
             Axis::LeftX => sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTX,
             Axis::LeftY => sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTY,
@@ -302,7 +307,12 @@ impl Button {
         })
     }
 
+    #[deprecated(since="0.34.4", note="please, use `into_ll()` instead")]
     pub fn to_ll(self) -> sys::SDL_GameControllerButton {
+        self.into_ll()
+    }
+
+    pub fn into_ll(self) -> sys::SDL_GameControllerButton {
         match self {
             Button::A             => sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_A,
             Button::B             => sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_B,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -905,7 +905,7 @@ impl Event {
                 xrel,
                 yrel
             } => {
-                let state = mousestate.to_sdl_state();
+                let state = mousestate.as_sdl_state();
                 let event = sys::SDL_MouseMotionEvent {
                     type_: SDL_EventType::SDL_MOUSEMOTION as u32,
                     timestamp,
@@ -1051,7 +1051,7 @@ impl Event {
                 hat_idx,
                 state,
             } => {
-                let hatvalue = state.to_raw();
+                let hatvalue = state.as_raw();
                 let event = sys::SDL_JoyHatEvent {
                     type_: SDL_EventType::SDL_JOYHATMOTION as u32,
                     timestamp,
@@ -1145,7 +1145,7 @@ impl Event {
                 axis,
                 value,
             } => {
-                let axisval = axis.to_ll();
+                let axisval = axis.into_ll();
                 let event = sys::SDL_ControllerAxisEvent {
                     type_: SDL_EventType::SDL_CONTROLLERAXISMOTION as u32,
                     timestamp,
@@ -1167,7 +1167,7 @@ impl Event {
                 which,
                 button,
             } => {
-                let buttonval = button.to_ll();
+                let buttonval = button.into_ll();
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONDOWN as u32,
                     timestamp,
@@ -1190,7 +1190,7 @@ impl Event {
                 which,
                 button,
             } => {
-                let buttonval = button.to_ll();
+                let buttonval = button.into_ll();
                 let event = sys::SDL_ControllerButtonEvent {
                     type_: SDL_EventType::SDL_CONTROLLERBUTTONUP as u32,
                     timestamp,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -45,7 +45,7 @@ impl CustomEventTypeMaps {
 }
 
 lazy_static! {
-    static ref CUSTOM_EVENT_TYPES : Mutex<CustomEventTypeMaps> = { Mutex::new(CustomEventTypeMaps::new()) };
+    static ref CUSTOM_EVENT_TYPES : Mutex<CustomEventTypeMaps> = Mutex::new(CustomEventTypeMaps::new());
 }
 
 impl crate::EventSubsystem {

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -497,7 +497,12 @@ impl HatState {
         }
     }
 
+    #[deprecated(since="0.34.4", note="please, use `as_raw()` instead")]
     pub fn to_raw(self) -> u8 {
+        self.as_raw()
+    }
+
+    pub fn as_raw(self) -> u8 {
         match self {
             HatState::Centered => 0,
             HatState::Up => 1,

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -177,7 +177,12 @@ impl MouseState {
     pub fn from_sdl_state(state: u32) -> MouseState {
         MouseState { mouse_state : state, x: 0, y: 0 }
     }
+
+    #[deprecated(since="0.34.4", note="please, use `as_sdl_state()` instead")]
     pub fn to_sdl_state(&self) -> u32 {
+        self.mouse_state
+    }
+    pub fn as_sdl_state(&self) -> u32 {
         self.mouse_state
     }
 

--- a/src/sdl2/mouse/relative.rs
+++ b/src/sdl2/mouse/relative.rs
@@ -30,7 +30,12 @@ impl RelativeMouseState {
     pub fn from_sdl_state(state: u32) -> RelativeMouseState {
         RelativeMouseState { mouse_state : state, x: 0, y: 0 }
     }
+
+    #[deprecated(since="0.34.4", note="please, use `as_sdl_state()` instead")]
     pub fn to_sdl_state(&self) -> u32 {
+        self.mouse_state
+    }
+    pub fn as_sdl_state(&self) -> u32 {
         self.mouse_state
     }
 

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -111,7 +111,11 @@ impl Color {
         Color { r, g, b, a }
     }
 
+    #[deprecated(since="0.34.4", note="please, use `as_u32()`")]
     pub fn to_u32(self, format: &PixelFormat) -> u32 {
+        unsafe { sys::SDL_MapRGBA(format.raw, self.r, self.g, self.b, self.a) }
+    }
+    pub fn as_u32(self, format: &PixelFormat) -> u32 {
         unsafe { sys::SDL_MapRGBA(format.raw, self.r, self.g, self.b, self.a) }
     }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -355,13 +355,25 @@ impl<'s> Canvas<Surface<'s>> {
 
     /// Gets a reference to the associated surface of the Canvas
     #[inline]
+    #[deprecated(since="0.34.4", note="please, use `as_surface()` instead")]
     pub fn surface(&self) -> &SurfaceRef {
+        &self.target
+    }
+    /// Gets a reference to the associated surface of the Canvas
+    #[inline]
+    pub fn as_surface(&self) -> &SurfaceRef {
         &self.target
     }
 
     /// Gets a mutable reference to the associated surface of the Canvas
     #[inline]
+    #[deprecated(since="0.34.4", note="please, use `as_surface_mut()` instead")]
     pub fn surface_mut(&mut self) -> &mut SurfaceRef {
+        &mut self.target
+    }
+    /// Gets a mutable reference to the associated surface of the Canvas
+    #[inline]
+    pub fn as_surface_mut(&mut self) -> &mut SurfaceRef {
         &mut self.target
     }
 
@@ -395,13 +407,25 @@ impl RenderTarget for Window {
 impl Canvas<Window> {
     /// Gets a reference to the associated window of the Canvas
     #[inline]
+    #[deprecated(since="0.34.4", note="please, use `as_window()` instead")]
     pub fn window(&self) -> &Window {
+        &self.target
+    }
+    /// Gets a reference to the associated window of the Canvas
+    #[inline]
+    pub fn as_window(&self) -> &Window {
         &self.target
     }
 
     /// Gets a mutable reference to the associated window of the Canvas
     #[inline]
+    #[deprecated(since="0.34.4", note="please, use `as_window_mut()` instead")]
     pub fn window_mut(&mut self) -> &mut Window {
+        &mut self.target
+    }
+    /// Gets a mutable reference to the associated window of the Canvas
+    #[inline]
+    pub fn as_window_mut(&mut self) -> &mut Window {
         &mut self.target
     }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -437,7 +437,7 @@ impl Canvas<Window> {
 
     #[inline]
     pub fn default_pixel_format(&self) -> PixelFormatEnum {
-        self.window().window_pixel_format()
+        self.as_window().window_pixel_format()
     }
 
     /// Returns a `TextureCreator` that can create Textures to be drawn on this `Canvas`

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -448,7 +448,7 @@ impl SurfaceRef {
     }
 
     pub fn set_color_key(&mut self, enable: bool, color: pixels::Color) -> Result<(), String> {
-        let key = color.to_u32(&self.pixel_format());
+        let key = color.as_u32(&self.pixel_format());
         let result = unsafe {
             sys::SDL_SetColorKey(self.raw(), if enable { 1 } else { 0 }, key)
         };
@@ -513,7 +513,7 @@ impl SurfaceRef {
             let rect_ptr = mem::transmute(rect.as_ref()); // TODO find a better way to transform
             // Option<&...> into a *const _
             let format = self.pixel_format();
-            let result = sys::SDL_FillRect(self.raw(), rect_ptr, color.to_u32(&format) );
+            let result = sys::SDL_FillRect(self.raw(), rect_ptr, color.as_u32(&format) );
             match result {
                 0 => Ok(()),
                 _ => Err(get_error())

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -175,32 +175,9 @@ impl<'a> Surface<'a> {
     }
 
     /// A convenience function for [`TextureCreator::create_texture_from_surface`].
-    ///
-    /// ```no_run
-    /// use sdl2::pixels::PixelFormatEnum;
-    /// use sdl2::surface::Surface;
-    /// use sdl2::render::{Canvas, Texture};
-    /// use sdl2::video::Window;
-    ///
-    /// // We init systems.
-    /// let sdl_context = sdl2::init().expect("failed to init SDL");
-    /// let video_subsystem = sdl_context.video().expect("failed to get video context");
-    ///
-    /// // We create a window.
-    /// let window = video_subsystem.window("sdl2 demo", 800, 600)
-    ///     .build()
-    ///     .expect("failed to build window");
-    ///
-    /// // We get the canvas from which we can get the `TextureCreator`.
-    /// let mut canvas: Canvas<Window> = window.into_canvas()
-    ///     .build()
-    ///     .expect("failed to build window's canvas");
-    /// let texture_creator = canvas.texture_creator();
-    ///
-    /// let surface = Surface::new(512, 512, PixelFormatEnum::RGB24).unwrap();
-    /// let texture = surface.as_texture(&texture_creator).unwrap();
-    /// ```
+    /// Deprecated: use `to_texture()` instead.
     #[cfg(not(feature = "unsafe_textures"))]
+    #[deprecated(since="0.34.4", note="please, use `to_texture()` instead")]
     pub fn as_texture<'b, T>(&self, texture_creator: &'b TextureCreator<T>) -> Result<Texture<'b>, TextureValueError> {
         texture_creator.create_texture_from_surface(self)
     }
@@ -229,10 +206,49 @@ impl<'a> Surface<'a> {
     /// let texture_creator = canvas.texture_creator();
     ///
     /// let surface = Surface::new(512, 512, PixelFormatEnum::RGB24).unwrap();
-    /// let texture = surface.as_texture(&texture_creator).unwrap();
+    /// let texture = surface.to_texture(&texture_creator).unwrap();
+    /// ```
+    #[cfg(not(feature = "unsafe_textures"))]
+    pub fn to_texture<'b, T>(&self, texture_creator: &'b TextureCreator<T>) -> Result<Texture<'b>, TextureValueError> {
+        texture_creator.create_texture_from_surface(self)
+    }
+
+    /// A convenience function for [`TextureCreator::create_texture_from_surface`].
+    /// Deprecated: use `to_texture()` instead.
+    #[cfg(feature = "unsafe_textures")]
+    #[deprecated(since="0.34.4", note="please, use `to_texture()` instead")]
+    pub fn as_texture<T>(&self, texture_creator: &TextureCreator<T>) -> Result<Texture, TextureValueError> {
+        texture_creator.create_texture_from_surface(self)
+    }
+
+    /// A convenience function for [`TextureCreator::create_texture_from_surface`].
+    ///
+    /// ```no_run
+    /// use sdl2::pixels::PixelFormatEnum;
+    /// use sdl2::surface::Surface;
+    /// use sdl2::render::{Canvas, Texture};
+    /// use sdl2::video::Window;
+    ///
+    /// // We init systems.
+    /// let sdl_context = sdl2::init().expect("failed to init SDL");
+    /// let video_subsystem = sdl_context.video().expect("failed to get video context");
+    ///
+    /// // We create a window.
+    /// let window = video_subsystem.window("sdl2 demo", 800, 600)
+    ///     .build()
+    ///     .expect("failed to build window");
+    ///
+    /// // We get the canvas from which we can get the `TextureCreator`.
+    /// let mut canvas: Canvas<Window> = window.into_canvas()
+    ///     .build()
+    ///     .expect("failed to build window's canvas");
+    /// let texture_creator = canvas.texture_creator();
+    ///
+    /// let surface = Surface::new(512, 512, PixelFormatEnum::RGB24).unwrap();
+    /// let texture = surface.to_texture(&texture_creator).unwrap();
     /// ```
     #[cfg(feature = "unsafe_textures")]
-    pub fn as_texture<T>(&self, texture_creator: &TextureCreator<T>) -> Result<Texture, TextureValueError> {
+    pub fn to_texture<T>(&self, texture_creator: &TextureCreator<T>) -> Result<Texture, TextureValueError> {
         texture_creator.create_texture_from_surface(self)
     }
 


### PR DESCRIPTION
Fix #1036 

Please review the changes.

I tried to strive to these rules, but I'm not sure about some of the changes I made. Most important to me was to change `Surface::as_texture()` to `Surface::to_texture()`

I'm not sure about `src/sdl2/joystick.rs`-s `HatState::as_raw()`, because it's owned and I believe it's Copy, too, so according to the table it should be `to_raw()`?

Prefix | Cost | Ownership
-- | -- | --
as_ | Free | borrowed -> borrowed
to_ | Expensive | borrowed -> borrowed 
to_ | Expensive | borrowed -> owned (non-Copy types) 
to_ | Expensive | owned -> owned (Copy types)
into_ | Variable | owned -> owned (non-Copy types)

