### PR TITLE
Bounce through SDL2 heap in AudioCVT::convert

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1024,7 +1024,7 @@ impl AudioCVT {
                     panic!("Failed SDL_malloc needed for SDL_ConvertAudio");
                 }
                 // raw.buf is dst_size long, but we want to copy into only the first src.len bytes.
-                assert!(src.len() < dst_size);
+                assert!(src.len() <= dst_size);
                 std::slice::from_raw_parts_mut(raw.buf, src.len()).copy_from_slice(src.as_ref());
 
                 let ret = sys::SDL_ConvertAudio(&mut raw);

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1020,7 +1020,7 @@ impl AudioCVT {
                 let dst_size = self.capacity(src.len());
 
                 // Bounce into SDL2 heap allocation as SDL_ConvertAudio may rewrite the pointer.
-                raw.buf = sys::SDL_malloc(dst_size as u32) as *mut _;
+                raw.buf = sys::SDL_malloc(dst_size as _) as *mut _;
                 if raw.buf.is_null() {
                     panic!("Failed SDL_malloc needed for SDL_ConvertAudio");
                 }

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1012,19 +1012,19 @@ impl AudioCVT {
             if self.raw.needed != 0 {
                 let mut raw = self.raw;
 
-                // calculate the size of the dst buffer.
-                use std::convert::TryInto;
-                raw.len = src.len().try_into().expect("Buffer length overflow");
-
+                // Calculate the size of the buffer we're handing to to SDL.
                 // This is more a suggestion, and not really a guarantee...
                 let dst_size = self.capacity(src.len());
 
                 // Bounce into SDL2 heap allocation as SDL_ConvertAudio may rewrite the pointer.
                 raw.buf = sys::SDL_malloc(dst_size as _) as *mut _;
+                use std::convert::TryInto;
+                raw.len = src.len().try_into().expect("Buffer length overflow");
                 if raw.buf.is_null() {
                     panic!("Failed SDL_malloc needed for SDL_ConvertAudio");
                 }
                 // raw.buf is dst_size long, but we want to copy into only the first src.len bytes.
+                assert!(src.len() < dst_size);
                 std::slice::from_raw_parts_mut(raw.buf, src.len()).copy_from_slice(src.as_ref());
 
                 let ret = sys::SDL_ConvertAudio(&mut raw);


### PR DESCRIPTION
This commit rewrites AudioCVT::convert to bounce the audio buffer into a
an SDL2 heap allocation, rather than trying to reuse the rust heap
buffer.  This is critical, as the underlying library warns internally
that the buffer may be reallocated, breaking configurations where
the library is not using the same heap as rust.

The underlying implementation also notes that the underlying buffer may
be transparently resized to larger than the output as part of the
transformations, so relying on the buffer being capacity() bytes long to
ensure the buffer is not re-allocated is a broken assumption.

Closes #1096