### PR TITLE
Add additional contract for timer callbacks

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -60,7 +60,7 @@ impl TimerSubsystem {
     }
 }
 
-pub type TimerCallback<'a> = Box<dyn FnMut() -> u32 + 'a + Sync>;
+pub type TimerCallback<'a> = Box<dyn FnMut() -> u32 + 'a + Send>;
 
 pub struct Timer<'b, 'a> {
     callback: Option<Box<TimerCallback<'a>>>,


### PR DESCRIPTION
It seems for me that there is wrong contract for timer callback. It just uses `Sync`, while it should require just `Send` for `FnMut` callbacks.

As i see timers are run in separate thread and callbacks are called timingwise:
https://github.com/libsdl-org/SDL/blob/main/src/timer/SDL_timer.c#L115-L202

So it runs in single separate thread therefore it should at least require `Send` (as this marker is responsible for sending data between threads).

Sync therefore is responsible for sending immutable references and allowing syncing mutations between them. But there is a synchronization for mutation everyth
There is also synchronization for mutating everything:
https://github.com/libsdl-org/SDL/blob/main/src/timer/SDL_timer.c#L349-L361

Dont see a reason why `FnMut` should also be `Sync`, as we giveaway its owning to library. So it should just be `Send`. Here is example using standart library:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=75b62154938206d346872812666e329d