### PR TITLE
Add wrapper for SDL_AddEventWatch and SDL_DelEventWatch

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -242,19 +242,13 @@ impl crate::EventSubsystem {
     ///
     /// # Example: dump every event to stderr
     /// ```
-    /// use sdl2::event::{Event, EventWatchCallback};
     /// let sdl = sdl2::init().unwrap();
     /// let ev = sdl.event().unwrap();
     ///
-    /// struct Callback;
-    /// impl EventWatchCallback for Callback {
-    ///     fn callback(&mut self, event: Event) {
-    ///         dbg!(event);
-    ///     }
-    /// }
-    ///
     /// // `let _ = ...` is insufficient, as it is dropped immediately.
-    /// let _event_watch = ev.add_event_watch(Callback);
+    /// let _event_watch = ev.add_event_watch(|event| {
+    ///     dbg!(event);
+    /// });
     /// ```
     pub fn add_event_watch<'a, CB: EventWatchCallback + 'a>(
         &self,
@@ -3007,4 +3001,10 @@ extern "C" fn event_callback_marshall<CB: EventWatchCallback>(
     let event = Event::from_ll(unsafe { *event });
     f.callback(event);
     0
+}
+
+impl<F: FnMut(Event) -> ()> EventWatchCallback for F {
+    fn callback(&mut self, event: Event) -> () {
+        self(event)
+    }
 }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -233,6 +233,19 @@ impl crate::EventSubsystem {
         EventSender { _priv: () }
     }
 
+    /// Create an event watcher which is called every time an event is added to event queue.
+    ///
+    /// The watcher is disabled when the return value is dropped.
+    /// Just calling this function without binding to a variable immediately disables the watcher.
+    /// In order to make it persistent, you have to bind in a variable and keep it until it's no
+    /// longer needed.
+    ///
+    /// # Example: dump every event to stderr
+    /// ```
+    /// let _event_watch = event_subsystem.add_event_watch(|event| {
+    ///     dbg!(event);
+    /// });
+    /// ```
     pub fn add_event_watch<'a, F: FnMut(Event) -> () + 'a>(
         &self,
         callback: F,

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -242,7 +242,11 @@ impl crate::EventSubsystem {
     ///
     /// # Example: dump every event to stderr
     /// ```
-    /// let _event_watch = event_subsystem.add_event_watch(|event| {
+    /// let sdl = sdl2::init().unwrap();
+    /// let ev = sdl.event().unwrap();
+    ///
+    /// // `let _ = ...` is insufficient, as it is dropped immediately.
+    /// let _event_watch = ev.add_event_watch(|event| {
     ///     dbg!(event);
     /// });
     /// ```

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -2920,10 +2920,12 @@ impl EventSender {
     }
 }
 
+/// An handler for the event watch callback.
+/// One must bind this struct in a variable as long as you want to keep the callback active.
 pub struct EventWatch<'a, F: FnMut(Event) -> () + 'a>(Box<F>, PhantomData<&'a F>);
 
 impl<'a, F: FnMut(Event) -> () + 'a> EventWatch<'a, F> {
-    pub fn add(f: F) -> EventWatch<'a, F> {
+    fn add(f: F) -> EventWatch<'a, F> {
         let f = Box::new(f);
         let mut watch = EventWatch(f, PhantomData);
         unsafe { sys::SDL_AddEventWatch(watch.filter(), watch.callback()) };

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -2923,7 +2923,6 @@ impl<'a, F: FnMut(Event) -> () + 'a> EventWatch<'a, F> {
         let f = Box::new(f);
         let mut watch = EventWatch(f, PhantomData);
         unsafe { sys::SDL_AddEventWatch(watch.filter(), watch.callback()) };
-        println!("Added");
         watch
     }
 
@@ -2939,7 +2938,6 @@ impl<'a, F: FnMut(Event) -> () + 'a> EventWatch<'a, F> {
 impl<'a, F: FnMut(Event) -> () + 'a> Drop for EventWatch<'a, F> {
     fn drop(&mut self) {
         unsafe { sys::SDL_DelEventWatch(self.filter(), self.callback()) };
-        println!("Deleted");
     }
 }
 


### PR DESCRIPTION
Closes #1023.

The new function enables to use an event watcher in a safe, user-friendly way.  We can call `EventSubsystem::add_event_watch` with a closure parameter as a callback to listen to the events.  The callback is automatically disabled when dropped.

When I wrote the code I largely referenced `AudioDevice::open`, `AudioSpecDesired::convert_to_ll` and `audio_callback_marshall` in `src/audio.rs`.  Great thanks to them.

Concerns:
* I'm not sure about the trait bounds and lifetimes.  Is it correct?  Also, the function may be called in multiple threads.  Is it desired to add `Send` or `Sync` as additional bounds?  (I'm not quite proficient at unsafe Rust, sorry)
* Is the "drop-to-disable" design good?