### PR TITLE
Add missing CoreHaptics framework

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -208,6 +208,7 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-flags=-l framework=CoreMotion");
             println!("cargo:rustc-flags=-l framework=Foundation");
             println!("cargo:rustc-flags=-l framework=GameController");
+            println!("cargo:rustc-flags=-l framework=CoreHaptics");
             println!("cargo:rustc-flags=-l framework=OpenGLES");
             println!("cargo:rustc-flags=-l framework=QuartzCore");
             println!("cargo:rustc-flags=-l framework=UIKit");
@@ -253,6 +254,7 @@ fn link_sdl2(target_os: &str) {
             println!("cargo:rustc-link-lib=framework=Carbon");
             println!("cargo:rustc-link-lib=framework=ForceFeedback");
             println!("cargo:rustc-link-lib=framework=GameController");
+            println!("cargo:rustc-link-lib=framework=CoreHaptics");
             println!("cargo:rustc-link-lib=framework=CoreVideo");
             println!("cargo:rustc-link-lib=framework=CoreAudio");
             println!("cargo:rustc-link-lib=framework=AudioToolbox");


### PR DESCRIPTION
This framework is used by the SDL_JOYSTICK module, but it is missing from Darwin builds.
I have confirmed that this fixes my issues on my MacOS build. I have added the directive for the iOS builds, too, but that will need to be double-checked as I don't have a workflow for that.