### PR TITLE
Return `Result` from `AudioQueue::queue` instead of `bool`

### DIFF
--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), String> {
 
     let target_bytes = 48_000 * 4;
     let wave = gen_wave(target_bytes);
-    device.queue(&wave);
+    device.queue_audio(&wave)?;
     // Start playback
     device.resume();
 

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -750,6 +750,10 @@ impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
 
     /// Adds data to the audio queue.
     #[doc(alias = "SDL_QueueAudio")]
+    #[deprecated(
+        since = "0.36.0",
+        note = "Users should instead use AudioQueue::queue_audio"
+    )]
     pub fn queue(&self, data: &[Channel]) -> bool {
         let result = unsafe {
             sys::SDL_QueueAudio(
@@ -759,6 +763,23 @@ impl<'a, Channel: AudioFormatNum> AudioQueue<Channel> {
             )
         };
         result == 0
+    }
+
+    /// Adds data to the audio queue.
+    #[doc(alias = "SDL_QueueAudio")]
+    pub fn queue_audio(&self, data: &[Channel]) -> Result<(), String> {
+        let result = unsafe {
+            sys::SDL_QueueAudio(
+                self.device_id.id(),
+                data.as_ptr() as *const c_void,
+                (data.len() * mem::size_of::<Channel>()) as u32,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
     }
 
     #[doc(alias = "SDL_GetQueuedAudioSize")]


### PR DESCRIPTION
Hi, thank you for developing the nice binding library. I enjoyed trying some SDL2 features with this library.

I noticed that `AudioQueue::queue` is not so idiomatic Rust API. It returns if it succeeded as `bool`. This PR replaces the return value with more idiomatic `Result` type. I believe `Result` is better because

- Rust compiler does not complain about missing error handling if it returns bool. Actually `audio-queue-squarewave` example missed the error handling.
- When an error occurs, user needs to get the error message via `sdl::get_error`. This is not idiomatic error handling and the error message may be overwritten by other errors.

I'm not sure that this change is appropriate because I'm new to both rust-sdl2 and SDL2. Please feel free to reject this PR if it's not appropriate.