### PR TITLE
sdl2-sys: Skip defining _fltused

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -306,6 +306,11 @@ fn compile_sdl2(sdl2_build_path: &Path, target_os: &str) -> PathBuf {
     let mut cfg = cmake::Config::new(sdl2_build_path);
     cfg.profile("release");
 
+    // Override __FLTUSED__ to keep the _fltused symbol from getting defined in the static build.
+    // This conflicts and fails to link properly when building statically on Windows, likely due to
+    // COMDAT conflicts/breakage happening somewhere.
+    cfg.cflag("-D__FLTUSED__");
+
     #[cfg(target_os = "linux")]
     {
         use version_compare::Version;

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -309,6 +309,7 @@ fn compile_sdl2(sdl2_build_path: &Path, target_os: &str) -> PathBuf {
     // Override __FLTUSED__ to keep the _fltused symbol from getting defined in the static build.
     // This conflicts and fails to link properly when building statically on Windows, likely due to
     // COMDAT conflicts/breakage happening somewhere.
+    #[cfg(feature = "static-link")]
     cfg.cflag("-D__FLTUSED__");
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Upstream SDL2 will include _fltused in the libary artifact as a
__declspec(selectany) symbol.  This seems to cause problems however with
a definition already coming from the top-most rust link, as it already
gets defined elsewhere when building statically.

Rather than patching the upstream codebase with another patch, just
specify this flag in all cases as we don't require it in any of our rust
builds.