### PR TITLE
Bind new functions: SDL_GL_GetCurrentContext and SDL_RenderFlush

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -1586,6 +1586,15 @@ impl<T: RenderTarget> Canvas<T> {
     pub unsafe fn raw_create_texture(&self, raw: *mut sys::SDL_Texture) -> Texture {
         Texture { raw }
     }
+
+    #[doc(alias = "SDL_RenderFlush")]
+    pub unsafe fn render_flush(&self) {
+        let ret = sys::SDL_RenderFlush(self.context.raw);
+
+        if ret != 0 {
+            panic!("Error setting blend: {}", get_error())
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1219,8 +1219,19 @@ impl Window {
         }
     }
 
-    /// Set the window's OpenGL context to the current context on the thread.
     #[doc(alias = "SDL_GL_GetCurrentContext")]
+    pub unsafe fn gl_get_current_context(&self) -> Option<GLContext> {
+        let context_raw = sys::SDL_GL_GetCurrentContext();
+
+        if !context_raw.is_null() {
+            Some(GLContext { raw: context_raw })
+        } else {
+            None
+        }
+    }
+
+    /// Set the window's OpenGL context to the current context on the thread.
+    #[doc(alias = "SDL_GL_MakeCurrent")]
     pub fn gl_set_context_to_current(&self) -> Result<(), String> {
         unsafe {
             let context_raw = sys::SDL_GL_GetCurrentContext();


### PR DESCRIPTION
`RenderFlush` in particular is quite important with egui_sdl2_gl when using SDL2 with `Canvas`.
