### PR TITLE
Fix XInput support in the game-controller example (fixes #1230)

### DIFF
--- a/examples/game-controller.rs
+++ b/examples/game-controller.rs
@@ -4,7 +4,7 @@ fn main() -> Result<(), String> {
     // This is required for certain controllers to work on Windows without the
     // video subsystem enabled:
     sdl2::hint::set("SDL_JOYSTICK_THREAD", "1");
-    
+
     let sdl_context = sdl2::init()?;
     let game_controller_subsystem = sdl_context.game_controller()?;
 

--- a/examples/game-controller.rs
+++ b/examples/game-controller.rs
@@ -1,6 +1,10 @@
 extern crate sdl2;
 
 fn main() -> Result<(), String> {
+    // This is required for certain controllers to work on Windows without the
+    // video subsystem enabled:
+    sdl2::hint::set("SDL_JOYSTICK_THREAD", "1");
+    
     let sdl_context = sdl2::init()?;
     let game_controller_subsystem = sdl_context.game_controller()?;
 


### PR DESCRIPTION
Fixes #1230.

An alternative fix for this would be to enable the video subsystem, but since this example doesn't use it, this seems a bit cleaner.