### PR TITLE
Make SdlDrop and SubsystemDrop safer to use

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1240](https://github.com/Rust-SDL2/rust-sdl2/pull/1240) **BREAKING CHANGE** Take `PixelMasks` by refrence
 
+[PR #1254](https://github.com/Rust-SDL2/rust-sdl2/pull/1254) **BREAKING CHANGE** Make `SdlDrop` and `SubsystemDrop` safer; forbid external code from constructing `SdlDrop`
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks
@@ -60,7 +62,7 @@ Various fixes to CI.
 [PR #1033](https://github.com/Rust-SDL2/rust-sdl2/pull/1033) Changed signature of TimerSubsystem::ticks to accept `&self`.
 
 [PR #1057](https://github.com/Rust-SDL2/rust-sdl2/pull/1057): fix memory safety bug in set_error
- 
+
 [PR #1081](https://github.com/Rust-SDL2/rust-sdl2/pull/1081): Allow bundled build to be built in debug mode.  Fixes issue when linking binary with mixed debug+release CRT dependencies.
 
 [PR #1080](https://github.com/Rust-SDL2/rust-sdl2/pull/1080): Fix line endings of patches to lf so patching of sources works on Windows.

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -175,7 +175,7 @@ impl crate::VideoSubsystem {
 /// let focused = sdl_context.keyboard().focused_window_id().is_some();
 /// ```
 pub struct KeyboardUtil {
-    _sdldrop: ::std::rc::Rc<crate::SdlDrop>,
+    _sdldrop: crate::SdlDrop,
 }
 
 impl KeyboardUtil {

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -374,7 +374,7 @@ impl crate::Sdl {
 /// sdl_context.mouse().show_cursor(false);
 /// ```
 pub struct MouseUtil {
-    _sdldrop: ::std::rc::Rc<crate::SdlDrop>,
+    _sdldrop: crate::SdlDrop,
 }
 
 impl MouseUtil {


### PR DESCRIPTION
Fixes #1247 and #1248. Ensures better initialization/drop guarantees for `SdlDrop` and `SubsystemDrop` by using global reference counts. This has a few caveats:

* `SdlDrop` can no longer be initialized from outside the `crate::sdl` module. Any external code depending on this (hopefully there was none because this is extremely unsafe) will break.
* Public but hidden functions returning `SdlDrop` and `SubsystemDrop` are no longer wrapped in `Rc<>`. Any external code depending on these functions will break. It would be possible to reverse this change, but with global reference counting, there is no longer any good reason to do so.
* The fixes caused at least one of the tests to break because tests are run in parallel by default, and more than one test initializes SDL. Now that this can only be done from one thread, one must specify `--test-threads=1` for the tests to pass. Maybe this was already the case, but I didn't check before making these changes. Example: `cargo test -- --test-threads=1`

Because the first two caveats are API breaks, even if hidden from documentation, I recommend a version bump to 0.36.0 if these changes are accepted.