### PR TITLE
Remove the trailing slash from libsdl-org/SDL submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sdl2-sys/SDL"]
 	path = sdl2-sys/SDL
-	url = https://github.com/libsdl-org/SDL/
+	url = https://github.com/libsdl-org/SDL


### PR DESCRIPTION
Hello!

One of the libraries in my project uses `rust-sdl2` like the following:

```toml
[dependencies]
sdl2 = { git = "https://github.com/Rust-SDL2/rust-sdl2" }

[features]
bundled-sdl2 = ["sdl2/bundled"]
```

However, I got the following error when I try to build:

```
   Updating git repository `https://github.com/Rust-SDL2/rust-sdl2`
    Updating git submodule `https://github.com/libsdl-org/SDL/`
error: failed to get `sdl2` as a dependency of package `fishsticks v0.1.1 (/home/orhun/gh/fishsticks)`
    ... which satisfies path dependency `fishsticks` (locked to 0.1.1) of package `fishfight v0.2.0 (/home/orhun/gh/fishfight)`

Caused by:
  failed to load source for dependency `sdl2`

Caused by:
  Unable to update https://github.com/Rust-SDL2/rust-sdl2

Caused by:
  failed to update submodule `sdl2-sys/SDL`

Caused by:
  failed to fetch submodule `sdl2-sys/SDL` from https://github.com/libsdl-org/SDL/

Caused by:
  process didn't exit successfully: `git fetch --tags --force --update-head-ok 'https://github.com/libsdl-org/SDL/' '+refs/heads/*:refs/remotes/origin/*' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
  --- stderr
  ERROR: Repository not found.
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
```

Then I discovered that this happens due to a trailing slash (`/`) character in the submodule URL:

> url = https://github.com/libsdl-org/SDL **/** <--

In this PR, I remove this character from the submodule URL.

To verify that this change solves the issue, I tried using `rust-sdl2` from my fork:

```toml
[dependencies]
sdl2 = { git = "https://github.com/orhun/rust-sdl2", branch = "update_submodule_url" }

[features]
bundled-sdl2 = ["sdl2/bundled"]
```

And it worked perfectly:

```
    Updating git repository `https://github.com/orhun/rust-sdl2`
    Updating git submodule `https://github.com/libsdl-org/SDL`
   Compiling libc v0.2.103
   ...
```
