### PR TITLE
Update raw-window-handle to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ optional = true
 
 [dev-dependencies]
 rand = "0.7"
-wgpu = { version = "0.12", features = ["spirv"] }
+wgpu = { version = "0.14", features = ["spirv"] }
 pollster = "0.2.4"
 env_logger = "0.9.0"
 
 [dependencies.raw-window-handle]
-version = "0.4.2"
+version = "0.5.0"
 optional = true
 
 [features]

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -4,7 +4,7 @@ extern crate sdl2;
 extern crate wgpu;
 
 use std::borrow::Cow;
-use wgpu::{SurfaceError, SurfaceTexture};
+use wgpu::SurfaceError;
 
 use sdl2::event::{Event, WindowEvent};
 use sdl2::keyboard::Keycode;
@@ -19,6 +19,7 @@ fn main() -> Result<(), String> {
         .window("Raw Window Handle Example", 800, 600)
         .position_centered()
         .resizable()
+        .metal_view()
         .build()
         .map_err(|e| e.to_string())?;
     let (width, height) = window.size();
@@ -138,10 +139,10 @@ fn main() -> Result<(), String> {
             }
         }
 
-        let mut frame = match surface.get_current_texture() {
+        let frame = match surface.get_current_texture() {
             Ok(frame) => frame,
             Err(err) => {
-                let reason = match (err) {
+                let reason = match err {
                     SurfaceError::Timeout => "Timeout",
                     SurfaceError::Outdated => "Outdated",
                     SurfaceError::Lost => "Lost",

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), String> {
         Err(e) => return Err(e.to_string()),
     };
 
-    let shader = device.create_shader_module(&wgpu::ShaderModuleDescriptor {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("shader"),
         source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
     });
@@ -75,11 +75,11 @@ fn main() -> Result<(), String> {
             entry_point: "vs_main",
         },
         fragment: Some(wgpu::FragmentState {
-            targets: &[wgpu::ColorTargetState {
+            targets: &[Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Bgra8UnormSrgb,
                 blend: None,
                 write_mask: wgpu::ColorWrites::ALL,
-            }],
+            })],
             module: &shader,
             entry_point: "fs_main",
         }),
@@ -104,10 +104,11 @@ fn main() -> Result<(), String> {
 
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface.get_preferred_format(&adapter).unwrap(),
+        format: surface.get_supported_formats(&adapter)[0],
         width,
         height,
-        present_mode: wgpu::PresentMode::Mailbox,
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode: wgpu::CompositeAlphaMode::Auto,
     };
     surface.configure(&device, &config);
 
@@ -159,14 +160,14 @@ fn main() -> Result<(), String> {
 
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                color_attachments: &[wgpu::RenderPassColorAttachment {
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &output,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
                         store: true,
                     },
-                }],
+                })],
                 depth_stencil_attachment: None,
                 label: None,
             });

--- a/examples/raw-window-handle-with-wgpu/shader.wgsl
+++ b/examples/raw-window-handle-with-wgpu/shader.wgsl
@@ -1,11 +1,11 @@
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] in_vertex_index: u32) -> [[builtin(position)]] vec4<f32> {
+@vertex
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) ->  @builtin(position) vec4<f32> {
     let x = f32(i32(in_vertex_index) - 1);
     let y = f32(i32(in_vertex_index & 1u) * 2 - 1);
     return vec4<f32>(x, y, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main() -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/sdl2/raw_window_handle.rs
+++ b/src/sdl2/raw_window_handle.rs
@@ -1,6 +1,8 @@
 extern crate raw_window_handle;
 
-use self::raw_window_handle::{HasRawWindowHandle, RawWindowHandle, HasRawDisplayHandle, RawDisplayHandle};
+use self::raw_window_handle::{
+    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
 use crate::{sys::SDL_Window, video::Window};
 
 unsafe impl HasRawWindowHandle for Window {

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -547,23 +547,30 @@ impl GLContext {
 pub struct WindowContext {
     subsystem: VideoSubsystem,
     raw: *mut sys::SDL_Window,
+    pub(crate) metal_view: sys::SDL_MetalView,
 }
 
 impl Drop for WindowContext {
     #[inline]
     #[doc(alias = "SDL_DestroyWindow")]
     fn drop(&mut self) {
-        unsafe { sys::SDL_DestroyWindow(self.raw) };
+        unsafe {
+            if !self.metal_view.is_null() {
+                sys::SDL_Metal_DestroyView(self.metal_view);
+            }
+            sys::SDL_DestroyWindow(self.raw)
+        };
     }
 }
 
 impl WindowContext {
     #[inline]
     /// Unsafe if the `*mut SDL_Window` is used after the `WindowContext` is dropped
-    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window) -> WindowContext {
+    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window, metal_view: sys::SDL_MetalView) -> WindowContext {
         WindowContext {
             subsystem: subsystem.clone(),
             raw,
+            metal_view,
         }
     }
 }
@@ -1098,6 +1105,7 @@ pub struct WindowBuilder {
     x: WindowPos,
     y: WindowPos,
     window_flags: u32,
+    create_metal_view: bool,
     /// The window builder cannot be built on a non-main thread, so prevent cross-threaded moves and references.
     /// `!Send` and `!Sync`,
     subsystem: VideoSubsystem,
@@ -1114,6 +1122,7 @@ impl WindowBuilder {
             y: WindowPos::Undefined,
             window_flags: 0,
             subsystem: v.clone(),
+            create_metal_view: false,
         }
     }
 
@@ -1143,11 +1152,16 @@ impl WindowBuilder {
                 raw_height,
                 self.window_flags,
             );
+            let mut metal_view = 0 as sys::SDL_MetalView;
+            #[cfg(target_os="macos")]
+            if self.create_metal_view {
+                metal_view = sys::SDL_Metal_CreateView(raw);
+            }
 
             if raw.is_null() {
                 Err(SdlError(get_error()))
             } else {
-                Ok(Window::from_ll(self.subsystem.clone(), raw))
+                Ok(Window::from_ll(self.subsystem.clone(), raw, metal_view))
             }
         }
     }
@@ -1243,6 +1257,14 @@ impl WindowBuilder {
         self.window_flags |= sys::SDL_WindowFlags::SDL_WINDOW_ALLOW_HIGHDPI as u32;
         self
     }
+
+    /// Create a SDL_MetalView when constructing the window.
+    /// This is required when using the raw_window_handle feature on MacOS.
+    /// Has no effect no other platforms.
+    pub fn metal_view(&mut self) -> &mut WindowBuilder {
+        self.create_metal_view = true;
+        self
+    }
 }
 
 impl From<Window> for CanvasBuilder {
@@ -1261,8 +1283,8 @@ impl Window {
     }
 
     #[inline]
-    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window) -> Window {
-        let context = WindowContext::from_ll(subsystem, raw);
+    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window, metal_view: sys::SDL_MetalView) -> Window {
+        let context = WindowContext::from_ll(subsystem, raw, metal_view);
         context.into()
     }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -566,7 +566,11 @@ impl Drop for WindowContext {
 impl WindowContext {
     #[inline]
     /// Unsafe if the `*mut SDL_Window` is used after the `WindowContext` is dropped
-    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window, metal_view: sys::SDL_MetalView) -> WindowContext {
+    pub unsafe fn from_ll(
+        subsystem: VideoSubsystem,
+        raw: *mut sys::SDL_Window,
+        metal_view: sys::SDL_MetalView,
+    ) -> WindowContext {
         WindowContext {
             subsystem: subsystem.clone(),
             raw,
@@ -1153,7 +1157,7 @@ impl WindowBuilder {
                 self.window_flags,
             );
             let mut metal_view = 0 as sys::SDL_MetalView;
-            #[cfg(target_os="macos")]
+            #[cfg(target_os = "macos")]
             if self.create_metal_view {
                 metal_view = sys::SDL_Metal_CreateView(raw);
             }
@@ -1283,7 +1287,11 @@ impl Window {
     }
 
     #[inline]
-    pub unsafe fn from_ll(subsystem: VideoSubsystem, raw: *mut sys::SDL_Window, metal_view: sys::SDL_MetalView) -> Window {
+    pub unsafe fn from_ll(
+        subsystem: VideoSubsystem,
+        raw: *mut sys::SDL_Window,
+        metal_view: sys::SDL_MetalView,
+    ) -> Window {
         let context = WindowContext::from_ll(subsystem, raw, metal_view);
         context.into()
     }

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -119,6 +119,7 @@ mod raw_window_handle_test {
         video_subsystem
             .window("Hello, World!", 800, 600)
             .hidden()
+            .metal_view()
             .build()
             .unwrap()
     }

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -3,7 +3,9 @@ mod raw_window_handle_test {
     extern crate raw_window_handle;
     extern crate sdl2;
 
-    use self::raw_window_handle::{HasRawWindowHandle, RawWindowHandle, HasRawDisplayHandle, RawDisplayHandle};
+    use self::raw_window_handle::{
+        HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+    };
     use self::sdl2::video::Window;
 
     #[cfg(target_os = "windows")]
@@ -40,7 +42,6 @@ mod raw_window_handle_test {
     ))]
     #[test]
     fn get_linux_handle() {
-
         let window = new_hidden_window();
         match window.raw_window_handle() {
             RawWindowHandle::Xlib(x11_handle) => {
@@ -91,9 +92,9 @@ mod raw_window_handle_test {
                     macos_handle.ns_window, 0 as *mut libc::c_void,
                     "ns_window should not be null"
                 );
-                assert_eq!(
+                assert_ne!(
                     macos_handle.ns_view, 0 as *mut libc::c_void,
-                    "nw_view should be null"
+                    "nw_view should not be null"
                 );
                 println!("Successfully received macOS RawWindowHandle!");
             }
@@ -104,7 +105,7 @@ mod raw_window_handle_test {
             ),
         };
         match window.raw_display_handle() {
-            RawDisplayHandle::AppKit(_) => {},
+            RawDisplayHandle::AppKit(_) => {}
             x => assert!(
                 false,
                 "Received wrong RawDisplayHandle type for macOS: {:?}",


### PR DESCRIPTION
Resolves #1269 

I tested this on:
- Linux with X11: raw-window-handle test pass and the example shows the triangle.
- Windows with Win32: raw-window-handle test pass and the example shows the triangle.
- MacOS: The example works and shows the triangle. We need SDL to construct a `SDL_MetalView` though, which likely means one can only use Metal afterwards. The test fails to run with the same error as in #1151. The mentioned issue is caused by `cargo test` using multiple threads.

Other platforms are best effort guess work.