### PR TITLE
Fix build error on Windows with `bundled` and `static-link` features

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -231,7 +231,11 @@ fn link_sdl2(target_os: &str) {
             || (cfg!(feature = "use-pkgconfig") == false && cfg!(feature = "use-vcpkg") == false)
         {
             println!("cargo:rustc-link-lib=static=SDL2main");
-            println!("cargo:rustc-link-lib=static=SDL2");
+            if target_os.contains("windows") {
+                println!("cargo:rustc-link-lib=static=SDL2-static");
+            } else {
+                println!("cargo:rustc-link-lib=static=SDL2");
+            }
         }
 
         // Also linked to any required libraries for each supported platform


### PR DESCRIPTION
Fixes [the following error](https://github.com/Rust-SDL2/rust-sdl2/runs/7975841404?check_suite_focus=true)

```
error: could not find native static library `SDL2`, perhaps an -L flag is missing?

error: could not compile `sdl2-sys` due to previous error
```

On Windows it currently outputs a `SDL2-static.lib` instead of `SDL2.lib`.