### PR TITLE
rust-sdl2: Force unix line-endings for patches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch eol=lf

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ when upgrading from a version of rust-sdl2 to another.
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
  * Changed signature of TimerSubsystem::ticks to accept `&self`.
- * Fix line endings of patches to lf so patching of sources works on Windows.
+[PR #1080](https://github.com/Rust-SDL2/rust-sdl2/pull/1080): Fix line endings of patches to lf so patching of sources works on Windows.
 
 ### v0.34.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ when upgrading from a version of rust-sdl2 to another.
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
  * Changed signature of TimerSubsystem::ticks to accept `&self`.
+ * Fix line endings of patches to lf so patching of sources works on Windows.
 
 ### v0.34.4
 


### PR DESCRIPTION
This fixes an issue where the *.patch files get windows line endings
when checked out on windows, which breaks the bundled build when
building from git directly.