### PR TITLE
add serde feature and derives for various types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/sdl2/lib.rs"
 bitflags = "1.2.1"
 libc = "0.2.92"
 lazy_static = "1.4.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dependencies.sdl2-sys]
 path = "sdl2-sys"

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -198,6 +198,7 @@ impl GameControllerSubsystem {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(i32)]
 pub enum Axis {
     LeftX = sys::SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_LEFTX as i32,
@@ -264,6 +265,7 @@ impl Axis {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(i32)]
 pub enum Button {
     A = sys::SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_A as i32,

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -577,6 +577,7 @@ impl Display for Guid {
 /// the same time... To simplify things I turn it into an enum which
 /// is how the SDL2 docs present it anyway (using macros).
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HatState {
     Centered = 0,
     Up = 0x01,

--- a/src/sdl2/keyboard/keycode.rs
+++ b/src/sdl2/keyboard/keycode.rs
@@ -7,6 +7,7 @@ use std::mem::transmute;
 use crate::sys;
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(i32)]
 pub enum Keycode {
     Backspace = sys::SDL_KeyCode::SDLK_BACKSPACE as i32,

--- a/src/sdl2/keyboard/scancode.rs
+++ b/src/sdl2/keyboard/scancode.rs
@@ -9,6 +9,7 @@ use crate::sys::SDL_Scancode;
 
 #[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Scancode {
     A = SDL_Scancode::SDL_SCANCODE_A as i32,
     B = SDL_Scancode::SDL_SCANCODE_B as i32,

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -107,6 +107,7 @@ impl Cursor {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseWheelDirection {
     Normal,
     Flipped,
@@ -151,6 +152,7 @@ impl MouseWheelDirection {
 
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseButton {
     Unknown = 0,
     Left = sys::SDL_BUTTON_LEFT as u8,

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -482,6 +482,7 @@ impl DisplayMode {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FullscreenType {
     Off = 0,
     True = 0x00_00_00_01,


### PR DESCRIPTION
This adds a `serde` feature as well as `Serialize` and `Deserialize` implementations for the following types:

- `Axis`
- `Button`
- `HatState`
- `Keycode`
- `Scancode`
- `MouseWheelDirection`
- `MouseButton`
- `FullscreenType`

I chose these types because I can see them all being used in a game settings struct that gets saved to a file.

There are some reasons given against adding a `serde` feature in the discussion for #1065, but I disagree with those reasons for the following reasons:

- Yes, it's another dependency, but it's an optional one, and a pretty standard one across the Rust ecosystem. Also, the code changes needed to add serde support are minimal.
- 8 types isn't *that* small of a number.
- All of the workarounds are a pain (in my opinion):
  - Manually implementing `Serialize` and `Deserialize` for a wrapper struct requires knowledge of serde that many people won't have.
  - While `Keycode`s and `Scancode`s can be converted to and from `i32`s, gamepad axes and buttons can only be converted to `String`s or `sdl2_sys` enums, which don't implement `Serialize` or `Deserialize`. `String`s are usable, but it's a weird inconsistency.
  - Using serde's [remote derive](https://serde.rs/remote-derive.html) feature requires duplicating the enums that already exist in the `sdl2` crate.

Implementing input remapping in my game would be a lot easier if `sdl2` had a `serde` feature. Please consider adding it!