### PR TITLE
rust-sdl2: cherry pick vs2019 intrisics fix

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -189,6 +189,13 @@ fn patch_sdl2(sdl2_source_path: &Path) {
             "SDL2-2.0.12-metal-detection-macos-ios.patch",
             include_str!("patches/SDL2-2.0.12-metal-detection-macos-ios.patch"),
         ),
+        // Cherrypick to fix "SDL_string.obj : error LNK2019: unresolved external symbol memset
+        // referenced in function SDL_vsnprintf_REAL"
+        // Expected to be fixed in 2.0.15
+        (
+            "SDL2-2.0.12-vs2019-intrinsics.patch",
+            include_str!("patches/SDL2-2.0.12-vs2019-intrinsics.patch"),
+        ),
     ];
     let sdl_version = format!("SDL2-{}", LASTEST_SDL2_VERSION);
 
@@ -238,8 +245,8 @@ fn patch_sdl2(sdl2_source_path: &Path) {
                 for expected_line in hunk.source_lines() {
                     let mut actual_line = String::new();
                     old_buf.read_line(&mut actual_line).unwrap();
-                    actual_line.pop(); // Remove the trailing newline.
-                    if expected_line.value.trim_end() != actual_line {
+                    actual_line.pop();
+                    if expected_line.value != actual_line {
                         panic!(
                             "Can't apply patch; mismatch between expected and actual in hunk {}",
                             i

--- a/sdl2-sys/patches/SDL2-2.0.12-vs2019-intrinsics.patch
+++ b/sdl2-sys/patches/SDL2-2.0.12-vs2019-intrinsics.patch
@@ -1,0 +1,75 @@
+commit 114c1fd6fd5b89955352a96b5096714579dfe429
+Author: Sam Lantinga <slouken@libsdl.org>
+Date:   Sat May 2 14:43:17 2020 -0700
+
+    Fixed bug 5112 - CMake won't compile in VS2019
+    
+    dark_sylinc
+    
+    Trying to build SDL with VS2019 using CMake will encounter a linking error
+    
+    More specifically:
+    
+        1>SDL_string.obj : error LNK2019: unresolved external symbol memset referenced in function SDL_vsnprintf_REAL
+    
+    (cherry picked from commit 8b60d39cb00779e0af2c9ccfcbcde8bdf7e26f1f)
+
+diff --git a/src/stdlib/SDL_stdlib.c b/src/stdlib/SDL_stdlib.c
+index c2774cb2..ff7bda8a 100644
+--- a/src/stdlib/SDL_stdlib.c
++++ b/src/stdlib/SDL_stdlib.c
+@@ -462,42 +462,22 @@ int SDL_tolower(int x) { return ((x) >= 'A') && ((x) <= 'Z') ? ('a'+((x)-'A')) :
+ __declspec(selectany) int _fltused = 1;
+ #endif
+ 
+-/* The optimizer on Visual Studio 2005 and later generates memcpy() calls */
+-#if (_MSC_VER >= 1400) && defined(_WIN64) && !defined(_DEBUG) && !(_MSC_VER >= 1900 && defined(_MT))
+-#include <intrin.h>
+-
++/* The optimizer on Visual Studio 2005 and later generates memcpy() and memset() calls */
++#if _MSC_VER >= 1400
+ #pragma function(memcpy)
+-void * memcpy ( void * destination, const void * source, size_t num )
++void *
++memcpy(void *dst, const void *src, size_t len)
+ {
+-    const Uint8 *src = (const Uint8 *)source;
+-    Uint8 *dst = (Uint8 *)destination;
+-    size_t i;
+-    
+-    /* All WIN64 architectures have SSE, right? */
+-    if (!((uintptr_t) src & 15) && !((uintptr_t) dst & 15)) {
+-        __m128 values[4];
+-        for (i = num / 64; i--;) {
+-            _mm_prefetch(src, _MM_HINT_NTA);
+-            values[0] = *(__m128 *) (src + 0);
+-            values[1] = *(__m128 *) (src + 16);
+-            values[2] = *(__m128 *) (src + 32);
+-            values[3] = *(__m128 *) (src + 48);
+-            _mm_stream_ps((float *) (dst + 0), values[0]);
+-            _mm_stream_ps((float *) (dst + 16), values[1]);
+-            _mm_stream_ps((float *) (dst + 32), values[2]);
+-            _mm_stream_ps((float *) (dst + 48), values[3]);
+-            src += 64;
+-            dst += 64;
+-        }
+-        num &= 63;
+-    }
++    return SDL_memcpy(dst, src, len);
++}
+ 
+-    while (num--) {
+-        *dst++ = *src++;
+-    }
+-    return destination;
++#pragma function(memset)
++void *
++memset(void *dst, int c, size_t len)
++{
++    return SDL_memset(dst, c, len);
+ }
+-#endif /* _MSC_VER == 1600 && defined(_WIN64) && !defined(_DEBUG) */
++#endif
+ 
+ #ifdef _M_IX86
+ 


### PR DESCRIPTION
When building for "bundled" dynamic library on Windows, VS2019
encounters a link error as it is generating an intrinsic for memset but
the cmake build misses linking in the code for it.

Fix by cherrypicking upstream patch that works around the problem by
telling the compiler to generate actual function calls to it.

https://github.com/libsdl-org/SDL/issues/3865