### PR TITLE
Silence warnings: string literals for panic!(), unneeded semicolons.

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1025,7 +1025,7 @@ impl AudioCVT {
                 // There's no reason for SDL_ConvertAudio to fail.
                 // The only time it can fail is if buf is NULL, which it never is.
                 if ret != 0 {
-                    panic!(get_error())
+                    panic!("{}", get_error())
                 }
 
                 // return original buffer back to caller

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -413,7 +413,7 @@ impl GameController {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }

--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -105,7 +105,7 @@ impl crate::EventSubsystem {
 
             if result < 0 {
                 // The only error possible is "Couldn't lock event queue"
-                panic!(get_error());
+                panic!("{}", get_error());
             } else {
                 events.set_len(result as usize);
 
@@ -2408,7 +2408,7 @@ unsafe fn wait_event() -> Event {
     if success {
         Event::from_ll(raw.assume_init())
     } else {
-        panic!(get_error())
+        panic!("{}", get_error())
     }
 }
 

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -168,7 +168,7 @@ impl Joystick {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }
@@ -183,7 +183,7 @@ impl Joystick {
 
         if guid.is_zero() {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             guid
         }
@@ -219,7 +219,7 @@ impl Joystick {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }
@@ -260,7 +260,7 @@ impl Joystick {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }
@@ -303,7 +303,7 @@ impl Joystick {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }
@@ -334,7 +334,7 @@ impl Joystick {
 
         if result < 0 {
             // Should only fail if the joystick is NULL.
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             result as u32
         }

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -77,7 +77,7 @@ impl From<MessageBoxColorScheme> for [sys::SDL_MessageBoxColor; 5] {
                 g: t.1,
                 b: t.2,
             }
-        };
+        }
         [
             to_message_box_color(scheme.background),
             to_message_box_color(scheme.text),
@@ -92,7 +92,7 @@ impl Into<MessageBoxColorScheme> for [sys::SDL_MessageBoxColor; 5] {
     fn into(self) -> MessageBoxColorScheme {
         fn from_message_box_color(prim_color: sys::SDL_MessageBoxColor) -> (u8, u8, u8) {
             (prim_color.r, prim_color.g, prim_color.b)
-        };
+        }
         MessageBoxColorScheme {
             background: from_message_box_color(self[0]),
             text: from_message_box_color(self[1]),

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -984,7 +984,7 @@ impl<T: RenderTarget> Canvas<T> {
         let ret = unsafe { sys::SDL_SetRenderDrawColor(self.raw, r, g, b, a) };
         // Should only fail on an invalid renderer
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         }
     }
 
@@ -997,7 +997,7 @@ impl<T: RenderTarget> Canvas<T> {
         };
         // Should only fail on an invalid renderer
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             pixels::Color::RGBA(r, g, b, a)
         }
@@ -1010,7 +1010,7 @@ impl<T: RenderTarget> Canvas<T> {
             unsafe { sys::SDL_SetRenderDrawBlendMode(self.context.raw, transmute(blend as u32)) };
         // Should only fail on an invalid renderer
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         }
     }
 
@@ -1021,7 +1021,7 @@ impl<T: RenderTarget> Canvas<T> {
         let ret = unsafe { sys::SDL_GetRenderDrawBlendMode(self.context.raw, blend.as_mut_ptr()) };
         // Should only fail on an invalid renderer
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             let blend = unsafe { blend.assume_init() };
             BlendMode::try_from(blend as u32).unwrap()
@@ -1833,7 +1833,7 @@ impl InternalTexture {
         };
         // Should only fail on an invalid texture
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             TextureQuery {
                 format: PixelFormatEnum::try_from(format as u32).unwrap(),
@@ -1860,7 +1860,7 @@ impl InternalTexture {
 
         // Should only fail on an invalid texture
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             (r, g, b)
         }
@@ -1882,7 +1882,7 @@ impl InternalTexture {
 
         // Should only fail on an invalid texture
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             alpha
         }
@@ -1904,7 +1904,7 @@ impl InternalTexture {
 
         // Should only fail on an invalid texture
         if ret != 0 {
-            panic!(get_error())
+            panic!("{}", get_error())
         } else {
             let blend = unsafe { blend.assume_init() };
             BlendMode::try_from(blend as u32).unwrap()
@@ -2529,7 +2529,7 @@ impl Iterator for DriverIterator {
         } else {
             let mut out = mem::MaybeUninit::uninit();
             let result = unsafe { sys::SDL_GetRenderDriverInfo(self.index, out.as_mut_ptr()) == 0 };
-            assert!(result, 0);
+            assert!(result, "{}", 0);
             self.index += 1;
 
             unsafe { Some(RendererInfo::from_ll(&out.assume_init())) }

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -130,7 +130,7 @@ impl<'a> Drop for RWops<'a> {
     fn drop(&mut self) {
         let ret = unsafe { ((*self.raw).close.unwrap())(self.raw) };
         if ret != 0 {
-            panic!(get_error());
+            panic!("{}", get_error());
         }
     }
 }

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -471,7 +471,7 @@ impl SurfaceRef {
 
         if result != 0 {
             // Should only panic on a null Surface
-            panic!(get_error());
+            panic!("{}", get_error());
         }
     }
 
@@ -482,7 +482,7 @@ impl SurfaceRef {
 
         if result != 0 {
             // Should only panic on a null Surface
-            panic!(get_error());
+            panic!("{}", get_error());
         }
     }
 
@@ -520,7 +520,7 @@ impl SurfaceRef {
 
         if result != 0 {
             // Should only fail on a null Surface
-            panic!(get_error());
+            panic!("{}", get_error());
         }
     }
 
@@ -539,7 +539,7 @@ impl SurfaceRef {
             pixels::Color::RGB(r, g, b)
         } else {
             // Should only fail on a null Surface
-            panic!(get_error())
+            panic!("{}", get_error())
         }
     }
 
@@ -578,7 +578,7 @@ impl SurfaceRef {
 
         if result != 0 {
             // Should only fail on a null Surface
-            panic!(get_error());
+            panic!("{}", get_error());
         }
     }
 
@@ -590,7 +590,7 @@ impl SurfaceRef {
         match result {
             0 => alpha,
             // Should only fail on a null Surface
-            _ => panic!(get_error()),
+            _ => panic!("{}", get_error()),
         }
     }
 
@@ -613,7 +613,7 @@ impl SurfaceRef {
         match result {
             0 => BlendMode::try_from(mode as u32).unwrap(),
             // Should only fail on a null Surface
-            _ => panic!(get_error()),
+            _ => panic!("{}", get_error()),
         }
     }
 


### PR DESCRIPTION
Rust 1.51 warns if panic!() is used without a string literal argument, and notes that this use will break in Rust 2021.

While here, also silence warnings about unneeded semi-colons.