### PR TITLE
Fix timer callback type

### DIFF
--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -88,7 +88,7 @@ impl<'b, 'a> Drop for Timer<'b, 'a> {
 }
 
 extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> u32 {
-    let f = param as *mut std::boxed::Box<dyn std::ops::Fn() -> u32>;
+    let f = param as *mut TimerCallback<'_>;
     unsafe { (*f)() }
 }
 


### PR DESCRIPTION
- Closes #1166
- `TimerCallback` has type: `Box<dyn FnMut() -> u32 + 'a + Send>`