### PR TITLE
Point at upstream vcpkg rev again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,9 +156,8 @@ dependencies = ["sdl2"]
 
 # dependencies required when building examples and tests for this crate
 dev-dependencies = ["sdl2", "sdl2-image[libjpeg-turbo,tiff,libwebp]", "sdl2-ttf", "sdl2-gfx", "sdl2-mixer"]
-# TODO: This should be tracking https://github.com/microsoft/vcpkg see #1085
-git = "https://github.com/waych/vcpkg"
-rev = "14d56fa2da809c5632043041625b975a3ce557bc"
+git = "https://github.com/microsoft/vcpkg"
+rev = "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -28,7 +28,7 @@ version = "^0.3"
 optional = true
 
 [build-dependencies.vcpkg]
-version = "^0.2.10"
+version = "^0.2.12"
 optional = true
 
 [build-dependencies.cmake]


### PR DESCRIPTION
vcpkg has been updated to fix the link ordering of the brotli libraries.

This means that vcpkg rev can now point at upstream again. Version
a267ab1 is current HEAD.