### PR TITLE
Fix windows bundled example tests

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -554,16 +554,22 @@ fn copy_dynamic_libraries(sdl2_compiled_path: &PathBuf, target_os: &str) {
     if target_os.contains("windows") {
         let sdl2_dll_name = "SDL2.dll";
         let sdl2_bin_path = sdl2_compiled_path.join("bin");
-        let target_path = find_cargo_target_dir();
-
         let src_dll_path = sdl2_bin_path.join(sdl2_dll_name);
-        let dst_dll_path = target_path.join(sdl2_dll_name);
 
-        fs::copy(&src_dll_path, &dst_dll_path).expect(&format!(
-            "Failed to copy SDL2 dynamic library from {} to {}",
-            src_dll_path.to_string_lossy(),
-            dst_dll_path.to_string_lossy()
-        ));
+        // Copy the dll to:
+        //  * target dir: as a product ship product of the build,
+        //  * deps directory: as comment example testing doesn't pick up the library search path
+        //    otherwise and fails.
+        let target_path = find_cargo_target_dir();
+        let deps_path = target_path.join("deps");
+        for path in &[target_path, deps_path] {
+            let dst_dll_path = path.join(&sdl2_dll_name);
+            fs::copy(&src_dll_path, &dst_dll_path).expect(&format!(
+                "Failed to copy SDL2 dynamic library from {} to {}",
+                src_dll_path.to_string_lossy(),
+                dst_dll_path.to_string_lossy()
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
Fixed by staging dll in deps directory.

This is required for running comment examples as tests, which otherwise
don't seem to be picking up the dll in library path when it is only
dropped in the top most target_path.

Fixes

```
 failures:
    src/sdl2\event.rs - event::EventSender::push_custom_event (line 2874)
    src/sdl2\event.rs - event::crate::EventSubsystem::add_event_watch (line 244)
    src/sdl2\event.rs - event::crate::EventSubsystem::push_custom_event (line 203)
    src/sdl2\event.rs - event::crate::EventSubsystem::register_event (line 135)
    src/sdl2\rect.rs - rect::Rect::has_intersection (line 482)
    src/sdl2\rect.rs - rect::Rect::intersection (line 504)
    src/sdl2\rect.rs - rect::Rect::union (line 536)
```

when running `cargo test --features bundled` on Windows.