### PR TITLE
Expand bundled testing to linux and macos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           cargo test --features "${CI_BUILD_FEATURES}"
 
   build-bundled:
-    name: build windows bundled
+    name: build bundled
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,14 +31,15 @@ jobs:
           cargo build --examples --features "${CI_BUILD_FEATURES}"
           cargo test --features "${CI_BUILD_FEATURES}"
 
-  build-windows:
+  build-bundled:
     name: build windows bundled
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         feature: ["", "static-link"]
         build_mode: ["", "--release"]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Build SDL2
@@ -56,12 +57,10 @@ jobs:
           cargo test --features "${CI_BUILD_FEATURES} ${{matrix.feature}}" ${{matrix.build_mode}}
 
   build-linux:
-    name: build linux
+    name: build linux pkg-config
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix:
-        feature: ["", "bundled"]
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -77,6 +76,6 @@ jobs:
           set -xeuo pipefail
           rustc --version
           cargo --version
-          cargo build --features "${CI_BUILD_FEATURES},${{matrix.feature}}"
-          cargo build --examples --features "${CI_BUILD_FEATURES},${{matrix.feature}}"
-          cargo test --features "${CI_BUILD_FEATURES},${{matrix.feature}}"
+          cargo build --features "${CI_BUILD_FEATURES}"
+          cargo build --examples --features "${CI_BUILD_FEATURES}"
+          cargo test --features "${CI_BUILD_FEATURES}"


### PR DESCRIPTION
Expand Linux "bundled" testing to also cover release and static
variants.  Has the added benefit that this testing doesn't accidentally
see the libsdl packages that were installed as part of the pkg-config
testing.

While here, try enabling for macos as well to gather coverage for it.