### PR TITLE
Update README and changelog with new min SDL2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We currently target the latest stable release of Rust.
 
 ## *SDL2.0 development libraries*
 
-SDL2 >= 2.0.8 is recommended to use these bindings, but note that SDL2 >= 2.0.5 is also supported. Below 2.0.5, you may experience link-time errors as some functions are used here but are not defined in SDL2. If you experience this issue because you are on a LTS machine (for instance, Ubuntu 12.04 or Ubuntu 14.04), we definitely recommend you to use the feature "bundled" which will compile the lastest stable version of SDL2 for your project.
+SDL2 >= 2.0.14 is recommended to use these bindings; below 2.0.14, you may experience link-time errors as some functions are used here but are not defined in SDL2. If you experience this issue because you are on a LTS machine (for instance, Ubuntu 12.04 or Ubuntu 14.04), we definitely recommend you to use the feature "bundled" which will compile the lastest stable version of SDL2 for your project.
 
 ### "Bundled" Feature
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@ when upgrading from a version of rust-sdl2 to another.
 * **BREAKING CHANGE** Update `sdl2-sys/sdl_bindings.rs` to use enums instead of consts. If you were using `sdl2-sys`'s
 enum variants directly in your project, you may be affected. If you only used sdl2 calls, there should not be any problems.
 
+* **BREAKING CHANGE** SDL 2.0.14 or higher is now recommended due to the new binding being added for `SDL_OpenURL`. If you get linking errors, upgrade your SDL2 libraries, or swap to using the `bundled` feature.
+
 [PR #1138](https://github.com/Rust-SDL2/rust-sdl2/pull/1138) Added binding for `SDL_OpenURL`
 
 [PR #1150](https://github.com/Rust-SDL2/rust-sdl2/pull/1150) Do not download SDL2 sources when using bundled feature


### PR DESCRIPTION
Closes #1244.

---

I stuck with the "recommended" wording because while linking on Windows flat out fails with an older version, linking on Linux works fine as long as you don't actually have a call to `sdl2::url::open_url()`.