### PR TITLE
Add doc aliases for C equivalents

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -101,6 +101,7 @@ impl AudioSubsystem {
         AudioQueue::open_queue(self, device, spec)
     }
 
+    #[doc(alias = "SDL_GetCurrentAudioDriver")]
     pub fn current_audio_driver(&self) -> &'static str {
         unsafe {
             let buf = sys::SDL_GetCurrentAudioDriver();
@@ -110,6 +111,7 @@ impl AudioSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetNumAudioDevices")]
     pub fn num_audio_playback_devices(&self) -> Option<u32> {
         let result = unsafe { sys::SDL_GetNumAudioDevices(0) };
         if result < 0 {
@@ -120,6 +122,7 @@ impl AudioSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetAudioDeviceName")]
     pub fn audio_playback_device_name(&self, index: u32) -> Result<String, String> {
         unsafe {
             let dev_name = sys::SDL_GetAudioDeviceName(index as c_int, 0);
@@ -176,6 +179,7 @@ impl AudioFormat {
         }
     }
 
+    #[doc(alias = "SDL_AudioFormat")]
     fn to_ll(self) -> sys::SDL_AudioFormat {
         self as sys::SDL_AudioFormat
     }
@@ -228,6 +232,7 @@ impl TryFrom<u32> for AudioStatus {
     }
 }
 
+#[doc(alias = "SDL_GetAudioDriver")]
 #[derive(Copy, Clone)]
 pub struct DriverIterator {
     length: i32,
@@ -262,6 +267,7 @@ impl Iterator for DriverIterator {
 impl ExactSizeIterator for DriverIterator { }
 
 /// Gets an iterator of all audio drivers compiled into the SDL2 library.
+#[doc(alias = "SDL_GetAudioDriver")]
 #[inline]
 pub fn drivers() -> DriverIterator {
     // This function is thread-safe and doesn't require the audio subsystem to be initialized.
@@ -290,6 +296,7 @@ impl AudioSpecWAV {
     }
 
     /// Loads a WAVE from the data source.
+    #[doc(alias = "SDL_LoadWAV_RW")]
     pub fn load_wav_rw(src: &mut RWops) -> Result<AudioSpecWAV, String> {
         use std::mem::MaybeUninit;
         use std::ptr::null_mut;
@@ -325,6 +332,7 @@ impl AudioSpecWAV {
 }
 
 impl Drop for AudioSpecWAV {
+    #[doc(alias = "SDL_FreeWAV")]
     fn drop(&mut self) {
         unsafe { sys::SDL_FreeWAV(self.audio_buf); }
     }
@@ -532,6 +540,7 @@ impl AudioDeviceID {
 }
 
 impl Drop for AudioDeviceID {
+    #[doc(alias = "SDL_CloseAudioDevice")]
     fn drop(&mut self) {
         //! Shut down audio processing and close the audio device.
         unsafe { sys::SDL_CloseAudioDevice(self.id()) }
@@ -548,6 +557,7 @@ pub struct AudioQueue<Channel: AudioFormatNum> {
 
 impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
     /// Opens a new audio device given the desired parameters and callback.
+    #[doc(alias = "SDL_OpenAudioDevice")]
     pub fn open_queue<D: Into<Option<&'a str>>>(a: &AudioSubsystem, device: D, spec: &AudioSpecDesired) -> Result<AudioQueue<Channel>, String> {
         use std::mem::MaybeUninit;
 
@@ -590,6 +600,7 @@ impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
     }
 
     #[inline]
+    #[doc(alias = "SDL_GetAudioDeviceStatus")]
     pub fn subsystem(&self) -> &AudioSubsystem { &self.subsystem }
 
     #[inline]
@@ -603,26 +614,31 @@ impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
     }
 
     /// Pauses playback of the audio device.
+    #[doc(alias = "SDL_PauseAudioDevice")]
     pub fn pause(&self) {
         unsafe { sys::SDL_PauseAudioDevice(self.device_id.id(), 1) }
     }
 
     /// Starts playback of the audio device.
+    #[doc(alias = "SDL_PauseAudioDevice")]
     pub fn resume(&self) {
         unsafe { sys::SDL_PauseAudioDevice(self.device_id.id(), 0) }
     }
 
     /// Adds data to the audio queue.
+    #[doc(alias = "SDL_QueueAudio")]
     pub fn queue(&self, data: &[Channel]) -> bool {
         let result = unsafe {sys::SDL_QueueAudio(self.device_id.id(), data.as_ptr() as *const c_void, (data.len() * mem::size_of::<Channel>()) as u32)};
         result == 0
     }
 
+    #[doc(alias = "SDL_GetQueuedAudioSize")]
     pub fn size(&self) -> u32 {
         unsafe {sys::SDL_GetQueuedAudioSize(self.device_id.id())}
     }
 
     /// Clears all data from the current audio queue.
+    #[doc(alias = "SDL_ClearQueuedAudio")]
     pub fn clear(&self) {
         unsafe {sys::SDL_ClearQueuedAudio(self.device_id.id());}
     }
@@ -639,6 +655,7 @@ pub struct AudioDevice<CB: AudioCallback> {
 
 impl<CB: AudioCallback> AudioDevice<CB> {
     /// Opens a new audio device for playback or capture (given the desired parameters and callback).
+    #[doc(alias = "SDL_OpenAudioDevice")]
     fn open<'a, F, D>(a: &AudioSubsystem, device: D, spec: &AudioSpecDesired, get_callback: F, capture: bool) -> Result<AudioDevice <CB>, String>
     where
         F: FnOnce(AudioSpec) -> CB,
@@ -713,6 +730,7 @@ impl<CB: AudioCallback> AudioDevice<CB> {
     }
 
     #[inline]
+    #[doc(alias = "SDL_GetAudioDeviceStatus")]
     pub fn subsystem(&self) -> &AudioSubsystem { &self.subsystem }
 
     #[inline]
@@ -726,11 +744,13 @@ impl<CB: AudioCallback> AudioDevice<CB> {
     }
 
     /// Pauses playback of the audio device.
+    #[doc(alias = "SDL_PauseAudioDevice")]
     pub fn pause(&self) {
         unsafe { sys::SDL_PauseAudioDevice(self.device_id.id(), 1) }
     }
 
     /// Starts playback of the audio device.
+    #[doc(alias = "SDL_PauseAudioDevice")]
     pub fn resume(&self) {
         unsafe { sys::SDL_PauseAudioDevice(self.device_id.id(), 0) }
     }
@@ -740,6 +760,7 @@ impl<CB: AudioCallback> AudioDevice<CB> {
     /// When the returned lock guard is dropped, `SDL_UnlockAudioDevice` is
     /// called.
     /// Use this method to read and mutate callback data.
+    #[doc(alias = "SDL_LockAudioDevice")]
     pub fn lock(&mut self) -> AudioDeviceLockGuard<CB> {
         unsafe { sys::SDL_LockAudioDevice(self.device_id.id()) };
         AudioDeviceLockGuard {
@@ -766,6 +787,7 @@ pub struct AudioDeviceLockGuard<'a, CB> where CB: AudioCallback, CB: 'a {
 
 impl<'a, CB: AudioCallback> Deref for AudioDeviceLockGuard<'a, CB> {
     type Target = CB;
+    #[doc(alias = "SDL_UnlockAudioDevice")]
     fn deref(&self) -> &CB { (*self.device.userdata).as_ref().expect("Missing callback") }
 }
 
@@ -785,6 +807,7 @@ pub struct AudioCVT {
 }
 
 impl AudioCVT {
+    #[doc(alias = "SDL_BuildAudioCVT")]
     pub fn new(src_format: AudioFormat, src_channels: u8, src_rate: i32,
                dst_format: AudioFormat, dst_channels: u8, dst_rate: i32) -> Result<AudioCVT, String>
     {
@@ -805,6 +828,7 @@ impl AudioCVT {
         }
     }
 
+    #[doc(alias = "SDL_ConvertAudio")]
     pub fn convert(&self, mut src: Vec<u8>) -> Vec<u8> {
         //! Convert audio data to a desired audio format.
         //!

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -29,6 +29,7 @@ impl crate::VideoSubsystem {
 }
 
 impl ClipboardUtil {
+    #[doc(alias = "SDL_SetClipboardText")]
     pub fn set_clipboard_text(&self, text: &str) -> Result<(), String> {
         unsafe {
             let text = CString::new(text).unwrap();
@@ -42,6 +43,7 @@ impl ClipboardUtil {
         }
     }
 
+    #[doc(alias = "SDL_GetClipboardText")]
     pub fn clipboard_text(&self) -> Result<String, String> {
         unsafe {
             let buf = sys::SDL_GetClipboardText();
@@ -56,6 +58,7 @@ impl ClipboardUtil {
         }
     }
 
+    #[doc(alias = "SDL_HasClipboardText")]
     pub fn has_clipboard_text(&self) -> bool {
         unsafe { sys::SDL_HasClipboardText() == sys::SDL_bool::SDL_TRUE }
     }

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -50,6 +50,7 @@ impl error::Error for AddMappingError {
 
 impl GameControllerSubsystem {
     /// Retrieve the total number of attached joysticks *and* controllers identified by SDL.
+    #[doc(alias = "SDL_NumJoysticks")]
     pub fn num_joysticks(&self) -> Result<u32, String> {
         let result = unsafe { sys::SDL_NumJoysticks() };
 
@@ -62,6 +63,7 @@ impl GameControllerSubsystem {
 
     /// Return true if the joystick at index `joystick_index` is a game controller.
     #[inline]
+    #[doc(alias = "SDL_IsGameController")]
     pub fn is_game_controller(&self, joystick_index: u32) -> bool {
         match validate_int(joystick_index, "joystick_index") {
             Ok(joystick_index) => unsafe { sys::SDL_IsGameController(joystick_index) != sys::SDL_bool::SDL_FALSE },
@@ -72,6 +74,7 @@ impl GameControllerSubsystem {
     /// Attempt to open the controller at index `joystick_index` and return it.
     /// Controller IDs are the same as joystick IDs and the maximum number can
     /// be retrieved using the `SDL_NumJoysticks` function.
+    #[doc(alias = "SDL_GameControllerOpen")]
     pub fn open(&self, joystick_index: u32) -> Result<GameController, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
@@ -88,6 +91,7 @@ impl GameControllerSubsystem {
     }
 
     /// Return the name of the controller at index `joystick_index`.
+    #[doc(alias = "SDL_GameControllerNameForIndex")]
     pub fn name_for_index(&self, joystick_index: u32) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
@@ -104,17 +108,20 @@ impl GameControllerSubsystem {
 
     /// If state is `true` controller events are processed, otherwise
     /// they're ignored.
+    #[doc(alias = "SDL_GameControllerEventState")]
     pub fn set_event_state(&self, state: bool) {
         unsafe { sys::SDL_GameControllerEventState(state as i32) };
     }
 
     /// Return `true` if controller events are processed.
+    #[doc(alias = "SDL_GameControllerEventState")]
     pub fn event_state(&self) -> bool {
         unsafe { sys::SDL_GameControllerEventState(sys::SDL_QUERY as i32)
                  == sys::SDL_ENABLE as i32 }
     }
 
     /// Add a new controller input mapping from a mapping string.
+    #[doc(alias = "SDL_GameControllerAddMapping")]
     pub fn add_mapping(&self, mapping: &str)
             -> Result<MappingStatus, AddMappingError> {
         use self::AddMappingError::*;
@@ -153,6 +160,7 @@ impl GameControllerSubsystem {
     }
 
     /// Load controller input mappings from an SDL [`RWops`] object.
+    #[doc(alias = "SDL_GameControllerAddMappingsFromRW")]
     pub fn load_mappings_from_rw<'a>(&self, rw: RWops<'a>) -> Result<i32, AddMappingError> {
         use self::AddMappingError::*;
 
@@ -163,6 +171,7 @@ impl GameControllerSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GameControllerMappingForGUID")]
     pub fn mapping_for_guid(&self, guid: joystick::Guid) -> Result<String, String> {
         let c_str = unsafe { sys::SDL_GameControllerMappingForGUID(guid.raw()) };
 
@@ -171,6 +180,7 @@ impl GameControllerSubsystem {
 
     #[inline]
     /// Force controller update when not using the event loop
+    #[doc(alias = "SDL_GameControllerUpdate")]
     pub fn update(&self) {
         unsafe { sys::SDL_GameControllerUpdate() };
     }
@@ -190,6 +200,7 @@ pub enum Axis {
 impl Axis {
     /// Return the Axis from a string description in the same format
     /// used by the game controller mapping strings.
+    #[doc(alias = "SDL_GameControllerGetAxisFromString")]
     pub fn from_string(axis: &str) -> Option<Axis> {
         let id = match CString::new(axis) {
             Ok(axis) => unsafe { sys::SDL_GameControllerGetAxisFromString(axis.as_ptr() as *const c_char) },
@@ -202,6 +213,7 @@ impl Axis {
 
     /// Return a string for a given axis in the same format using by
     /// the game controller mapping strings
+    #[doc(alias = "SDL_GameControllerGetStringForAxis")]
     pub fn string(self) -> String {
         let axis: sys::SDL_GameControllerAxis;
         unsafe { axis = transmute(self); }
@@ -259,6 +271,7 @@ pub enum Button {
 impl Button {
     /// Return the Button from a string description in the same format
     /// used by the game controller mapping strings.
+    #[doc(alias = "SDL_GameControllerGetButtonFromString")]
     pub fn from_string(button: &str) -> Option<Button> {
         let id = match CString::new(button) {
             Ok(button) => unsafe { sys::SDL_GameControllerGetButtonFromString(button.as_ptr() as *const c_char) },
@@ -271,6 +284,7 @@ impl Button {
 
     /// Return a string for a given button in the same format using by
     /// the game controller mapping strings
+    #[doc(alias = "SDL_GameControllerGetStringForButton")]
     pub fn string(self) -> String {
         let button: sys::SDL_GameControllerButton;
         unsafe { button = transmute(self); }
@@ -342,6 +356,7 @@ impl GameController {
 
     /// Return the name of the controller or an empty string if no
     /// name is found.
+    #[doc(alias = "SDL_GameControllerName")]
     pub fn name(&self) -> String {
         let name = unsafe { sys::SDL_GameControllerName(self.raw) };
 
@@ -350,6 +365,7 @@ impl GameController {
 
     /// Return a String describing the controller's button and axis
     /// mappings
+    #[doc(alias = "SDL_GameControllerMapping")]
     pub fn mapping(&self) -> String {
         let mapping = unsafe { sys::SDL_GameControllerMapping(self.raw) };
 
@@ -358,11 +374,13 @@ impl GameController {
 
     /// Return true if the controller has been opened and currently
     /// connected.
+    #[doc(alias = "SDL_GameControllerGetAttached")]
     pub fn attached(&self) -> bool {
         unsafe { sys::SDL_GameControllerGetAttached(self.raw) != sys::SDL_bool::SDL_FALSE }
     }
 
     /// Return the joystick instance id of this controller
+    #[doc(alias = "SDL_GameControllerGetJoystick")]
     pub fn instance_id(&self) -> u32 {
         let result = unsafe {
           let joystick = sys::SDL_GameControllerGetJoystick(self.raw);
@@ -378,6 +396,7 @@ impl GameController {
     }
 
     /// Get the position of the given `axis`
+    #[doc(alias = "SDL_GameControllerGetAxis")]
     pub fn axis(&self, axis: Axis) -> i16 {
         // This interface is a bit messed up: 0 is a valid position
         // but can also mean that an error occured.
@@ -391,6 +410,7 @@ impl GameController {
     }
 
     /// Returns `true` if `button` is pressed.
+    #[doc(alias = "SDL_GameControllerGetButton")]
     pub fn button(&self, button: Button) -> bool {
         // This interface is a bit messed up: 0 is a valid position
         // but can also mean that an error occured.
@@ -414,6 +434,7 @@ impl GameController {
     /// the rumble effect to keep playing for a long time, as this results in
     /// the effect ending immediately after starting due to an overflow.
     /// Use some smaller, "huge enough" number instead.
+    #[doc(alias = "SDL_GameControllerRumble")]
     pub fn set_rumble(&mut self,
                       low_frequency_rumble: u16,
                       high_frequency_rumble: u16,
@@ -436,6 +457,7 @@ impl GameController {
 }
 
 impl Drop for GameController {
+    #[doc(alias = "SDL_GameControllerClose")]
     fn drop(&mut self) {
         unsafe { sys::SDL_GameControllerClose(self.raw) }
     }

--- a/src/sdl2/cpuinfo.rs
+++ b/src/sdl2/cpuinfo.rs
@@ -3,62 +3,77 @@ use crate::sys::SDL_bool;
 
 pub const CACHELINESIZE: u8 = 128;
 
+#[doc(alias = "SDL_GetCPUCount")]
 pub fn cpu_count() -> i32 {
     unsafe { sys::SDL_GetCPUCount() }
 }
 
+#[doc(alias = "SDL_GetCPUCacheLineSize")]
 pub fn cpu_cache_line_size() -> i32 {
     unsafe { sys::SDL_GetCPUCacheLineSize() }
 }
 
+#[doc(alias = "SDL_HasRDTSC")]
 pub fn has_rdtsc() -> bool {
     unsafe { sys::SDL_HasRDTSC() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasAltiVec")]
 pub fn has_alti_vec() -> bool {
     unsafe { sys::SDL_HasAltiVec() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasMMX")]
 pub fn has_mmx() -> bool {
     unsafe { sys::SDL_HasMMX() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_Has3DNow")]
 pub fn has_3d_now() -> bool {
     unsafe { sys::SDL_Has3DNow() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasSSE")]
 pub fn has_sse() -> bool {
     unsafe { sys::SDL_HasSSE() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasSSE2")]
 pub fn has_sse2() -> bool {
     unsafe { sys::SDL_HasSSE2() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasSSE3")]
 pub fn has_sse3() -> bool {
     unsafe { sys::SDL_HasSSE3() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasSSE41")]
 pub fn has_sse41() -> bool {
     unsafe { sys::SDL_HasSSE41() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasSSE42")]
 pub fn has_sse42() -> bool {
     unsafe { sys::SDL_HasSSE42() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasAVX")]
 pub fn has_avx() -> bool {
     unsafe { sys::SDL_HasAVX() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasAVX2")]
 pub fn has_avx2() -> bool {
     unsafe { sys::SDL_HasAVX2() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_HasAVX512F")]
 pub fn has_avx512f() -> bool {
     unsafe { sys::SDL_HasAVX512F() == SDL_bool::SDL_TRUE }
 }
 
+#[doc(alias = "SDL_GetSystemRAM")]
 pub fn system_ram() -> i32 {
     unsafe { sys::SDL_GetSystemRAM() }
 }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -50,11 +50,13 @@ lazy_static! {
 
 impl crate::EventSubsystem {
     /// Removes all events in the event queue that match the specified event type.
+    #[doc(alias = "SDL_FlushEvent")]
     pub fn flush_event(&self, event_type: EventType) {
         unsafe { sys::SDL_FlushEvent(event_type as u32) };
     }
 
     /// Removes all events in the event queue that match the specified type range.
+    #[doc(alias = "SDL_FlushEvents")]
     pub fn flush_events(&self, min_type: u32, max_type: u32) {
         unsafe { sys::SDL_FlushEvents(min_type, max_type) };
     }
@@ -79,6 +81,7 @@ impl crate::EventSubsystem {
     ///     println!("{:?}", event);
     /// }
     /// ```
+    #[doc(alias = "SDL_PeepEvents")]
     pub fn peek_events<B>(&self, max_amount: u32) -> B
     where B: FromIterator<Event>
     {
@@ -770,6 +773,7 @@ unsafe impl Sync for Event {}
 
 /// Helper function to make converting scancodes
 /// and keycodes to primitive `SDL_Keysym` types.
+#[doc(alias = "SDL_Keysym")]
 fn mk_keysym<S, K>(scancode: S,
              keycode: K,
              keymod: Mod) -> sys::SDL_Keysym
@@ -2359,6 +2363,7 @@ unsafe fn wait_event_timeout(timeout: u32) -> Option<Event> {
 
 impl crate::EventPump {
     /// Query if an event type is enabled.
+    #[doc(alias = "SDL_EventState")]
     pub fn is_event_enabled(&self, event_type: EventType) -> bool {
         let result = unsafe { sys::SDL_EventState(event_type as u32, sys::SDL_QUERY) };
 
@@ -2366,6 +2371,7 @@ impl crate::EventPump {
     }
 
     /// Enable an event type. Returns if the event type was enabled before the call.
+    #[doc(alias = "SDL_EventState")]
     pub fn enable_event(&mut self, event_type: EventType) -> bool {
         let result = unsafe { sys::SDL_EventState(event_type as u32, sys::SDL_ENABLE as c_int) };
 
@@ -2373,6 +2379,7 @@ impl crate::EventPump {
     }
 
     /// Disable an event type. Returns if the event type was enabled before the call.
+    #[doc(alias = "SDL_EventState")]
     pub fn disable_event(&mut self, event_type: EventType) -> bool {
         let result = unsafe { sys::SDL_EventState(event_type as u32, sys::SDL_DISABLE as c_int) };
 
@@ -2409,6 +2416,7 @@ impl crate::EventPump {
     }
 
     /// Pumps the event loop, gathering events from the input devices.
+    #[doc(alias = "SDL_PumpEvents")]
     pub fn pump_events(&mut self) {
         unsafe { sys::SDL_PumpEvents(); };
     }
@@ -2768,6 +2776,7 @@ pub struct EventSender {
 
 impl EventSender {
     /// Pushes an event to the event queue.
+    #[doc(alias = "SDL_PushEvent")]
     pub fn push_event(&self, event: Event) -> Result<(), String> {
         match event.to_ll() {
             Some(mut raw_event) => {

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -7,6 +7,7 @@ use libc::c_char;
 
 use crate::sys;
 
+#[doc(alias = "SDL_GetBasePath")]
 pub fn base_path() -> Result<String, String> {
     let result = unsafe {
         let buf = sys::SDL_GetBasePath();
@@ -56,6 +57,7 @@ impl error::Error for PrefPathError {
 // TODO: Change to OsStr or something?
 /// Return the preferred directory for the application to write files on this
 /// system, based on the given organization and application name.
+#[doc(alias = "SDL_GetPrefPath")]
 pub fn pref_path(org_name: &str, app_name: &str)
         -> Result<String, PrefPathError> {
     use self::PrefPathError::*;

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -7,6 +7,7 @@ use crate::get_error;
 
 impl HapticSubsystem {
     /// Attempt to open the joystick at index `joystick_index` and return its haptic device.
+    #[doc(alias = "SDL_JoystickOpen")]
     pub fn open_from_joystick_id(&self, joystick_index: u32) -> Result<Haptic, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
@@ -37,6 +38,7 @@ pub struct Haptic {
 
 impl Haptic {
     #[inline]
+    #[doc(alias = "SDL_HapticRumblePlay")]
     pub fn subsystem(&self) -> &HapticSubsystem { &self.subsystem }
 
     /// Run a simple rumble effect on the haptic device.
@@ -45,6 +47,7 @@ impl Haptic {
     }
 
     /// Stop the simple rumble on the haptic device.
+    #[doc(alias = "SDL_HapticRumbleStop")]
     pub fn rumble_stop(&mut self) {
         unsafe { sys::SDL_HapticRumbleStop(self.raw) };
     }
@@ -52,6 +55,7 @@ impl Haptic {
 
 
 impl Drop for Haptic {
+    #[doc(alias = "SDL_HapticClose")]
     fn drop(&mut self) {
         unsafe { sys::SDL_HapticClose(self.raw) }
     }

--- a/src/sdl2/hint.rs
+++ b/src/sdl2/hint.rs
@@ -73,6 +73,7 @@ pub fn get_video_minimize_on_focus_loss() -> bool {
     }
 }
 
+#[doc(alias = "SDL_SetHint")]
 pub fn set(name: &str, value: &str) -> bool{
     let name = CString::new(name).unwrap();
     let value = CString::new(value).unwrap();
@@ -81,6 +82,7 @@ pub fn set(name: &str, value: &str) -> bool{
     }
 }
 
+#[doc(alias = "SDL_GetHint")]
 pub fn get(name: &str) -> Option<String> {
     use std::str;
 
@@ -97,6 +99,7 @@ pub fn get(name: &str) -> Option<String> {
     }
 }
 
+#[doc(alias = "SDL_SetHintWithPriority")]
 pub fn set_with_priority(name: &str, value: &str, priority: &Hint) -> bool {
     let name = CString::new(name).unwrap();
     let value = CString::new(value).unwrap();

--- a/src/sdl2/image/mod.rs
+++ b/src/sdl2/image/mod.rs
@@ -152,6 +152,7 @@ impl<T> LoadTexture for TextureCreator<T> {
         }
     }
 
+    #[doc(alias = "IMG_LoadTexture")]
     fn load_texture_bytes(&self, buf: &[u8]) -> Result<Texture, String> {
         //! Loads an SDL Texture from a buffer that the format must be something supported by SDL2_image (png, jpeg, ect, but NOT RGBA8888 bytes for instance)
         unsafe {

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -11,6 +11,7 @@ use crate::common::{validate_int, IntegerOrSdlError};
 
 impl JoystickSubsystem {
     /// Retrieve the total number of attached joysticks *and* controllers identified by SDL.
+    #[doc(alias = "SDL_NumJoysticks")]
     pub fn num_joysticks(&self) -> Result<u32, String> {
         let result = unsafe { sys::SDL_NumJoysticks() };
 
@@ -22,6 +23,7 @@ impl JoystickSubsystem {
     }
 
     /// Attempt to open the joystick at index `joystick_index` and return it.
+    #[doc(alias = "SDL_JoystickOpen")]
     pub fn open(&self, joystick_index: u32)
             -> Result<Joystick, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
@@ -40,6 +42,7 @@ impl JoystickSubsystem {
     }
 
     /// Return the name of the joystick at index `joystick_index`.
+    #[doc(alias = "SDL_JoystickNameForIndex")]
     pub fn name_for_index(&self, joystick_index: u32) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
@@ -56,6 +59,7 @@ impl JoystickSubsystem {
     }
 
     /// Get the GUID for the joystick at index `joystick_index`
+    #[doc(alias = "SDL_JoystickGetDeviceGUID")]
     pub fn device_guid(&self, joystick_index: u32) -> Result<Guid, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
@@ -73,11 +77,13 @@ impl JoystickSubsystem {
 
     /// If state is `true` joystick events are processed, otherwise
     /// they're ignored.
+    #[doc(alias = "SDL_JoystickEventState")]
     pub fn set_event_state(&self, state: bool) {
         unsafe { sys::SDL_JoystickEventState(state as i32) };
     }
 
     /// Return `true` if joystick events are processed.
+    #[doc(alias = "SDL_JoystickEventState")]
     pub fn event_state(&self) -> bool {
         unsafe { sys::SDL_JoystickEventState(sys::SDL_QUERY as i32)
                  == sys::SDL_ENABLE as i32 }
@@ -85,6 +91,7 @@ impl JoystickSubsystem {
 
     /// Force joystick update when not using the event loop
     #[inline]
+    #[doc(alias = "SDL_JoystickUpdate")]
     pub fn update(&self) {
         unsafe { sys::SDL_JoystickUpdate() };
     }
@@ -140,6 +147,7 @@ impl Joystick {
 
     /// Return the name of the joystick or an empty string if no name
     /// is found.
+    #[doc(alias = "SDL_JoystickName")]
     pub fn name(&self) -> String {
         let name = unsafe { sys::SDL_JoystickName(self.raw) };
 
@@ -148,10 +156,12 @@ impl Joystick {
 
     /// Return true if the joystick has been opened and currently
     /// connected.
+    #[doc(alias = "SDL_JoystickGetAttached")]
     pub fn attached(&self) -> bool {
         unsafe { sys::SDL_JoystickGetAttached(self.raw) != sys::SDL_bool::SDL_FALSE }
     }
 
+    #[doc(alias = "SDL_JoystickInstanceID")]
     pub fn instance_id(&self) -> u32 {
         let result = unsafe { sys::SDL_JoystickInstanceID(self.raw) };
 
@@ -164,6 +174,7 @@ impl Joystick {
     }
 
     /// Retrieve the joystick's GUID
+    #[doc(alias = "SDL_JoystickGetGUID")]
     pub fn guid(&self) -> Guid {
         let raw = unsafe { sys::SDL_JoystickGetGUID(self.raw) };
 
@@ -178,6 +189,7 @@ impl Joystick {
     }
 
     /// Retrieve the battery level of this joystick
+    #[doc(alias = "SDL_JoystickCurrentPowerLevel")]
     pub fn power_level(&self) -> Result<PowerLevel, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         clear_error();
@@ -200,6 +212,7 @@ impl Joystick {
     }
 
     /// Retrieve the number of axes for this joystick
+    #[doc(alias = "SDL_JoystickNumAxes")]
     pub fn num_axes(&self) -> u32 {
         let result = unsafe { sys::SDL_JoystickNumAxes(self.raw) };
 
@@ -214,6 +227,7 @@ impl Joystick {
     /// Gets the position of the given `axis`.
     ///
     /// The function will fail if the joystick doesn't have the provided axis.
+    #[doc(alias = "SDL_JoystickGetAxis")]
     pub fn axis(&self, axis: u32) -> Result<i16, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         // This interface is a bit messed up: 0 is a valid position
@@ -239,6 +253,7 @@ impl Joystick {
     }
 
     /// Retrieve the number of buttons for this joystick
+    #[doc(alias = "SDL_JoystickNumButtons")]
     pub fn num_buttons(&self) -> u32 {
         let result = unsafe { sys::SDL_JoystickNumButtons(self.raw) };
 
@@ -253,6 +268,7 @@ impl Joystick {
     /// Return `Ok(true)` if `button` is pressed.
     ///
     /// The function will fail if the joystick doesn't have the provided button.
+    #[doc(alias = "SDL_JoystickGetButton")]
     pub fn button(&self, button: u32) -> Result<bool, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         // Same deal as axis, 0 can mean both unpressed or
@@ -280,6 +296,7 @@ impl Joystick {
     }
 
     /// Retrieve the number of balls for this joystick
+    #[doc(alias = "SDL_JoystickNumBalls")]
     pub fn num_balls(&self) -> u32 {
         let result = unsafe { sys::SDL_JoystickNumBalls(self.raw) };
 
@@ -293,6 +310,7 @@ impl Joystick {
 
     /// Return a pair `(dx, dy)` containing the difference in axis
     /// position since the last poll
+    #[doc(alias = "SDL_JoystickGetBall")]
     pub fn ball(&self, ball: u32) -> Result<(i32, i32), IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let mut dx = 0;
@@ -309,6 +327,7 @@ impl Joystick {
     }
 
     /// Retrieve the number of balls for this joystick
+    #[doc(alias = "SDL_JoystickNumHats")]
     pub fn num_hats(&self) -> u32 {
         let result = unsafe { sys::SDL_JoystickNumHats(self.raw) };
 
@@ -321,6 +340,7 @@ impl Joystick {
     }
 
     /// Return the position of `hat` for this joystick
+    #[doc(alias = "SDL_JoystickGetHat")]
     pub fn hat(&self, hat: u32) -> Result<HatState, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         // Guess what? This function as well uses 0 to report an error
@@ -357,6 +377,7 @@ impl Joystick {
     /// the rumble effect to keep playing for a long time, as this results in
     /// the effect ending immediately after starting due to an overflow.
     /// Use some smaller, "huge enough" number instead.
+    #[doc(alias = "SDL_JoystickRumble")]
     pub fn set_rumble(&mut self,
                       low_frequency_rumble: u16,
                       high_frequency_rumble: u16,
@@ -379,6 +400,7 @@ impl Joystick {
 }
 
 impl Drop for Joystick {
+    #[doc(alias = "SDL_JoystickClose")]
     fn drop(&mut self) {
         if self.attached() {
             unsafe { sys::SDL_JoystickClose(self.raw) }
@@ -403,6 +425,7 @@ impl Eq for Guid {}
 
 impl Guid {
     /// Create a GUID from a string representation.
+    #[doc(alias = "SDL_JoystickGetGUIDFromString")]
     pub fn from_string(guid: &str) -> Result<Guid, NulError> {
         let guid = CString::new(guid)?;
 
@@ -423,6 +446,7 @@ impl Guid {
     }
 
     /// Return a String representation of GUID
+    #[doc(alias = "SDL_JoystickGetGUIDString")]
     pub fn string(&self) -> String {
         // Doc says "buf should supply at least 33bytes". I took that
         // to mean that 33bytes should be enough in all cases, but

--- a/src/sdl2/keyboard/keycode.rs
+++ b/src/sdl2/keyboard/keycode.rs
@@ -504,6 +504,7 @@ use crate::keyboard::Scancode;
 
 impl Keycode {
     /// Gets the virtual key from a scancode. Returns None if there is no corresponding virtual key.
+    #[doc(alias = "SDL_GetKeyFromScancode")]
     pub fn from_scancode(scancode: Scancode) -> Option<Keycode> {
         const UNKNOWN: i32 = sys::SDLK_UNKNOWN as i32;
         unsafe {
@@ -514,6 +515,7 @@ impl Keycode {
         }
     }
 
+    #[doc(alias = "SDL_GetKeyFromName")]
     pub fn from_name(name: &str) -> Option<Keycode> {
         const UNKNOWN: i32 = sys::SDLK_UNKNOWN as i32;
         unsafe {
@@ -528,6 +530,7 @@ impl Keycode {
         }
     }
 
+    #[doc(alias = "SDL_GetKeyName")]
     pub fn name(self) -> String {
         // The name string pointer's contents _might_ change, depending on the last call to SDL_GetKeyName.
         // Knowing this, we must always return a new string.

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -41,6 +41,7 @@ pub struct KeyboardState<'a> {
 }
 
 impl<'a> KeyboardState<'a> {
+    #[doc(alias = "SDL_GetKeyboardState")]
     pub fn new(_e: &'a EventPump) -> KeyboardState<'a> {
         let keyboard_state = unsafe {
             let mut count = 0;
@@ -179,6 +180,7 @@ pub struct KeyboardUtil {
 
 impl KeyboardUtil {
     /// Gets the id of the window which currently has keyboard focus.
+    #[doc(alias = "SDL_GetKeyboardFocus")]
     pub fn focused_window_id(&self) -> Option<u32> {
         let raw = unsafe { sys::SDL_GetKeyboardFocus() };
         if raw.is_null() {
@@ -189,10 +191,12 @@ impl KeyboardUtil {
         }
     }
 
+    #[doc(alias = "SDL_GetModState")]
     pub fn mod_state(&self) -> Mod {
         unsafe { Mod::from_bits(sys::SDL_GetModState() as u16).unwrap() }
     }
 
+    #[doc(alias = "SDL_SetModState")]
     pub fn set_mod_state(&self, flags: Mod) {
         unsafe { sys::SDL_SetModState(transmute::<u32, sys::SDL_Keymod>(flags.bits() as u32)); }
     }
@@ -214,26 +218,32 @@ pub struct TextInputUtil {
 }
 
 impl TextInputUtil {
+    #[doc(alias = "SDL_StartTextInput")]
     pub fn start(&self) {
         unsafe { sys::SDL_StartTextInput(); }
     }
 
+    #[doc(alias = "SDL_IsTextInputActive")]
     pub fn is_active(&self, ) -> bool {
         unsafe { sys::SDL_IsTextInputActive() == sys::SDL_bool::SDL_TRUE }
     }
 
+    #[doc(alias = "SDL_StopTextInput")]
     pub fn stop(&self) {
         unsafe { sys::SDL_StopTextInput(); }
     }
 
+    #[doc(alias = "SDL_SetTextInputRect")]
     pub fn set_rect(&self, rect: Rect) {
         unsafe { sys::SDL_SetTextInputRect(rect.raw() as *mut sys::SDL_Rect); }
     }
 
+    #[doc(alias = "SDL_HasScreenKeyboardSupport")]
     pub fn has_screen_keyboard_support(&self) -> bool {
         unsafe { sys::SDL_HasScreenKeyboardSupport() == sys::SDL_bool::SDL_TRUE }
     }
 
+    #[doc(alias = "SDL_IsScreenKeyboardShown")]
     pub fn is_screen_keyboard_shown(&self, window: &Window) -> bool {
         unsafe { sys::SDL_IsScreenKeyboardShown(window.raw()) == sys::SDL_bool::SDL_TRUE }
     }

--- a/src/sdl2/keyboard/scancode.rs
+++ b/src/sdl2/keyboard/scancode.rs
@@ -517,6 +517,7 @@ use crate::keyboard::Keycode;
 
 impl Scancode {
     /// Gets the scancode from a virtual key. Returns None if there is no corresponding scancode.
+    #[doc(alias = "SDL_GetScancodeFromKey")]
     pub fn from_keycode(keycode: Keycode) -> Option<Scancode> {
         unsafe {
             match sys::SDL_GetScancodeFromKey(keycode as i32) {
@@ -526,6 +527,7 @@ impl Scancode {
         }
     }
 
+    #[doc(alias = "SDL_GetScancodeFromName")]
     pub fn from_name(name: &str) -> Option<Scancode> {
         unsafe {
             match CString::new(name) {
@@ -539,6 +541,7 @@ impl Scancode {
         }
     }
 
+    #[doc(alias = "SDL_GetScancodeName")]
     pub fn name(self) -> &'static str {
         // The name string pointer lives in static, read-only memory.
         // Knowing this, we can always return a string slice.

--- a/src/sdl2/log.rs
+++ b/src/sdl2/log.rs
@@ -85,6 +85,7 @@ unsafe extern "C" fn rust_sdl2_log_fn(_userdata: *mut libc::c_void,
     custom_log_fn(priority, category, &*message);
 }
 
+#[doc(alias = "SDL_LogSetOutputFunction")]
 pub fn set_output_function(callback : fn(Priority, Category, &str)) {
     unsafe {
         custom_log_fn = callback;
@@ -94,6 +95,7 @@ pub fn set_output_function(callback : fn(Priority, Category, &str)) {
 
 /// Standard log function which takes as priority INFO and
 /// as category APPLICATION
+#[doc(alias = "SDL_Log")]
 pub fn log(message: &str) {
     let message = message.replace('%', "%%");
     let message = CString::new(message).unwrap();

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -141,6 +141,7 @@ impl error::Error for ShowMessageError {
 /// There is no way to know if the user clicked "Ok" or closed the message box,
 /// If you want to retrieve which button was clicked and customize a bit more
 /// your message box, use `show_message_box` instead.
+#[doc(alias = "SDL_ShowSimpleMessageBox")]
 pub fn show_simple_message_box<'a, W>(flags: MessageBoxFlag, title: &str,
         message: &str, window: W)
         -> Result<(), ShowMessageError>
@@ -180,6 +181,7 @@ where W: Into<Option<&'a Window>>
 /// Note that the variant of the `ClickedButton` enum will also be returned if the message box
 /// has been forcefully closed (Alt-F4, ...)
 ///
+#[doc(alias = "SDL_ShowMessageBox")]
 pub fn show_message_box<'a, 'b, W, M>(flags:MessageBoxFlag, buttons:&'a [ButtonData], title:&str,
     message:&str, window: W, scheme: M)
     -> Result<ClickedButton<'a>,ShowMessageError>

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -791,6 +791,7 @@ impl<'a> Music<'a> {
     }
 
     /// Load music from a static byte buffer.
+    #[doc(alias = "SDL_RWFromConstMem")]
     pub fn from_static_bytes(buf: &'static [u8]) -> Result<Music<'static>, String> {
         let rw = unsafe {
             sys::SDL_RWFromConstMem(buf.as_ptr() as *const c_void, buf.len() as c_int)

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -33,12 +33,14 @@ pub struct Cursor {
 
 impl Drop for Cursor {
     #[inline]
+    #[doc(alias = "SDL_FreeCursor")]
     fn drop(&mut self) {
         unsafe { sys::SDL_FreeCursor(self.raw) };
     }
 }
 
 impl Cursor {
+    #[doc(alias = "SDL_CreateCursor")]
     pub fn new(data: &[u8], mask: &[u8], width: i32, height: i32, hot_x: i32, hot_y: i32) -> Result<Cursor, String> {
         unsafe {
             let raw = sys::SDL_CreateCursor(data.as_ptr(),
@@ -55,6 +57,7 @@ impl Cursor {
     }
 
     // TODO: figure out how to pass Surface in here correctly
+    #[doc(alias = "SDL_CreateColorCursor")]
     pub fn from_surface<S: AsRef<SurfaceRef>>(surface: S, hot_x: i32, hot_y: i32) -> Result<Cursor, String> {
         unsafe {
             let raw = sys::SDL_CreateColorCursor(surface.as_ref().raw(), hot_x, hot_y);
@@ -67,6 +70,7 @@ impl Cursor {
         }
     }
 
+    #[doc(alias = "SDL_CreateSystemCursor")]
     pub fn from_system(cursor: SystemCursor) -> Result<Cursor, String> {
         unsafe {
             let raw = sys::SDL_CreateSystemCursor(transmute(cursor as u32));
@@ -79,6 +83,7 @@ impl Cursor {
         }
     }
 
+    #[doc(alias = "SDL_SetCursor")]
     pub fn set(&self) {
         unsafe { sys::SDL_SetCursor(self.raw); }
     }
@@ -160,6 +165,7 @@ pub struct MouseState {
 }
 
 impl MouseState {
+    #[doc(alias = "SDL_GetMouseState")]
     pub fn new(_e: &EventPump) -> MouseState {
         let mut x = 0;
         let mut y = 0;
@@ -338,6 +344,7 @@ pub struct MouseUtil {
 
 impl MouseUtil {
     /// Gets the id of the window which currently has mouse focus.
+    #[doc(alias = "SDL_GetMouseFocus")]
     pub fn focused_window_id(&self) -> Option<u32> {
         let raw = unsafe { sys::SDL_GetMouseFocus() };
         if raw.is_null() {
@@ -348,27 +355,33 @@ impl MouseUtil {
         }
     }
 
+    #[doc(alias = "SDL_WarpMouseInWindow")]
     pub fn warp_mouse_in_window(&self, window: &video::Window, x: i32, y: i32) {
         unsafe { sys::SDL_WarpMouseInWindow(window.raw(), x, y); }
     }
 
+    #[doc(alias = "SDL_SetRelativeMouseMode")]
     pub fn set_relative_mouse_mode(&self, on: bool) {
         let on = if on { sys::SDL_bool::SDL_TRUE } else { sys::SDL_bool::SDL_FALSE };
         unsafe { sys::SDL_SetRelativeMouseMode(on); }
     }
 
+    #[doc(alias = "SDL_GetRelativeMouseMode")]
     pub fn relative_mouse_mode(&self) -> bool {
         unsafe { sys::SDL_GetRelativeMouseMode() == sys::SDL_bool::SDL_TRUE }
     }
 
+    #[doc(alias = "SDL_ShowCursor")]
     pub fn is_cursor_showing(&self) -> bool {
         unsafe { sys::SDL_ShowCursor(crate::sys::SDL_QUERY) == 1 }
     }
 
+    #[doc(alias = "SDL_ShowCursor")]
     pub fn show_cursor(&self, show: bool) {
         unsafe { sys::SDL_ShowCursor(show as i32); }
     }
 
+    #[doc(alias = "SDL_CaptureMouse")]
     pub fn capture(&self, enable: bool) {
         let enable = if enable { sys::SDL_bool::SDL_TRUE } else { sys::SDL_bool::SDL_FALSE };
         unsafe { sys::SDL_CaptureMouse(enable); }

--- a/src/sdl2/mouse/relative.rs
+++ b/src/sdl2/mouse/relative.rs
@@ -12,6 +12,7 @@ pub struct RelativeMouseState {
 }
 
 impl RelativeMouseState {
+    #[doc(alias = "SDL_GetRelativeMouseState")]
     pub fn new(_e: &EventPump) -> RelativeMouseState {
         let mut x = 0;
         let mut y = 0;

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -11,6 +11,7 @@ pub struct Palette {
 impl Palette {
     #[inline]
     /// Creates a new, uninitialized palette
+    #[doc(alias = "SDL_AllocPalette")]
     pub fn new(mut capacity: usize) -> Result<Self, String> {
         use crate::common::*;
 
@@ -39,6 +40,7 @@ impl Palette {
     }
 
     /// Creates a palette from the provided colors
+    #[doc(alias = "SDL_SetPaletteColors")]
     pub fn with_colors(colors: &[Color]) -> Result<Self, String> {
         let pal = Self::new(colors.len())?;
 
@@ -72,6 +74,7 @@ impl Palette {
 }
 
 impl Drop for Palette {
+    #[doc(alias = "SDL_FreePalette")]
     fn drop(&mut self) {
         unsafe { sys::SDL_FreePalette(self.raw); }
     }
@@ -111,10 +114,12 @@ impl Color {
         Color { r, g, b, a }
     }
 
+    #[doc(alias = "SDL_MapRGBA")]
     pub fn to_u32(self, format: &PixelFormat) -> u32 {
         unsafe { sys::SDL_MapRGBA(format.raw, self.r, self.g, self.b, self.a) }
     }
 
+    #[doc(alias = "SDL_GetRGBA")]
     pub fn from_u32(format: &PixelFormat, pixel: u32) -> Color {
         let (mut r, mut g, mut b, mut a) = (0, 0, 0, 0);
 
@@ -261,6 +266,7 @@ impl PixelFormatEnum {
 }
 
 impl PixelFormatEnum {
+    #[doc(alias = "SDL_MasksToPixelFormatEnum")]
     pub fn from_masks(masks: PixelMasks) -> PixelFormatEnum {
         unsafe {
             let format = sys::SDL_MasksToPixelFormatEnum(masks.bpp as i32, masks.rmask, masks.gmask, masks.bmask, masks.amask);
@@ -268,6 +274,7 @@ impl PixelFormatEnum {
         }
     }
 
+    #[doc(alias = "SDL_PixelFormatEnumToMasks")]
     pub fn into_masks(self) -> Result<PixelMasks, String> {
         let format: u32 = self as u32;
         let mut bpp = 0;
@@ -457,6 +464,7 @@ impl TryFrom<u32> for PixelFormatEnum {
 impl TryFrom<PixelFormatEnum> for PixelFormat {
     type Error = String;
 
+    #[doc(alias = "SDL_AllocFormat")]
     fn try_from(pfe: PixelFormatEnum) -> Result<Self, Self::Error> {
         unsafe {
             let pf_ptr = sys::SDL_AllocFormat(pfe as u32);

--- a/src/sdl2/raw_window_handle.rs
+++ b/src/sdl2/raw_window_handle.rs
@@ -4,6 +4,7 @@ use self::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use crate::{sys::SDL_Window, video::Window};
 
 unsafe impl HasRawWindowHandle for Window {
+    #[doc(alias = "SDL_GetVersion")]
     fn raw_window_handle(&self) -> RawWindowHandle {
         use self::SDL_SYSWM_TYPE::*;
 

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -402,6 +402,7 @@ impl Rect {
         self.raw() as *mut _
     }
 
+    #[doc(alias = "SDL_Rect")]
     pub fn raw_slice(slice: &[Rect]) -> *const sys::SDL_Rect {
         slice.as_ptr() as *const sys::SDL_Rect
     }
@@ -413,6 +414,7 @@ impl Rect {
     /// Calculate a minimal rectangle enclosing a set of points.
     /// If a clipping rectangle is given, only points that are within it will be
     /// considered.
+    #[doc(alias = "SDL_EnclosePoints")]
     pub fn from_enclose_points<R: Into<Option<Rect>>>(points: &[Point], clipping_rect: R)
             -> Option<Rect>
     where R: Into<Option<Rect>>
@@ -463,6 +465,7 @@ impl Rect {
     /// assert!(rect.has_intersection(Rect::new(2, 2, 5, 5)));
     /// assert!(!rect.has_intersection(Rect::new(5, 0, 5, 5)));
     /// ```
+    #[doc(alias = "SDL_HasIntersection")]
     pub fn has_intersection(&self, other: Rect) -> bool {
         unsafe {
             sys::SDL_HasIntersection(self.raw(), other.raw()) != sys::SDL_bool::SDL_FALSE
@@ -487,6 +490,7 @@ impl Rect {
     ///            Some(Rect::new(2, 2, 3, 3)));
     /// assert_eq!(rect.intersection(Rect::new(5, 0, 5, 5)), None);
     /// ```
+    #[doc(alias = "SDL_IntersectRect")]
     pub fn intersection(&self, other: Rect) -> Option<Rect> {
         let mut out = mem::MaybeUninit::uninit();
 
@@ -516,6 +520,7 @@ impl Rect {
     /// assert_eq!(rect.union(Rect::new(2, 2, 5, 5)), Rect::new(0, 0, 7, 7));
     /// assert_eq!(rect.union(Rect::new(5, 0, 5, 5)), Rect::new(0, 0, 10, 5));
     /// ```
+    #[doc(alias = "SDL_UnionRect")]
     pub fn union(&self, other: Rect) -> Rect {
         let mut out = mem::MaybeUninit::uninit();
 
@@ -532,6 +537,7 @@ impl Rect {
 
     /// Calculates the intersection of a rectangle and a line segment and
     /// returns the points of their intersection.
+    #[doc(alias = "SDL_IntersectRectAndLine")]
     pub fn intersect_line(&self, start: Point, end: Point)
             -> Option<(Point, Point)> {
 
@@ -622,6 +628,7 @@ impl AsMut<sys::SDL_Rect> for Rect {
 // Intersection
 impl BitAnd<Rect> for Rect {
     type Output = Option<Rect>;
+    #[doc(alias = "SDL_Point")]
     fn bitand(self, rhs: Rect) -> Option<Rect> { self.intersection(rhs) }
 }
 
@@ -738,6 +745,7 @@ impl Point {
         Point::new(raw.x, raw.y)
     }
 
+    #[doc(alias = "SDL_Point")]
     pub fn raw_slice(slice: &[Point]) -> *const sys::SDL_Point {
         slice.as_ptr() as *const sys::SDL_Point
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -194,6 +194,7 @@ pub struct RendererContext<T> {
 }
 
 impl<T> Drop for RendererContext<T> {
+    #[doc(alias = "SDL_DestroyRenderer")]
     fn drop(&mut self) {
         unsafe {
             sys::SDL_DestroyRenderer(self.raw);
@@ -203,6 +204,7 @@ impl<T> Drop for RendererContext<T> {
 
 impl<T> RendererContext<T> {
     /// Gets information about the rendering context.
+    #[doc(alias = "SDL_GetRendererInfo")]
     pub fn info(&self) -> RendererInfo {
         let mut renderer_info_raw = mem::MaybeUninit::uninit();
         let result = unsafe { sys::SDL_GetRendererInfo(self.raw, renderer_info_raw.as_mut_ptr()) != 0 };
@@ -337,6 +339,7 @@ impl<'s> Canvas<Surface<'s>> {
     ///
     /// This method should only fail if SDL2 is not built with rendering
     /// support, or there's an out-of-memory error.
+    #[doc(alias = "SDL_CreateSoftwareRenderer")]
     pub fn from_surface(surface: surface::Surface<'s>) -> Result<Self, String> {
         let raw_renderer = unsafe { sys::SDL_CreateSoftwareRenderer(surface.raw()) };
         if !raw_renderer.is_null() {
@@ -432,6 +435,7 @@ impl Canvas<Window> {
 
 impl<T: RenderTarget> Canvas<T> {
     /// Determine whether a window supports the use of render targets.
+    #[doc(alias = "SDL_RenderTargetSupported")]
     pub fn render_target_supported(&self) -> bool {
         unsafe { sys::SDL_RenderTargetSupported(self.context.raw) == sys::SDL_bool::SDL_TRUE }
     }
@@ -654,6 +658,7 @@ impl CanvasBuilder {
     }
 
     /// Builds the renderer.
+    #[doc(alias = "SDL_CreateRenderer")]
     pub fn build(self) -> Result<WindowCanvas, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let index = match self.index {
@@ -752,6 +757,7 @@ impl Error for TextureValueError {
     }
 }
 
+#[doc(alias = "SDL_CreateTexture")]
 fn ll_create_texture(context: *mut sys::SDL_Renderer,
                      pixel_format: PixelFormatEnum,
                      access: TextureAccess,
@@ -893,6 +899,7 @@ impl<T> TextureCreator<T> {
     /// let surface = Surface::new(512, 512, PixelFormatEnum::RGB24).unwrap();
     /// let texture = texture_creator.create_texture_from_surface(surface).unwrap();
     /// ```
+    #[doc(alias = "SDL_CreateTextureFromSurface")]
     pub fn create_texture_from_surface<S: AsRef<SurfaceRef>>
         (&self,
          surface: S)
@@ -936,6 +943,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Sets the color used for drawing operations (Rect, Line and Clear).
+    #[doc(alias = "SDL_SetRenderDrawColor")]
     pub fn set_draw_color<C: Into<pixels::Color>>(&mut self, color: C) {
         let (r, g, b, a) = color.into().rgba();
         let ret = unsafe { sys::SDL_SetRenderDrawColor(self.raw, r, g, b, a) };
@@ -946,6 +954,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Gets the color used for drawing operations (Rect, Line and Clear).
+    #[doc(alias = "SDL_GetRenderDrawColor")]
     pub fn draw_color(&self) -> pixels::Color {
         let (mut r, mut g, mut b, mut a) = (0, 0, 0, 0);
         let ret =
@@ -959,6 +968,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Sets the blend mode used for drawing operations (Fill and Line).
+    #[doc(alias = "SDL_SetRenderDrawBlendMode")]
     pub fn set_blend_mode(&mut self, blend: BlendMode) {
         let ret = unsafe {
             sys::SDL_SetRenderDrawBlendMode(self.context.raw, transmute(blend as u32))
@@ -970,6 +980,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Gets the blend mode used for drawing operations.
+    #[doc(alias = "SDL_GetRenderDrawBlendMode")]
     pub fn blend_mode(&self) -> BlendMode {
         let mut blend: MaybeUninit<SDL_BlendMode> = mem::MaybeUninit::uninit();
         let ret = unsafe { sys::SDL_GetRenderDrawBlendMode(self.context.raw, blend.as_mut_ptr()) };
@@ -983,6 +994,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Clears the current rendering target with the drawing color.
+    #[doc(alias = "SDL_RenderClear")]
     pub fn clear(&mut self) {
         let ret = unsafe { sys::SDL_RenderClear(self.context.raw) };
         if ret != 0 {
@@ -997,11 +1009,13 @@ impl<T: RenderTarget> Canvas<T> {
     /// the screen, but rather updates the backbuffer.
     /// As such, you compose your entire scene and present the composed
     /// backbuffer to the screen as a complete picture.
+    #[doc(alias = "SDL_RenderPresent")]
     pub fn present(&mut self) {
         unsafe { sys::SDL_RenderPresent(self.context.raw) }
     }
 
     /// Gets the output size of a rendering context.
+    #[doc(alias = "SDL_GetRendererOutputSize")]
     pub fn output_size(&self) -> Result<(u32, u32), String> {
         let mut width = 0;
         let mut height = 0;
@@ -1017,6 +1031,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Sets a device independent resolution for rendering.
+    #[doc(alias = "SDL_RenderSetLogicalSize")]
     pub fn set_logical_size(&mut self, width: u32, height: u32) -> Result<(), IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let width = validate_int(width, "width")?;
@@ -1029,6 +1044,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Gets device independent resolution for rendering.
+    #[doc(alias = "SDL_RenderGetLogicalSize")]
     pub fn logical_size(&self) -> (u32, u32) {
         let mut width = 0;
         let mut height = 0;
@@ -1039,6 +1055,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Sets the drawing area for rendering on the current target.
+    #[doc(alias = "SDL_RenderSetViewport")]
     pub fn set_viewport<R: Into<Option<Rect>>>(&mut self, rect: R) {
         let ptr = match rect.into() {
             Some(ref rect) => rect.raw(),
@@ -1051,6 +1068,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Gets the drawing area for the current target.
+    #[doc(alias = "SDL_RenderGetViewport")]
     pub fn viewport(&self) -> Rect {
         let mut rect = mem::MaybeUninit::uninit();
         unsafe { sys::SDL_RenderGetViewport(self.context.raw, rect.as_mut_ptr()) };
@@ -1061,6 +1079,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Sets the clip rectangle for rendering on the specified target.
     ///
     /// If the rectangle is `None`, clipping will be disabled.
+    #[doc(alias = "SDL_RenderSetClipRect")]
     pub fn set_clip_rect<R: Into<Option<Rect>>>(&mut self, rect: R) {
         let ret = unsafe {
             sys::SDL_RenderSetClipRect(self.context.raw,
@@ -1077,6 +1096,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Gets the clip rectangle for the current target.
     ///
     /// Returns `None` if clipping is disabled.
+    #[doc(alias = "SDL_RenderGetClipRect")]
     pub fn clip_rect(&self) -> Option<Rect> {
         let mut raw = mem::MaybeUninit::uninit();
         unsafe { sys::SDL_RenderGetClipRect(self.context.raw, raw.as_mut_ptr()) };
@@ -1089,6 +1109,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Sets the drawing scale for rendering on the current target.
+    #[doc(alias = "SDL_RenderSetScale")]
     pub fn set_scale(&mut self, scale_x: f32, scale_y: f32) -> Result<(), String> {
         let ret = unsafe { sys::SDL_RenderSetScale(self.context.raw, scale_x, scale_y) };
         // Should only fail on an invalid renderer
@@ -1096,6 +1117,7 @@ impl<T: RenderTarget> Canvas<T> {
     }
 
     /// Gets the drawing scale for the current target.
+    #[doc(alias = "SDL_RenderGetScale")]
     pub fn scale(&self) -> (f32, f32) {
         let mut scale_x = 0.0;
         let mut scale_y = 0.0;
@@ -1105,6 +1127,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws a point on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawPoint")]
     pub fn draw_point<P: Into<Point>>(&mut self, point: P) -> Result<(), String> {
         let point = point.into();
         let result = unsafe { sys::SDL_RenderDrawPoint(self.context.raw, point.x(), point.y()) };
@@ -1117,6 +1140,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws multiple points on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawPoints")]
     pub fn draw_points<'a, P: Into<&'a [Point]>>(&mut self, points: P) -> Result<(), String> {
         let points = points.into();
         let result = unsafe {
@@ -1133,6 +1157,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws a line on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawLine")]
     pub fn draw_line<P1: Into<Point>, P2: Into<Point>>(&mut self,
                                                        start: P1,
                                                        end: P2)
@@ -1151,6 +1176,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws a series of connected lines on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawLines")]
     pub fn draw_lines<'a, P: Into<&'a [Point]>>(&mut self, points: P) -> Result<(), String> {
         let points = points.into();
         let result = unsafe {
@@ -1167,6 +1193,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws a rectangle on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawRect")]
     pub fn draw_rect(&mut self, rect: Rect) -> Result<(), String> {
         let result = unsafe { sys::SDL_RenderDrawRect(self.context.raw, rect.raw()) };
         if result != 0 {
@@ -1178,6 +1205,7 @@ impl<T: RenderTarget> Canvas<T> {
 
     /// Draws some number of rectangles on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderDrawRects")]
     pub fn draw_rects(&mut self, rects: &[Rect]) -> Result<(), String> {
         let result = unsafe {
             sys::SDL_RenderDrawRects(self.context.raw,
@@ -1195,6 +1223,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// color.
     /// Passing None will fill the entire rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderFillRect")]
     pub fn fill_rect<R: Into<Option<Rect>>>(&mut self, rect: R) -> Result<(), String> {
         let result = unsafe {
             sys::SDL_RenderFillRect(self.context.raw,
@@ -1213,6 +1242,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Fills some number of rectangles on the current rendering target with
     /// the drawing color.
     /// Errors if drawing fails for any reason (e.g. driver failure)
+    #[doc(alias = "SDL_RenderFillRects")]
     pub fn fill_rects(&mut self, rects: &[Rect]) -> Result<(), String> {
         let result = unsafe {
             sys::SDL_RenderFillRects(self.context.raw,
@@ -1234,6 +1264,7 @@ impl<T: RenderTarget> Canvas<T> {
     ///
     /// Errors if drawing fails for any reason (e.g. driver failure),
     /// or if the provided texture does not belong to the renderer.
+    #[doc(alias = "SDL_RenderCopy")]
     pub fn copy<R1, R2>(&mut self, texture: &Texture, src: R1, dst: R2) -> Result<(), String>
         where R1: Into<Option<Rect>>,
               R2: Into<Option<Rect>>
@@ -1267,6 +1298,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Errors if drawing fails for any reason (e.g. driver failure),
     /// if the provided texture does not belong to the renderer,
     /// or if the driver does not support RenderCopyEx.
+    #[doc(alias = "SDL_RenderCopyEx")]
     pub fn copy_ex<R1, R2, P>(&mut self,
                               texture: &Texture,
                               src: R1,
@@ -1316,6 +1348,7 @@ impl<T: RenderTarget> Canvas<T> {
     /// Reads pixels from the current rendering target.
     /// # Remarks
     /// WARNING: This is a very slow operation, and should not be used frequently.
+    #[doc(alias = "SDL_RenderReadPixels")]
     pub fn read_pixels<R: Into<Option<Rect>>>(&self,
                                               rect: R,
                                               format: pixels::PixelFormatEnum)
@@ -1449,6 +1482,7 @@ impl<T: RenderTarget> Canvas<T> {
     ///
     /// Note that this method is only accessible in Canvas with the `unsafe_textures` feature.
     #[cfg(feature = "unsafe_textures")]
+    #[doc(alias = "SDL_CreateTextureFromSurface")]
     pub fn create_texture_from_surface<S: AsRef<SurfaceRef>>
         (&self,
          surface: S)
@@ -1528,6 +1562,7 @@ pub struct Texture<'r> {
 
 #[cfg(not(feature = "unsafe_textures"))]
 impl<'r> Drop for Texture<'r> {
+    #[doc(alias = "SDL_DestroyTexture")]
     fn drop(&mut self) {
         unsafe {
             sys::SDL_DestroyTexture(self.raw);
@@ -1704,6 +1739,7 @@ struct InternalTexture {
 }
 
 impl InternalTexture {
+    #[doc(alias = "SDL_QueryTexture")]
     pub fn query(&self) -> TextureQuery {
         let mut format = 0;
         let mut access = 0;
@@ -1726,6 +1762,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_SetTextureColorMod")]
     pub fn set_color_mod(&mut self, red: u8, green: u8, blue: u8) {
         let ret = unsafe { sys::SDL_SetTextureColorMod(self.raw, red, green, blue) };
 
@@ -1734,6 +1771,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_GetTextureColorMod")]
     pub fn color_mod(&self) -> (u8, u8, u8) {
         let (mut r, mut g, mut b) = (0, 0, 0);
         let ret = unsafe { sys::SDL_GetTextureColorMod(self.raw, &mut r, &mut g, &mut b) };
@@ -1746,6 +1784,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_SetTextureAlphaMod")]
     pub fn set_alpha_mod(&mut self, alpha: u8) {
         let ret = unsafe { sys::SDL_SetTextureAlphaMod(self.raw, alpha) };
 
@@ -1754,6 +1793,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_GetTextureAlphaMod")]
     pub fn alpha_mod(&self) -> u8 {
         let mut alpha = 0;
         let ret = unsafe { sys::SDL_GetTextureAlphaMod(self.raw, &mut alpha) };
@@ -1762,6 +1802,7 @@ impl InternalTexture {
         if ret != 0 { panic!(get_error()) } else { alpha }
     }
 
+    #[doc(alias = "SDL_SetTextureBlendMode")]
     pub fn set_blend_mode(&mut self, blend: BlendMode) {
         let ret = unsafe {
             sys::SDL_SetTextureBlendMode(self.raw, transmute(blend as u32))
@@ -1772,6 +1813,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_GetTextureBlendMode")]
     pub fn blend_mode(&self) -> BlendMode {
         let mut blend: MaybeUninit<SDL_BlendMode> = mem::MaybeUninit::uninit();
         let ret = unsafe { sys::SDL_GetTextureBlendMode(self.raw, blend.as_mut_ptr()) };
@@ -1785,6 +1827,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_UpdateTexture")]
     pub fn update<R>(&mut self,
                      rect: R,
                      pixel_data: &[u8],
@@ -1843,6 +1886,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_UpdateYUVTexture")]
     pub fn update_yuv<R>(&mut self,
                          rect: R,
                          y_plane: &[u8],
@@ -1968,6 +2012,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_LockTexture")]
     pub fn with_lock<F, R, R2>(&mut self, rect: R2, func: F) -> Result<R, String>
         where F: FnOnce(&mut [u8], usize) -> R,
               R2: Into<Option<Rect>>
@@ -2023,6 +2068,7 @@ impl InternalTexture {
         }
     }
 
+    #[doc(alias = "SDL_GL_BindTexture")]
     pub fn gl_with_bind<R, F: FnOnce(f32, f32) -> R>(&mut self, f: F) -> R {
         unsafe {
             let mut texw = 0.0;
@@ -2358,6 +2404,7 @@ impl Iterator for DriverIterator {
     type Item = RendererInfo;
 
     #[inline]
+    #[doc(alias = "SDL_GetRenderDriverInfo")]
     fn next(&mut self) -> Option<RendererInfo> {
         if self.index >= self.length {
             None
@@ -2384,6 +2431,7 @@ impl ExactSizeIterator for DriverIterator {}
 
 /// Gets an iterator of all render drivers compiled into the SDL2 library.
 #[inline]
+#[doc(alias = "SDL_GetNumRenderDrivers")]
 pub fn drivers() -> DriverIterator {
     // This function is thread-safe and doesn't require the video subsystem to be initialized.
     // The list of drivers are read-only and statically compiled into SDL2, varying by platform.

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -29,6 +29,7 @@ impl<'a> RWops<'a> {
     }
 
     /// Creates an SDL file stream.
+    #[doc(alias = "SDL_RWFromFile")]
     pub fn from_file<P: AsRef<Path>>(path: P, mode: &str) -> Result<RWops <'static>, String> {
         let raw = unsafe {
             let path_c = CString::new(path.as_ref().to_str().unwrap()).unwrap();
@@ -49,6 +50,7 @@ impl<'a> RWops<'a> {
     /// Prepares a read-only memory buffer for use with `RWops`.
     ///
     /// This method can only fail if the buffer size is zero.
+    #[doc(alias = "SDL_RWFromConstMem")]
     pub fn from_bytes(buf: &'a [u8]) -> Result<RWops <'a>, String> {
         let raw = unsafe {
             sys::SDL_RWFromConstMem(buf.as_ptr() as *const c_void, buf.len() as c_int)
@@ -82,6 +84,7 @@ impl<'a> RWops<'a> {
     /// Prepares a read-write memory buffer for use with `RWops`.
     ///
     /// This method can only fail if the buffer size is zero.
+    #[doc(alias = "SDL_RWFromMem")]
     pub fn from_bytes_mut(buf: &'a mut [u8]) -> Result<RWops <'a>, String> {
         let raw = unsafe {
             sys::SDL_RWFromMem(buf.as_ptr() as *mut c_void, buf.len() as c_int)

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -69,6 +69,7 @@ pub struct Sdl {
 
 impl Sdl {
     #[inline]
+    #[doc(alias = "SDL_Init")]
     fn new() -> Result<Sdl, String> {
         unsafe {
             use std::sync::atomic::Ordering;
@@ -142,6 +143,7 @@ pub struct SdlDrop;
 
 impl Drop for SdlDrop {
     #[inline]
+    #[doc(alias = "SDL_Quit")]
     fn drop(&mut self) {
         use std::sync::atomic::Ordering;
 
@@ -161,6 +163,7 @@ macro_rules! subsystem {
     ($name:ident, $flag:expr) => (
         impl $name {
             #[inline]
+            #[doc(alias = "SDL_InitSubSystem")]
             fn new(sdl: &Sdl) -> Result<$name, String> {
                 let result = unsafe { sys::SDL_InitSubSystem($flag) };
 
@@ -234,6 +237,7 @@ struct SubsystemDrop {
 
 impl Drop for SubsystemDrop {
     #[inline]
+    #[doc(alias = "SDL_QuitSubSystem")]
     fn drop(&mut self) {
         unsafe { sys::SDL_QuitSubSystem(self.flag); }
     }
@@ -259,6 +263,7 @@ pub struct EventPump {
 impl EventPump {
     /// Obtains the SDL event pump.
     #[inline]
+    #[doc(alias = "SDL_InitSubSystem")]
     fn new(sdl: &Sdl) -> Result<EventPump, String> {
         // Called on the main SDL thread.
 
@@ -285,6 +290,7 @@ impl EventPump {
 
 impl Drop for EventPump {
     #[inline]
+    #[doc(alias = "SDL_QuitSubSystem")]
     fn drop(&mut self) {
         // Called on the main SDL thread.
 
@@ -298,6 +304,7 @@ impl Drop for EventPump {
 
 /// Get platform name
 #[inline]
+#[doc(alias = "SDL_GetPlatform")]
 pub fn get_platform() -> &'static str {
   unsafe {
     CStr::from_ptr(sys::SDL_GetPlatform()).to_str().unwrap()
@@ -319,6 +326,7 @@ pub fn get_platform() -> &'static str {
 /// // SDL_Quit() is called here as `sdl_context` is dropped.
 /// ```
 #[inline]
+#[doc(alias = "SDL_GetError")]
 pub fn init() -> Result<Sdl, String> { Sdl::new() }
 
 pub fn get_error() -> String {
@@ -328,6 +336,7 @@ pub fn get_error() -> String {
     }
 }
 
+#[doc(alias = "SDL_SetError")]
 pub fn set_error(err: &str) -> Result<(), NulError> {
     let c_string = CString::new(err)?;
     unsafe {
@@ -336,10 +345,12 @@ pub fn set_error(err: &str) -> Result<(), NulError> {
     Ok(())
 }
 
+#[doc(alias = "SDL_Error")]
 pub fn set_error_from_code(err: Error) {
     unsafe { sys::SDL_Error(transmute(err)); }
 }
 
+#[doc(alias = "SDL_ClearError")]
 pub fn clear_error() {
     unsafe { sys::SDL_ClearError(); }
 }

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -29,6 +29,7 @@ pub struct SurfaceContext<'a> {
 
 impl<'a> Drop for SurfaceContext<'a> {
     #[inline]
+    #[doc(alias = "SDL_FreeSurface")]
     fn drop(&mut self) {
         unsafe { sys::SDL_FreeSurface(self.raw); }
     }
@@ -130,6 +131,7 @@ impl<'a> Surface<'a> {
     /// let masks = PixelFormatEnum::RGB24.into_masks().unwrap();
     /// let surface = Surface::from_pixelmasks(512, 512, masks).unwrap();
     /// ```
+    #[doc(alias = "SDL_CreateRGBSurface")]
     pub fn from_pixelmasks(width: u32, height: u32, masks: pixels::PixelMasks) -> Result<Surface<'static>, String> {
         unsafe {
             if width >= (1<<31) || height >= (1<<31) {
@@ -154,6 +156,7 @@ impl<'a> Surface<'a> {
     }
 
     /// Creates a new surface from an existing buffer, using pixel masks.
+    #[doc(alias = "SDL_CreateRGBSurfaceFrom")]
     pub fn from_data_pixelmasks(data: &'a mut [u8], width: u32, height: u32, pitch: u32, masks: pixels::PixelMasks) -> Result<Surface<'a>, String> {
         unsafe {
             if width >= (1<<31) || height >= (1<<31) {
@@ -236,6 +239,7 @@ impl<'a> Surface<'a> {
         texture_creator.create_texture_from_surface(self)
     }
 
+    #[doc(alias = "SDL_LoadBMP_RW")]
     pub fn load_bmp_rw(rwops: &mut RWops) -> Result<Surface<'static>, String> {
         let raw = unsafe {
             sys::SDL_LoadBMP_RW(rwops.raw(), 0)
@@ -284,6 +288,7 @@ impl SurfaceRef {
     // this can prevent introducing UB until
     // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[doc(alias = "SDL_Surface")]
     pub fn raw(&self) -> *mut sys::SDL_Surface {
         self as *const SurfaceRef as *mut SurfaceRef as *mut () as *mut sys::SDL_Surface
     }
@@ -326,6 +331,7 @@ impl SurfaceRef {
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
+    #[doc(alias = "SDL_LockSurface")]
     pub fn with_lock<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
         unsafe {
             if sys::SDL_LockSurface(self.raw()) != 0 { panic!("could not lock surface"); }
@@ -340,6 +346,7 @@ impl SurfaceRef {
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
+    #[doc(alias = "SDL_LockSurface")]
     pub fn with_lock_mut<R, F: FnOnce(&mut [u8]) -> R>(&mut self, f: F) -> R {
         unsafe {
             if sys::SDL_LockSurface(self.raw()) != 0 { panic!("could not lock surface"); }
@@ -389,6 +396,7 @@ impl SurfaceRef {
         (self.raw_ref().flags & sys::SDL_RLEACCEL) != 0
     }
 
+    #[doc(alias = "SDL_SaveBMP_RW")]
     pub fn save_bmp_rw(&self, rwops: &mut RWops) -> Result<(), String> {
         let ret = unsafe {
             sys::SDL_SaveBMP_RW(self.raw(), rwops.raw(), 0)
@@ -402,6 +410,7 @@ impl SurfaceRef {
         self.save_bmp_rw(&mut file)
     }
 
+    #[doc(alias = "SDL_SetSurfacePalette")]
     pub fn set_palette(&mut self, palette: &pixels::Palette) -> Result<(), String> {
         let result = unsafe { sys::SDL_SetSurfacePalette(self.raw(), palette.raw()) };
 
@@ -412,6 +421,7 @@ impl SurfaceRef {
     }
 
     #[allow(non_snake_case)]
+    #[doc(alias = "SDL_SetSurfaceRLE")]
     pub fn enable_RLE(&mut self) {
         let result = unsafe { sys::SDL_SetSurfaceRLE(self.raw(), 1) };
 
@@ -422,6 +432,7 @@ impl SurfaceRef {
     }
 
     #[allow(non_snake_case)]
+    #[doc(alias = "SDL_SetSurfaceRLE")]
     pub fn disable_RLE(&mut self) {
         let result = unsafe { sys::SDL_SetSurfaceRLE(self.raw(), 0) };
 
@@ -431,6 +442,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_SetColorKey")]
     pub fn set_color_key(&mut self, enable: bool, color: pixels::Color) -> Result<(), String> {
         let key = color.to_u32(&self.pixel_format());
         let result = unsafe {
@@ -444,6 +456,7 @@ impl SurfaceRef {
     }
 
     /// The function will fail if the surface doesn't have color key enabled.
+    #[doc(alias = "SDL_GetColorKey")]
     pub fn color_key(&self) -> Result<pixels::Color, String> {
         let mut key = 0;
 
@@ -460,6 +473,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_SetSurfaceColorMod")]
     pub fn set_color_mod(&mut self, color: pixels::Color) {
         let (r, g, b) = color.rgb();
         let result = unsafe { sys::SDL_SetSurfaceColorMod(self.raw(), r, g, b) };
@@ -470,6 +484,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_GetSurfaceColorMod")]
     pub fn color_mod(&self) -> pixels::Color {
         let mut r = 0;
         let mut g = 0;
@@ -489,6 +504,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_FillRect")]
     pub fn fill_rect<R>(&mut self, rect: R, color: pixels::Color) -> Result<(), String>
     where R: Into<Option<Rect>>
     {
@@ -518,6 +534,7 @@ impl SurfaceRef {
         Ok(())
     }
 
+    #[doc(alias = "SDL_SetSurfaceAlphaMod")]
     pub fn set_alpha_mod(&mut self, alpha: u8) {
         let result = unsafe {
             sys::SDL_SetSurfaceAlphaMod(self.raw(), alpha)
@@ -529,6 +546,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_GetSurfaceAlphaMod")]
     pub fn alpha_mod(&self) -> u8 {
         let mut alpha = 0;
         let result = unsafe {
@@ -543,6 +561,7 @@ impl SurfaceRef {
     }
 
     /// The function will fail if the blend mode is not supported by SDL.
+    #[doc(alias = "SDL_SetSurfaceBlendMode")]
     pub fn set_blend_mode(&mut self, mode: BlendMode) -> Result<(), String> {
         let result = unsafe {
             sys::SDL_SetSurfaceBlendMode(self.raw(), transmute(mode))
@@ -554,6 +573,7 @@ impl SurfaceRef {
         }
     }
 
+    #[doc(alias = "SDL_GetSurfaceBlendMode")]
     pub fn blend_mode(&self) -> BlendMode {
         let mut mode = sys::SDL_BlendMode::SDL_BLENDMODE_NONE;
         let result = unsafe {
@@ -570,6 +590,7 @@ impl SurfaceRef {
     /// Sets the clip rectangle for the surface.
     ///
     /// If the rectangle is `None`, clipping will be disabled.
+    #[doc(alias = "SDL_SetClipRect")]
     pub fn set_clip_rect<R>(&mut self, rect: R) -> bool
     where R: Into<Option<Rect>>
     {
@@ -585,6 +606,7 @@ impl SurfaceRef {
     /// Gets the clip rectangle for the surface.
     ///
     /// Returns `None` if clipping is disabled.
+    #[doc(alias = "SDL_GetClipRect")]
     pub fn clip_rect(&self) -> Option<Rect> {
         let mut raw = mem::MaybeUninit::uninit();
         unsafe {
@@ -600,6 +622,7 @@ impl SurfaceRef {
     }
 
     /// Copies the surface into a new one that is optimized for blitting to a surface of a specified pixel format.
+    #[doc(alias = "SDL_ConvertSurface")]
     pub fn convert(&self, format: &pixels::PixelFormat) -> Result<Surface<'static>, String> {
         // SDL_ConvertSurface takes a flag as the last parameter, which should be 0 by the docs.
         let surface_ptr = unsafe { sys::SDL_ConvertSurface(self.raw(), format.raw(), 0u32) };
@@ -612,6 +635,7 @@ impl SurfaceRef {
     }
 
     /// Copies the surface into a new one of a specified pixel format.
+    #[doc(alias = "SDL_ConvertSurfaceFormat")]
     pub fn convert_format(&self, format: pixels::PixelFormatEnum) -> Result<Surface<'static>, String> {
         // SDL_ConvertSurfaceFormat takes a flag as the last parameter, which should be 0 by the docs.
         let surface_ptr = unsafe { sys::SDL_ConvertSurfaceFormat(self.raw(), format as u32, 0u32) };
@@ -626,6 +650,7 @@ impl SurfaceRef {
     /// Performs surface blitting (surface copying).
     ///
     /// Returns the final blit rectangle, if a `dst_rect` was provided.
+    #[doc(alias = "SDL_UpperBlit")]
     pub fn blit<R1, R2>(&self, src_rect: R1,
             dst: &mut SurfaceRef, dst_rect: R2)
             -> Result<Option<Rect>, String>
@@ -683,6 +708,7 @@ impl SurfaceRef {
     /// Performs scaled surface bliting (surface copying).
     ///
     /// Returns the final blit rectangle, if a `dst_rect` was provided.
+    #[doc(alias = "SDL_UpperBlitScaled")]
     pub fn blit_scaled<R1, R2>(&self, src_rect: R1,
                              dst: &mut SurfaceRef, dst_rect: R2) -> Result<Option<Rect>, String>
     where R1: Into<Option<Rect>>,

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -13,6 +13,7 @@ impl TimerSubsystem {
     /// * when the timer is dropped
     /// * or when the callback returns a non-positive continuation interval
     #[must_use = "if unused the Timer will be dropped immediately"]
+    #[doc(alias = "SDL_AddTimer")]
     pub fn add_timer<'b, 'c>(&'b self, delay: u32, callback: TimerCallback<'c>) -> Timer<'b, 'c> {
         unsafe {
             let callback = Box::new(callback);
@@ -31,6 +32,7 @@ impl TimerSubsystem {
     /// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
     ///
     /// It's recommended that you use another library for timekeeping, such as `time`.
+    #[doc(alias = "SDL_GetTicks")]
     pub fn ticks(&self) -> u32 {
         // Google says this is probably not thread-safe (TODO: prove/disprove this).
         unsafe { sys::SDL_GetTicks() }
@@ -39,15 +41,18 @@ impl TimerSubsystem {
     /// Sleeps the current thread for the specified amount of milliseconds.
     ///
     /// It's recommended that you use `std::thread::sleep()` instead.
+    #[doc(alias = "SDL_Delay")]
     pub fn delay(&mut self, ms: u32) {
         // Google says this is probably not thread-safe (TODO: prove/disprove this).
         unsafe { sys::SDL_Delay(ms) }
     }
 
+    #[doc(alias = "SDL_GetPerformanceCounter")]
     pub fn performance_counter(&self) -> u64 {
         unsafe { sys::SDL_GetPerformanceCounter() }
     }
 
+    #[doc(alias = "SDL_GetPerformanceFrequency")]
     pub fn performance_frequency(&self) -> u64 {
         unsafe { sys::SDL_GetPerformanceFrequency() }
     }
@@ -71,6 +76,7 @@ impl<'b, 'a> Timer<'b, 'a> {
 
 impl<'b, 'a> Drop for Timer<'b, 'a> {
     #[inline]
+    #[doc(alias = "SDL_RemoveTimer")]
     fn drop(&mut self) {
         // SDL_RemoveTimer returns SDL_FALSE if the timer wasn't found (impossible),
         // or the timer has been cancelled via the callback (possible).

--- a/src/sdl2/touch.rs
+++ b/src/sdl2/touch.rs
@@ -3,18 +3,22 @@ use crate::sys;
 pub type Finger = sys::SDL_Finger;
 pub type TouchDevice = sys::SDL_TouchID;
 
+#[doc(alias = "SDL_GetNumTouchDevices")]
 pub fn num_touch_devices() -> i32 {
     unsafe { sys::SDL_GetNumTouchDevices() }
 }
 
+#[doc(alias = "SDL_GetTouchDevice")]
 pub fn touch_device(index: i32) -> TouchDevice {
     unsafe { sys::SDL_GetTouchDevice(index) }
 }
 
+#[doc(alias = "SDL_GetNumTouchFingers")]
 pub fn num_touch_fingers(touch: TouchDevice) -> i32 {
     unsafe { sys::SDL_GetNumTouchFingers(touch) }
 }
 
+#[doc(alias = "SDL_GetTouchFinger")]
 pub fn touch_finger(touch: TouchDevice, index: i32) -> Option<Finger> {
     let raw = unsafe { sys::SDL_GetTouchFinger(touch, index) };
 

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -32,6 +32,7 @@ impl fmt::Display for Version {
 }
 
 /// Get the version of SDL that is linked against your program.
+#[doc(alias = "SDL_GetVersion")]
 pub fn version() -> Version {
     unsafe {
         let mut cver = sys::SDL_version { major: 0, minor: 0, patch: 0};
@@ -41,6 +42,7 @@ pub fn version() -> Version {
 }
 
 /// Get the code revision of SDL that is linked against your program.
+#[doc(alias = "SDL_GetRevision")]
 pub fn revision() -> String {
     unsafe {
         let rev = sys::SDL_GetRevision();
@@ -49,6 +51,7 @@ pub fn revision() -> String {
 }
 
 /// Get the revision number of SDL that is linked against your program.
+#[doc(alias = "SDL_GetRevisionNumber")]
 pub fn revision_number() -> i32 {
     unsafe {
         sys::SDL_GetRevisionNumber()

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -43,6 +43,7 @@ impl<'a> WindowSurfaceRef<'a> {
     /// Updates the change made to the inner Surface to the Window it was created from.
     ///
     /// This would effectively be the theoretical equivalent of `present` from a Canvas.
+    #[doc(alias = "SDL_UpdateWindowSurface")]
     pub fn update_window(&self) -> Result<(), String> {
         unsafe {
             if sys::SDL_UpdateWindowSurface(self.1.context.raw) == 0 {
@@ -55,6 +56,7 @@ impl<'a> WindowSurfaceRef<'a> {
 
     /// Same as `update_window`, but only update the parts included in `rects` to the Window it was
     /// created from.
+    #[doc(alias = "SDL_UpdateWindowSurfaceRects")]
     pub fn update_window_rects(&self, rects: &[Rect]) -> Result<(), String> {
         unsafe {
             if sys::SDL_UpdateWindowSurfaceRects(self.1.context.raw, Rect::raw_slice(rects), rects.len() as c_int) == 0 {
@@ -502,6 +504,7 @@ pub struct GLContext {
 }
 
 impl Drop for GLContext {
+    #[doc(alias = "SDL_GL_DeleteContext")]
     fn drop(&mut self) {
         unsafe {
             sys::SDL_GL_DeleteContext(self.raw)
@@ -511,6 +514,7 @@ impl Drop for GLContext {
 
 impl GLContext {
     /// Returns true if the OpenGL context is the current one in the thread.
+    #[doc(alias = "SDL_GL_GetCurrentContext")]
     pub fn is_current(&self) -> bool {
         let current_raw = unsafe { sys::SDL_GL_GetCurrentContext() };
         self.raw == current_raw
@@ -527,6 +531,7 @@ pub struct WindowContext {
 
 impl Drop for WindowContext {
     #[inline]
+    #[doc(alias = "SDL_DestroyWindow")]
     fn drop(&mut self) {
         unsafe { sys::SDL_DestroyWindow(self.raw) };
     }
@@ -593,6 +598,7 @@ impl VideoSubsystem {
         WindowBuilder::new(self, title, width, height)
     }
 
+    #[doc(alias = "SDL_GetCurrentVideoDriver")]
     pub fn current_video_driver(&self) -> &'static str {
         use std::str;
 
@@ -604,6 +610,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetNumVideoDisplays")]
     pub fn num_video_displays(&self) -> Result<i32, String> {
         let result = unsafe { sys::SDL_GetNumVideoDisplays() };
         if result < 0 {
@@ -617,6 +624,7 @@ impl VideoSubsystem {
     ///
     /// Will return an error if the index is out of bounds or if SDL experienced a failure; inspect
     /// the returned string for further info.
+    #[doc(alias = "SDL_GetDisplayName")]
     pub fn display_name(&self, display_index: i32) -> Result<String, String> {
         unsafe {
             let display = sys::SDL_GetDisplayName(display_index as c_int);
@@ -628,6 +636,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetDisplayBounds")]
     pub fn display_bounds(&self, display_index: i32) -> Result<Rect, String> {
         let mut out = mem::MaybeUninit::uninit();
         let result = unsafe { sys::SDL_GetDisplayBounds(display_index as c_int, out.as_mut_ptr()) == 0 };
@@ -640,6 +649,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetNumDisplayModes")]
     pub fn num_display_modes(&self, display_index: i32) -> Result<i32, String> {
         let result = unsafe { sys::SDL_GetNumDisplayModes(display_index as c_int) };
         if result < 0 {
@@ -649,6 +659,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetDisplayMode")]
     pub fn display_mode(&self, display_index: i32, mode_index: i32) -> Result<DisplayMode, String> {
         let mut dm = mem::MaybeUninit::uninit();
         let result = unsafe { sys::SDL_GetDisplayMode(display_index as c_int, mode_index as c_int, dm.as_mut_ptr()) == 0};
@@ -661,6 +672,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetDesktopDisplayMode")]
     pub fn desktop_display_mode(&self, display_index: i32) -> Result<DisplayMode, String> {
         let mut dm = mem::MaybeUninit::uninit();
         let result = unsafe { sys::SDL_GetDesktopDisplayMode(display_index as c_int, dm.as_mut_ptr()) == 0};
@@ -673,6 +685,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetCurrentDisplayMode")]
     pub fn current_display_mode(&self, display_index: i32) -> Result<DisplayMode, String> {
         let mut dm = mem::MaybeUninit::uninit();
         let result = unsafe { sys::SDL_GetCurrentDisplayMode(display_index as c_int, dm.as_mut_ptr()) == 0};
@@ -685,6 +698,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetClosestDisplayMode")]
     pub fn closest_display_mode(&self, display_index: i32, mode: &DisplayMode) -> Result<DisplayMode, String> {
         let input = mode.to_ll();
         let mut dm = mem::MaybeUninit::uninit();
@@ -701,6 +715,7 @@ impl VideoSubsystem {
 
     /// Return a triplet `(ddpi, hdpi, vdpi)` containing the diagonal, horizontal and vertical
     /// dots/pixels-per-inch of a display
+    #[doc(alias = "SDL_GetDisplayDPI")]
     pub fn display_dpi(&self, display_index: i32) -> Result<(f32, f32, f32), String> {
         let mut ddpi = 0.0;
         let mut hdpi = 0.0;
@@ -713,14 +728,17 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_IsScreenSaverEnabled")]
     pub fn is_screen_saver_enabled(&self) -> bool {
         unsafe { sys::SDL_IsScreenSaverEnabled() == sys::SDL_bool::SDL_TRUE }
     }
 
+    #[doc(alias = "SDL_EnableScreenSaver")]
     pub fn enable_screen_saver(&self) {
         unsafe { sys::SDL_EnableScreenSaver() }
     }
 
+    #[doc(alias = "SDL_DisableScreenSaver")]
     pub fn disable_screen_saver(&self) {
         unsafe { sys::SDL_DisableScreenSaver() }
     }
@@ -731,6 +749,7 @@ impl VideoSubsystem {
     /// If no OpenGL library is loaded, the default library will be loaded upon creation of the first OpenGL window.
     ///
     /// If a different library is already loaded, this function will return an error.
+    #[doc(alias = "SDL_GL_LoadLibrary")]
     pub fn gl_load_library_default(&self) -> Result<(), String> {
         unsafe {
             if sys::SDL_GL_LoadLibrary(ptr::null()) == 0 {
@@ -747,6 +766,7 @@ impl VideoSubsystem {
     /// If no OpenGL library is loaded, the default library will be loaded upon creation of the first OpenGL window.
     ///
     /// If a different library is already loaded, this function will return an error.
+    #[doc(alias = "SDL_GL_LoadLibrary")]
     pub fn gl_load_library<P: AsRef<::std::path::Path>>(&self, path: P) -> Result<(), String> {
         unsafe {
             // TODO: use OsStr::to_cstring() once it's stable
@@ -763,6 +783,7 @@ impl VideoSubsystem {
     ///
     /// To completely unload the library, this should be called for every successful load of the
     /// OpenGL library.
+    #[doc(alias = "SDL_GL_UnloadLibrary")]
     pub fn gl_unload_library(&self) {
         unsafe { sys::SDL_GL_UnloadLibrary(); }
     }
@@ -770,6 +791,7 @@ impl VideoSubsystem {
     /// Gets the pointer to the named OpenGL function.
     ///
     /// This is useful for OpenGL wrappers such as [`gl-rs`](https://github.com/bjz/gl-rs).
+    #[doc(alias = "SDL_GL_GetProcAddress")]
     pub fn gl_get_proc_address(&self, procname: &str) -> *const () {
         match CString::new(procname) {
             Ok(procname) => unsafe { sys::SDL_GL_GetProcAddress(procname.as_ptr() as *const c_char) as *const () },
@@ -778,6 +800,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GL_ExtensionSupported")]
     pub fn gl_extension_supported(&self, extension: &str) -> bool {
         match CString::new(extension) {
             Ok(extension) => unsafe { sys::SDL_GL_ExtensionSupported(extension.as_ptr() as *const c_char) != sys::SDL_bool::SDL_FALSE },
@@ -786,6 +809,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GL_GetCurrentWindow")]
     pub fn gl_get_current_window_id(&self) -> Result<u32, String> {
         let raw = unsafe { sys::SDL_GL_GetCurrentWindow() };
         if raw.is_null() {
@@ -797,6 +821,7 @@ impl VideoSubsystem {
     }
 
     /// Releases the thread's current OpenGL context, i.e. sets the current OpenGL context to nothing.
+    #[doc(alias = "SDL_GL_MakeCurrent")]
     pub fn gl_release_current_context(&self) -> Result<(), String> {
         let result = unsafe { sys::SDL_GL_MakeCurrent(ptr::null_mut(), ptr::null_mut()) };
 
@@ -807,6 +832,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GL_SetSwapInterval")]
     pub fn gl_set_swap_interval<S: Into<SwapInterval>>(&self, interval: S) -> Result<(), String> {
         let result = unsafe { sys::SDL_GL_SetSwapInterval(interval.into() as c_int) };
         if result == 0{
@@ -816,6 +842,7 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GL_GetSwapInterval")]
     pub fn gl_get_swap_interval(&self) -> SwapInterval {
         unsafe {
             let interval = sys::SDL_GL_GetSwapInterval() as i32;
@@ -830,6 +857,7 @@ impl VideoSubsystem {
     /// If no Vulkan library is loaded, the default library will be loaded upon creation of the first Vulkan window.
     ///
     /// If a different library is already loaded, this function will return an error.
+    #[doc(alias = "SDL_Vulkan_LoadLibrary")]
     pub fn vulkan_load_library_default(&self) -> Result<(), String> {
         unsafe {
             if sys::SDL_Vulkan_LoadLibrary(ptr::null()) == 0 {
@@ -846,6 +874,7 @@ impl VideoSubsystem {
     /// If no Vulkan library is loaded, the default library will be loaded upon creation of the first Vulkan window.
     ///
     /// If a different library is already loaded, this function will return an error.
+    #[doc(alias = "SDL_Vulkan_LoadLibrary")]
     pub fn vulkan_load_library<P: AsRef<::std::path::Path>>(&self, path: P) -> Result<(), String> {
         unsafe {
             // TODO: use OsStr::to_cstring() once it's stable
@@ -862,6 +891,7 @@ impl VideoSubsystem {
     ///
     /// To completely unload the library, this should be called for every successful load of the
     /// Vulkan library.
+    #[doc(alias = "SDL_Vulkan_UnloadLibrary")]
     pub fn vulkan_unload_library(&self) {
         unsafe { sys::SDL_Vulkan_UnloadLibrary(); }
     }
@@ -870,6 +900,7 @@ impl VideoSubsystem {
     /// [`vkGetInstanceProcAddr`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetInstanceProcAddr.html)
     /// Vulkan function. This function can be called to retrieve the address of other Vulkan
     /// functions.
+    #[doc(alias = "SDL_Vulkan_GetVkGetInstanceProcAddr")]
     pub fn vulkan_get_proc_address_function(&self) -> Result<*const (), String> {
         let result = unsafe { sys::SDL_Vulkan_GetVkGetInstanceProcAddr() as *const () };
         if result.is_null() {
@@ -943,6 +974,7 @@ impl WindowBuilder {
     }
 
     /// Builds the window.
+    #[doc(alias = "SDL_CreateWindow")]
     pub fn build(&self) -> Result<Window, WindowBuildError> {
         use self::WindowBuildError::*;
         let title = match CString::new(self.title.clone()) {
@@ -1104,10 +1136,12 @@ impl Window {
         self.context.clone()
     }
 
+    #[doc(alias = "SDL_GetWindowID")]
     pub fn id(&self) -> u32 {
         unsafe { sys::SDL_GetWindowID(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_GL_CreateContext")]
     pub fn gl_create_context(&self) -> Result<GLContext, String> {
         let result = unsafe { sys::SDL_GL_CreateContext(self.context.raw) };
         if result.is_null() {
@@ -1118,6 +1152,7 @@ impl Window {
     }
 
     /// Set the window's OpenGL context to the current context on the thread.
+    #[doc(alias = "SDL_GL_GetCurrentContext")]
     pub fn gl_set_context_to_current(&self) -> Result<(), String> {
         unsafe {
             let context_raw = sys::SDL_GL_GetCurrentContext();
@@ -1130,6 +1165,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GL_MakeCurrent")]
     pub fn gl_make_current(&self, context: &GLContext) -> Result<(), String> {
         unsafe {
             if sys::SDL_GL_MakeCurrent(self.context.raw, context.raw) == 0 {
@@ -1140,11 +1176,13 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GL_SwapWindow")]
     pub fn gl_swap_window(&self) {
         unsafe { sys::SDL_GL_SwapWindow(self.context.raw) }
     }
 
     /// Get the names of the Vulkan instance extensions needed to create a surface with `vulkan_create_surface`.
+    #[doc(alias = "SDL_Vulkan_GetInstanceExtensions")]
     pub fn vulkan_instance_extensions(&self) -> Result<Vec<&'static str>, String> {
         let mut count: c_uint = 0;
         if unsafe { sys::SDL_Vulkan_GetInstanceExtensions(self.context.raw, &mut count, ptr::null_mut()) } == sys::SDL_bool::SDL_FALSE {
@@ -1162,6 +1200,7 @@ impl Window {
     /// The `VkInstance` must be created using a prior call to the
     /// [`vkCreateInstance`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateInstance.html)
     /// function in the Vulkan library.
+    #[doc(alias = "SDL_Vulkan_CreateSurface")]
     pub fn vulkan_create_surface(&self, instance: VkInstance) -> Result<VkSurfaceKHR, String> {
         let mut surface: VkSurfaceKHR = 0;
         if unsafe { sys::SDL_Vulkan_CreateSurface(self.context.raw, instance, &mut surface) } == sys::SDL_bool::SDL_FALSE {
@@ -1171,6 +1210,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowDisplayIndex")]
     pub fn display_index(&self) -> Result<i32, String> {
         let result = unsafe { sys::SDL_GetWindowDisplayIndex(self.context.raw) };
         if result < 0 {
@@ -1180,6 +1220,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_SetWindowDisplayMode")]
     pub fn set_display_mode<D>(&mut self, display_mode: D) -> Result<(), String>
     where D: Into<Option<DisplayMode>>
     {
@@ -1199,6 +1240,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowDisplayMode")]
     pub fn display_mode(&self) -> Result<DisplayMode, String> {
         let mut dm = mem::MaybeUninit::uninit();
 
@@ -1217,16 +1259,19 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowPixelFormat")]
     pub fn window_pixel_format(&self) -> PixelFormatEnum {
         unsafe{ PixelFormatEnum::try_from(sys::SDL_GetWindowPixelFormat(self.context.raw) as u32).unwrap() }
     }
 
+    #[doc(alias = "SDL_GetWindowFlags")]
     pub fn window_flags(&self) -> u32 {
         unsafe {
             sys::SDL_GetWindowFlags(self.context.raw)
         }
     }
 
+    #[doc(alias = "SDL_SetWindowTitle")]
     pub fn set_title(&mut self, title: &str) -> Result<(), NulError> {
         let title = CString::new(title)?;
         unsafe {
@@ -1235,6 +1280,7 @@ impl Window {
         Ok(())
     }
 
+    #[doc(alias = "SDL_GetWindowTitle")]
     pub fn title(&self) -> &str {
         unsafe {
             let buf = sys::SDL_GetWindowTitle(self.context.raw);
@@ -1254,6 +1300,7 @@ impl Window {
     /// let window_icon = Surface::from_file("/path/to/icon.png")?;
     /// window.set_icon(window_icon);
     /// ```
+    #[doc(alias = "SDL_SetWindowIcon")]
     pub fn set_icon<S: AsRef<SurfaceRef>>(&mut self, icon: S) {
         unsafe {
             sys::SDL_SetWindowIcon(self.context.raw, icon.as_ref().raw())
@@ -1263,6 +1310,7 @@ impl Window {
     //pub fn SDL_SetWindowData(window: *SDL_Window, name: *c_char, userdata: *c_void) -> *c_void; //TODO: Figure out what this does
     //pub fn SDL_GetWindowData(window: *SDL_Window, name: *c_char) -> *c_void;
 
+    #[doc(alias = "SDL_SetWindowPosition")]
     pub fn set_position(&mut self, x: WindowPos, y: WindowPos) {
         unsafe {
             sys::SDL_SetWindowPosition(
@@ -1271,6 +1319,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowPosition")]
     pub fn position(&self) -> (i32, i32) {
         let mut x: c_int = 0;
         let mut y: c_int = 0;
@@ -1282,6 +1331,7 @@ impl Window {
     ///
     /// # Remarks
     /// This function is only supported on X11, otherwise an error is returned.
+    #[doc(alias = "SDL_GetWindowBordersSize")]
     pub fn border_size(&self) -> Result<(u16, u16, u16, u16), String> {
         let mut top: c_int = 0;
         let mut left: c_int = 0;
@@ -1295,6 +1345,7 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_SetWindowSize")]
     pub fn set_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
@@ -1305,6 +1356,7 @@ impl Window {
         Ok(())
     }
 
+    #[doc(alias = "SDL_GetWindowSize")]
     pub fn size(&self) -> (u32, u32) {
         let mut w: c_int = 0;
         let mut h: c_int = 0;
@@ -1312,6 +1364,7 @@ impl Window {
         (w as u32, h as u32)
     }
 
+    #[doc(alias = "SDL_GL_GetDrawableSize")]
     pub fn drawable_size(&self) -> (u32, u32) {
         let mut w: c_int = 0;
         let mut h: c_int = 0;
@@ -1319,6 +1372,7 @@ impl Window {
         (w as u32, h as u32)
     }
 
+    #[doc(alias = "SDL_Vulkan_GetDrawableSize")]
     pub fn vulkan_drawable_size(&self) -> (u32, u32) {
         let mut w: c_int = 0;
         let mut h: c_int = 0;
@@ -1326,6 +1380,7 @@ impl Window {
         (w as u32, h as u32)
     }
 
+    #[doc(alias = "SDL_SetWindowMinimumSize")]
     pub fn set_minimum_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
@@ -1336,6 +1391,7 @@ impl Window {
         Ok(())
     }
 
+    #[doc(alias = "SDL_GetWindowMinimumSize")]
     pub fn minimum_size(&self) -> (u32, u32) {
         let mut w: c_int = 0;
         let mut h: c_int = 0;
@@ -1343,6 +1399,7 @@ impl Window {
         (w as u32, h as u32)
     }
 
+    #[doc(alias = "SDL_SetWindowMaximumSize")]
     pub fn set_maximum_size(&mut self, width: u32, height: u32)
             -> Result<(), IntegerOrSdlError> {
         let w = validate_int(width, "width")?;
@@ -1353,6 +1410,7 @@ impl Window {
         Ok(())
     }
 
+    #[doc(alias = "SDL_GetWindowMaximumSize")]
     pub fn maximum_size(&self) -> (u32, u32) {
         let mut w: c_int = 0;
         let mut h: c_int = 0;
@@ -1362,6 +1420,7 @@ impl Window {
         (w as u32, h as u32)
     }
 
+    #[doc(alias = "SDL_SetWindowBordered")]
     pub fn set_bordered(&mut self, bordered: bool) {
         unsafe {
             sys::SDL_SetWindowBordered(
@@ -1371,26 +1430,32 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_ShowWindow")]
     pub fn show(&mut self) {
         unsafe { sys::SDL_ShowWindow(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_HideWindow")]
     pub fn hide(&mut self) {
         unsafe { sys::SDL_HideWindow(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_RaiseWindow")]
     pub fn raise(&mut self) {
         unsafe { sys::SDL_RaiseWindow(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_MaximizeWindow")]
     pub fn maximize(&mut self) {
         unsafe { sys::SDL_MaximizeWindow(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_MinimizeWindow")]
     pub fn minimize(&mut self) {
         unsafe { sys::SDL_MinimizeWindow(self.context.raw) }
     }
 
+    #[doc(alias = "SDL_RestoreWindow")]
     pub fn restore(&mut self) {
         unsafe { sys::SDL_RestoreWindow(self.context.raw) }
     }
@@ -1399,6 +1464,7 @@ impl Window {
         FullscreenType::from_window_flags(self.window_flags())
     }
 
+    #[doc(alias = "SDL_SetWindowFullscreen")]
     pub fn set_fullscreen(&mut self, fullscreen_type: FullscreenType)
             -> Result<(), String> {
         unsafe {
@@ -1425,6 +1491,7 @@ impl Window {
     /// to support Software Rendering (which is what using Surface is), you can still create a
     /// Renderer which renders in a Software-based manner, so try to rely on a Renderer as much as
     /// possible !
+    #[doc(alias = "SDL_GetWindowSurface")]
     pub fn surface<'a>(&'a self, _e: &'a EventPump) -> Result<WindowSurfaceRef<'a>, String> {
         let raw = unsafe { sys::SDL_GetWindowSurface(self.context.raw) };
 
@@ -1436,14 +1503,17 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_SetWindowGrab")]
     pub fn set_grab(&mut self, grabbed: bool) {
         unsafe { sys::SDL_SetWindowGrab(self.context.raw, if grabbed { sys::SDL_bool::SDL_TRUE } else { sys::SDL_bool::SDL_FALSE }) }
     }
 
+    #[doc(alias = "SDL_GetWindowGrab")]
     pub fn grab(&self) -> bool {
         unsafe { sys::SDL_GetWindowGrab(self.context.raw) == sys::SDL_bool::SDL_TRUE }
     }
 
+    #[doc(alias = "SDL_SetWindowBrightness")]
     pub fn set_brightness(&mut self, brightness: f64) -> Result<(), String> {
         unsafe {
             if sys::SDL_SetWindowBrightness(self.context.raw, brightness as c_float) == 0 {
@@ -1454,10 +1524,12 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowBrightness")]
     pub fn brightness(&self) -> f64 {
         unsafe { sys::SDL_GetWindowBrightness(self.context.raw) as f64 }
     }
 
+    #[doc(alias = "SDL_SetWindowGammaRamp")]
     pub fn set_gamma_ramp<'a, 'b, 'c, R, G, B>(&mut self, red: R, green: G, blue: B) -> Result<(), String>
     where R: Into<Option<&'a [u16; 256]>>,
           G: Into<Option<&'b [u16; 256]>>,
@@ -1488,6 +1560,7 @@ impl Window {
     }
 
     #[allow(clippy::type_complexity)]
+    #[doc(alias = "SDL_GetWindowGammaRamp")]
     pub fn gamma_ramp(&self) -> Result<(Vec<u16>, Vec<u16>, Vec<u16>), String> {
         let mut red: Vec<u16> = vec![0; 256];
         let mut green: Vec<u16> = vec![0; 256];
@@ -1509,6 +1582,7 @@ impl Window {
     /// `0.0` (fully transparent), and `1.0` (fully opaque).
     ///
     /// This method returns an error if opacity isn't supported by the current platform.
+    #[doc(alias = "SDL_SetWindowOpacity")]
     pub fn set_opacity(&mut self, opacity: f32) -> Result<(), String> {
         let result = unsafe { sys::SDL_SetWindowOpacity(self.context.raw, opacity) };
         if result < 0 {
@@ -1523,6 +1597,7 @@ impl Window {
     ///
     /// If opacity isn't supported by the current platform, this method returns `Ok(1.0)` instead
     /// of an error.
+    #[doc(alias = "SDL_GetWindowOpacity")]
     pub fn opacity(&self) -> Result<f32, String> {
         let mut opacity = 0.0;
         let result = unsafe { sys::SDL_GetWindowOpacity(self.context.raw, &mut opacity) };
@@ -1535,6 +1610,7 @@ impl Window {
 }
 
 #[derive(Copy, Clone)]
+#[doc(alias = "SDL_GetVideoDriver")]
 pub struct DriverIterator {
     length: i32,
     index: i32
@@ -1571,6 +1647,7 @@ impl ExactSizeIterator for DriverIterator { }
 
 /// Gets an iterator of all video drivers compiled into the SDL2 library.
 #[inline]
+#[doc(alias = "SDL_GetVideoDriver")]
 pub fn drivers() -> DriverIterator {
     // This function is thread-safe and doesn't require the video subsystem to be initialized.
     // The list of drivers are read-only and statically compiled into SDL2, varying by platform.


### PR DESCRIPTION
Hi, `doc(alias = "...")` just got released (more info about it [here](https://blog.guillaume-gomez.fr/articles/2020-12-04+doc%28alias%29+is+stable+and+it%27s+gonna+be+super+useful%21)) and I think it'd be very useful for this crate (I had issues finding what I was looking for more than once).

One thing to note: I added aliases for drop methods too, not sure if you want to keep them?

Little bonus: I used this python script to generate the attributes:

```python
import os


def is_valid_name(s):
    for c in s:
        if not c.isalnum() and c != '_':
            return False
    return True


def add_parts(path):
    print("=> Updating '{}'".format(path))
    with open(path, 'r') as f:
        content = f.read().split('\n')
    x = 0
    while x < len(content):
        clean = content[x].lstrip()
        if not clean.startswith("pub fn") and not clean.startswith("fn"):
            x += 1
            continue
        spaces = ''
        for _ in range(0, len(content[x]) - len(clean)):
            spaces += ' '
        spaces_and_braces = spaces + '}'
        start = x
        x += 1
        ended = False
        while x < len(content):
            if content[x] == spaces_and_braces:
                break
            if not ended and "sys::" in content[x]:
                sys_name = content[x].split("sys::")[1].split("(")[0]
                if is_valid_name(sys_name):
                    content.insert(start, '{}#[doc(alias = "{}")]'.format(spaces, sys_name))
                    ended = True
            x += 1
        x += 1
    with open(path, 'w') as f:
        f.write('\n'.join(content))


def run_dirs(path):
    for entry in os.listdir(path):
        full = os.path.join(path, entry)
        if os.path.isdir(full):
            run_dirs(full)
        else:
            add_parts(full)


if __name__ == "__main__":
    run_dirs("src")
```

Run it at the top-level and tadam.