### PR TITLE
Update raw-window-handle to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pollster = "0.2.4"
 env_logger = "0.9.0"
 
 [dependencies.raw-window-handle]
-version = "0.3.3"
+version = "0.4.2"
 optional = true
 
 [features]


### PR DESCRIPTION
This is required for Rust-SDL2 to work with the latest version of WGPU.

This would usually be a breaking change, but thankfully `raw-window-handle` have used the [semver trick](https://github.com/dtolnay/semver-trick) to [do a compatibility release of 0.3](https://github.com/rust-windowing/raw-window-handle/pull/74). This means that any 0.4 `HasRawWindowHandle` also implements the 0.3 `HasRawWindowHandle` (hence why the WGPU example hasn't broken as a result of this change).

I did try to update the WGPU example too, but I don't know the API well enough to do so.

I have tested this on Windows and it seems to work - I don't have any way of testing other OSes, but the API changes seem fairly uniform, so hopefully it should all be fine? Will wait and see how the CI build goes :)

Summary of changes:

* Loads of stuff got renamed.
* All of the structs are non-exhaustive now, so we can't use the `..` syntax to build them.