### PR TITLE
Update vcpkg rev to unblock Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ dependencies = ["sdl2"]
 # dependencies required when building examples and tests for this crate
 dev-dependencies = ["sdl2", "sdl2-image[libjpeg-turbo,tiff,libwebp]", "sdl2-ttf", "sdl2-gfx", "sdl2-mixer"]
 git = "https://github.com/microsoft/vcpkg"
-rev = "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
+rev = "261c458af6e3eed5d099144aff95d2b5035f656b"
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ features = ["ttf","image","gfx","mixer","static-link","use-vcpkg"]
 [package.metadata.vcpkg]
 dependencies = ["sdl2", "sdl2-image[libjpeg-turbo,tiff,libwebp]", "sdl2-ttf", "sdl2-gfx", "sdl2-mixer"]
 git = "https://github.com/microsoft/vcpkg"
-rev = "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
+rev = "261c458af6e3eed5d099144aff95d2b5035f656b"
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }


### PR DESCRIPTION
Something happened that broke the `vcpkg.exe install` invocation for
sdl2 on Windows when using github actions with `windows-latest`.

I have not been able to determine what is actually causing the break,
however updating to a more recent version of vcpkg seems to have fixed
the issue, so that is what is proposed here.

The commit selected is current top of tree.

Original report: https://github.com/mcgoo/cargo-vcpkg/issues/9