### PR TITLE
Debug builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ when upgrading from a version of rust-sdl2 to another.
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
  * Changed signature of TimerSubsystem::ticks to accept `&self`.
+ * Allow bundled build to be built in debug mode.  Fixes issue when linking binary with mixed debug+release CRT dependencies.
 
 ### v0.34.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ when upgrading from a version of rust-sdl2 to another.
 
  * Add patch to fix metal detection (https://bugzilla.libsdl.org/show_bug.cgi?id=4988)
  * Changed signature of TimerSubsystem::ticks to accept `&self`.
- * Allow bundled build to be built in debug mode.  Fixes issue when linking binary with mixed debug+release CRT dependencies.
+[PR #1081](https://github.com/Rust-SDL2/rust-sdl2/pull/1081): Allow bundled build to be built in debug mode.  Fixes issue when linking binary with mixed debug+release CRT dependencies.
 
 ### v0.34.4
 


### PR DESCRIPTION
sdl2-sys was hardcoding the bundled build as a release build,
unconditionally for a long time.  This can cause problems however if an
upstream link of a binary is mixing C++ libraries that mix debug and non
debug builds, or so at least I'm led to believe for static builds.