### PR TITLE
Update cfg-if to 1.0

### DIFF
--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -49,7 +49,7 @@ optional = true
 
 [build-dependencies]
 version-compare = "0.0.10"
-cfg-if = "^0.1"
+cfg-if = "^1.0"
 
 [features]
 


### PR DESCRIPTION
Since the most common crates have already moved to v1 of cfg-if, the current version makes sdl2 introduce a new version.
(tested on a monorepo with more than a 100deps).