### PR TITLE
Update wgpu to 0.12 and fix raw-window-handle-with-wgpu example program.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.7"
-wgpu = { version = "0.10", features = ["spirv"] }
+wgpu = { version = "0.12", features = ["spirv"] }
 pollster = "0.2.4"
 env_logger = "0.9.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### v0.35.2
 
+[PR #1225](https://github.com/Rust-SDL2/rust-sdl2/pull/1225) Update wgpu to 0.12 and fix raw-window-handle-with-wgpu example
+
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks
 
 [PR #1183](https://github.com/Rust-SDL2/rust-sdl2/pull/1183) WinRT support for raw-window-handle

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,11 @@
 In this file will be listed the changes, especially the breaking ones that one should be careful of
 when upgrading from a version of rust-sdl2 to another.
 
-### v0.35.2
+### Unreleased
 
 [PR #1225](https://github.com/Rust-SDL2/rust-sdl2/pull/1225) Update wgpu to 0.12 and fix raw-window-handle-with-wgpu example
+
+### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks
 


### PR DESCRIPTION
As described in https://github.com/Rust-SDL2/rust-sdl2/issues/1224, updates wgpu to latest version and fixes the wgpu example program so that it runs and displays the triangle.