### PR TITLE
Surface: take PixelMasks by refrence not value

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1225](https://github.com/Rust-SDL2/rust-sdl2/pull/1225) Update wgpu to 0.12 and fix raw-window-handle-with-wgpu example
 
+[PR #1240](https://github.com/Rust-SDL2/rust-sdl2/pull/1240) **BREAKING CHANGE** Take `PixelMasks` by refrence
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -125,7 +125,7 @@ impl<'a> Surface<'a> {
         format: pixels::PixelFormatEnum,
     ) -> Result<Surface<'static>, String> {
         let masks = format.into_masks()?;
-        Surface::from_pixelmasks(width, height, masks)
+        Surface::from_pixelmasks(width, height, &masks)
     }
 
     /// Creates a new surface using pixel masks.
@@ -142,7 +142,7 @@ impl<'a> Surface<'a> {
     pub fn from_pixelmasks(
         width: u32,
         height: u32,
-        masks: pixels::PixelMasks,
+        masks: &pixels::PixelMasks,
     ) -> Result<Surface<'static>, String> {
         unsafe {
             if width >= (1 << 31) || height >= (1 << 31) {
@@ -177,7 +177,7 @@ impl<'a> Surface<'a> {
         format: pixels::PixelFormatEnum,
     ) -> Result<Surface<'a>, String> {
         let masks = format.into_masks()?;
-        Surface::from_data_pixelmasks(data, width, height, pitch, masks)
+        Surface::from_data_pixelmasks(data, width, height, pitch, &masks)
     }
 
     /// Creates a new surface from an existing buffer, using pixel masks.
@@ -187,7 +187,7 @@ impl<'a> Surface<'a> {
         width: u32,
         height: u32,
         pitch: u32,
-        masks: pixels::PixelMasks,
+        masks: &pixels::PixelMasks,
     ) -> Result<Surface<'a>, String> {
         unsafe {
             if width >= (1 << 31) || height >= (1 << 31) {


### PR DESCRIPTION
This patch changes the Surface to receive the PixelMasks by refrence not
a moved value. This avoids continous reconstruction of a PixelMasks
struct when using the from_data_pixelmasks method to create a
surface many times.