### PR TITLE
Update doc for AudioCVT::convert

### DIFF
--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -1004,10 +1004,8 @@ impl AudioCVT {
     pub fn convert(&self, mut src: Vec<u8>) -> Vec<u8> {
         //! Convert audio data to a desired audio format.
         //!
-        //! The `src` vector is adjusted to the capacity necessary to perform
-        //! the conversion in place; then it is passed to the SDL library.
-        //!
-        //! Certain conversions may cause buffer overflows. See AngryLawyer/rust-sdl2 issue #270.
+        //! Passes raw audio data from src to the SDL library for conversion, returning the result
+        //! of the conversion.
         unsafe {
             if self.raw.needed != 0 {
                 use std::convert::TryInto;


### PR DESCRIPTION
Update to reflect the surface interface and remove the bits about
conversion in place which are now out of date.

This also removes the note about buffer overflows in issue #270. Looking
back, the understanding was that the buffer wouldn't get reallocated,
and this is evident even in the sample C code used there.