### PR TITLE
Add wrapper functions for getting and setting renderer integer scaling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
+### Unreleased
+
+Add wrapper functions for `SDL_RenderSetIntegerScale` and `SDL_RenderGetIntegerScale`
+
 ### v0.34.5
 
 [PR #1100](https://github.com/Rust-SDL2/rust-sdl2/pull/1100) Added binding for `SDL_GetDisplayUsableBounds`

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -1145,6 +1145,32 @@ impl<T: RenderTarget> Canvas<T> {
         }
     }
 
+    /// Sets whether to force integer scales for resolution-independent rendering.
+    #[doc(alias = "SDL_RenderSetIntegerScale")]
+    pub fn set_integer_scale(&mut self, scale: bool) -> Result<(), String> {
+        let ret = unsafe {
+            sys::SDL_RenderSetIntegerScale(
+                self.raw(),
+                if scale {
+                    sys::SDL_bool::SDL_TRUE
+                } else {
+                    sys::SDL_bool::SDL_FALSE
+                },
+            )
+        };
+        if ret != 0 {
+            Err(get_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Gets whether integer scales are forced for resolution-independent rendering.
+    #[doc(alias = "SDL_RenderGetIntegerScale")]
+    pub fn integer_scale(&self) -> bool {
+        unsafe { sys::SDL_RenderGetIntegerScale(self.raw()) == sys::SDL_bool::SDL_TRUE }
+    }
+
     /// Sets the drawing scale for rendering on the current target.
     #[doc(alias = "SDL_RenderSetScale")]
     pub fn set_scale(&mut self, scale_x: f32, scale_y: f32) -> Result<(), String> {


### PR DESCRIPTION
Brought up in #1110 
* Adds `set_integer_scale` and `integer_scale` to `Canvas<T>`

For doc comments, I just copied the short description from the SDL2 docs, is that ok?