### PR TITLE
Fixed static-link on macOS and Android and added instructions for distributing bundled library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rust-SDL2 [![Build Status][workflows-ci-img]] [workflows-ci] [![crates.io badge][crates-io-badge]][crates-io-url]
+# Rust-SDL2 [![Build Status][workflows-ci-img]][workflows-ci] [![crates.io badge][crates-io-badge]][crates-io-url]
 
 Bindings for SDL2 in Rust
 
@@ -42,6 +42,16 @@ SDL2 >= 2.0.8 is recommended to use these bindings, but note that SDL2 >= 2.0.5 
 ### "Bundled" Feature
 
 Since 0.31, this crate supports a feature named "bundled" which compiles SDL2 from source and links it automatically. While this should work for any architecture, you **will** need a C compiler (like `gcc`, `clang`, or MS's own compiler) to use this feature properly.
+
+By default, macOS and Linux only load libraries from system directories like `/usr/lib`. If you wish to distribute the newly built libSDL2.so/libSDL2.dylib alongside your executable, you will need to add rpath to your executable. Add the following line to `build.rs` script:
+* on macOS:
+```rust
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+```
+* on Linux:
+```rust
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+```
 
 ### Linux
 Install these through your favourite package management tool, or via

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -252,6 +252,7 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-link-lib=framework=IOKit");
             println!("cargo:rustc-link-lib=framework=Carbon");
             println!("cargo:rustc-link-lib=framework=ForceFeedback");
+            println!("cargo:rustc-link-lib=framework=GameController");
             println!("cargo:rustc-link-lib=framework=CoreVideo");
             println!("cargo:rustc-link-lib=framework=CoreAudio");
             println!("cargo:rustc-link-lib=framework=AudioToolbox");
@@ -264,6 +265,7 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-link-lib=GLESv2");
             println!("cargo:rustc-link-lib=hidapi");
             println!("cargo:rustc-link-lib=log");
+            println!("cargo:rustc-link-lib=OpenSLES");
         } else {
             // TODO: Add other platform linker options here.
         }


### PR DESCRIPTION
1. Added a couple of libraries required to use static-link feature on macOS and Android.
2. Added a small instruction on how to set rpath for macOS and Linux.

The second point is actually a bit interesting: right now you can the `bundled` feature on macOS and Linux works differently when you run binaries/tests/benches via cargo and when you run the binary directly. This happens because cargo sets a few env vars: https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths and causes a lot of confusion (either the binary does not run with error such as `dyld: Library not loaded: @rpath/libSDL2-2.0.dylib` or picks up the system (probably, outdated) copy of the library).