### PR TITLE
sdl2-sys: Avoid to add unwanted system folder in library research paths

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -45,6 +45,7 @@ fn init_submodule(sdl_path: &Path) {
 #[cfg(feature = "use-pkgconfig")]
 fn pkg_config_print(statik: bool, lib_name: &str) {
     pkg_config::Config::new()
+        .print_system_libs(false)
         .statik(statik)
         .probe(lib_name)
         .unwrap();


### PR DESCRIPTION
Default pkg-config-rs behavior is to add default system library paths (ex:
-L/usr/lib/x86_64-linux-gnu).

This is because PKG_CONFIG_ALLOW_SYSTEM_LIBS is set by pkg-config-rs by
default. print_system_libs(false) disable this behavior.

More details in evdev-rs project:
https://github.com/ndesh26/evdev-rs/issues/85