### PR TITLE
rename default cmake build type to Release, to fix issue with bundled feature

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -97,7 +97,7 @@ fn compile_sdl2(sdl2_build_path: &Path, target_os: &str) -> PathBuf {
     if let Ok(profile) = env::var("SDL2_BUILD_PROFILE") {
         cfg.profile(&profile);
     } else {
-        cfg.profile("release");
+        cfg.profile("Release");
     }
 
     // Allow specifying custom toolchain specifically for SDL2.


### PR DESCRIPTION
Changed default cmake build profile when using bundled feature from `release` to `Release`.

[As per the CMake doc](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html), the build types are written with a capital letter at the beginning.
 
The incorrect spelling causes an issue with the Ninja Multi-Config generator when building with the bundled feature. Cmake tries to run `build-release.ninja` which produces this error:

```ninja: error: loading 'build-release.ninja': No such file or directory```

Because Ninja produces a script called `build-Release.njnja`. simply renaming the build file in the target folder and building again does not produce the error and everything builds ok.

Changing the default cmake build type for the bundled feature in the `build.rs` script of `sdl2-sys` to `Release` fixes the issue.