### PR TITLE
Added binding for SDL_GetDisplayUsableBounds.

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -676,6 +676,20 @@ impl VideoSubsystem {
         }
     }
 
+    #[doc(alias = "SDL_GetDisplayUsableBounds")]
+    pub fn display_usable_bounds(&self, display_index: i32) -> Result<Rect, String> {
+        let mut out = mem::MaybeUninit::uninit();
+        let result = unsafe {
+            sys::SDL_GetDisplayUsableBounds(display_index as c_int, out.as_mut_ptr())
+        };
+        if result == 0 {
+            let out = unsafe { out.assume_init() };
+            Ok(Rect::from_ll(out))
+        } else {
+            Err(get_error())
+        }
+    }
+
     #[doc(alias = "SDL_GetNumDisplayModes")]
     pub fn num_display_modes(&self, display_index: i32) -> Result<i32, String> {
         let result = unsafe { sys::SDL_GetNumDisplayModes(display_index as c_int) };

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -679,9 +679,8 @@ impl VideoSubsystem {
     #[doc(alias = "SDL_GetDisplayUsableBounds")]
     pub fn display_usable_bounds(&self, display_index: i32) -> Result<Rect, String> {
         let mut out = mem::MaybeUninit::uninit();
-        let result = unsafe {
-            sys::SDL_GetDisplayUsableBounds(display_index as c_int, out.as_mut_ptr())
-        };
+        let result =
+            unsafe { sys::SDL_GetDisplayUsableBounds(display_index as c_int, out.as_mut_ptr()) };
         if result == 0 {
             let out = unsafe { out.assume_init() };
             Ok(Rect::from_ll(out))


### PR DESCRIPTION
Linux and MacOS will make sure your window fits in the available space but Windows instead makes a window go under the taskbar. Use `SDL_GetDisplayUsableBounds` to avoid this.