### PR TITLE
Added `Clone` to error types

### DIFF
--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -14,7 +14,7 @@ use std::mem::transmute;
 
 use crate::sys;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AddMappingError {
     InvalidMapping(NulError),
     InvalidFilePath(String),

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -23,7 +23,7 @@ pub fn base_path() -> Result<String, String> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PrefPathError {
     InvalidOrganizationName(NulError),
     InvalidApplicationName(NulError),

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -103,7 +103,7 @@ impl Into<MessageBoxColorScheme> for [sys::SDL_MessageBoxColor; 5] {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ShowMessageError {
     InvalidTitle(NulError),
     InvalidMessage(NulError),

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -56,11 +56,11 @@ use crate::sys::SDL_BlendMode;
 use crate::sys::SDL_TextureAccess;
 
 /// Contains the description of an error returned by SDL
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SdlError(String);
 
 /// Possible errors returned by targeting a `Canvas` to render to a `Texture`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TargetRenderError {
     SdlError(SdlError),
     NotSupported,
@@ -732,7 +732,7 @@ impl CanvasBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TextureValueError {
     WidthOverflows(u32),
     HeightOverflows(u32),
@@ -1652,7 +1652,7 @@ impl Texture {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum UpdateTextureError {
     PitchOverflows(usize),
     PitchMustBeMultipleOfTwoForFormat(usize, PixelFormatEnum),
@@ -1725,7 +1725,7 @@ impl Error for UpdateTextureError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum UpdateTextureYUVError {
     PitchOverflows {
         plane: &'static str,

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -49,7 +49,7 @@ pub struct GlyphMetrics {
 pub type FontResult<T> = Result<T, FontError>;
 
 /// A font-related error.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FontError {
     /// A Latin-1 encoded byte string is invalid.
     InvalidLatin1Text(NulError),

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -960,7 +960,7 @@ impl VideoSubsystem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum WindowBuildError {
     HeightOverflows(u32),
     WidthOverflows(u32),


### PR DESCRIPTION
Currently the error types that do exist in rust-sdl2 do not derive `Clone` which is inconvenient and not idiomatic rust. This pull request adds `Clone` as a derive for all error types defined (that I found at least). 