### PR TITLE
Added back accidentally removed default feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ optional = true
 
 [features]
 unsafe_textures = []
-#default = ["hidapi"]
+default = []
 gfx = ["c_vec", "sdl2-sys/gfx"]
 mixer = ["sdl2-sys/mixer"]
 image = ["sdl2-sys/image"]


### PR DESCRIPTION
Right now commented out "default" feature prevents the docs from building: https://docs.rs/crate/sdl2/0.35.0/builds/449422. It looks like the feature has been accidentally removed in https://github.com/Rust-SDL2/rust-sdl2/pull/1131.