### PR TITLE
Fix failure on running events tests in parallel

### DIFF
--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,9 +1,20 @@
 extern crate sdl2;
+#[macro_use]
+extern crate lazy_static;
 
 use sdl2::event;
+use std::sync::Mutex;
+
+// Since only one `Sdl` context instance can be created at a time, running tests in parallel causes
+// 'Cannot initialize `Sdl` more than once at a time' error. To avoid it, run tests in serial by
+// locking this mutex.
+lazy_static! {
+    static ref CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
+}
 
 #[test]
 fn test_events() {
+    let _lock = CONTEXT_MUTEX.lock();
     let sdl = sdl2::init().unwrap();
     let ev = sdl.event().unwrap();
     let mut ep = sdl.event_pump().unwrap();
@@ -103,6 +114,7 @@ fn test4(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
 
 #[test]
 fn test_event_sender_no_subsystem() {
+    let _lock = CONTEXT_MUTEX.lock();
     let sdl = sdl2::init().unwrap();
     let ev = sdl.event().unwrap();
     let tx = ev.event_sender();


### PR DESCRIPTION
## Problem

When I ran `cargo test` I got this failure:

```
test test_events ... ok
test test_event_sender_no_subsystem ... FAILED

failures:

---- test_event_sender_no_subsystem stdout ----
thread 'test_event_sender_no_subsystem' panicked at 'called `Result::unwrap()` on an `Err` value: "Cannot initialize `Sdl` more than once at a time."', tests/events.rs:106:28
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::result::unwrap_failed
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/result.rs:1616:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/result.rs:1298:23
   4: events::test_event_sender_no_subsystem
             at ./tests/events.rs:106:15
   5: events::test_event_sender_no_subsystem::{{closure}}
             at ./tests/events.rs:105:1
   6: core::ops::function::FnOnce::call_once
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/ops/function.rs:227:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    test_event_sender_no_subsystem
```

Either `test_events` or `test_event_sender_no_subsystem` fails randomly. This is because `cargo test` runs test cases in parallel but only one `Sdl` context instance can be created at a time.

`cargo test -- --test-threads=1` can avoid this issue, but it slows running tests since all tests are run in single thread.

## Solution by this PR

This PR makes the tests running in serial by adding a static mutex value. I confirmed the above failure no longer happened after adding this fix.