### PR TITLE
Fix Android bundled build: define ANDROID_NDK CMake variable

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -132,6 +132,15 @@ fn compile_sdl2(sdl2_build_path: &Path, target_os: &str) -> PathBuf {
         cfg.define("VIDEO_OPENGLES", "OFF");
     }
 
+    if target_os == "android" {
+        cfg.define(
+            "ANDROID_NDK",
+            env::var("ANDROID_NDK_HOME").expect(
+                "ANDROID_NDK_HOME environment variable must be set when compiling for Android",
+            ),
+        );
+    }
+
     if cfg!(feature = "static-link") {
         cfg.define("SDL_SHARED", "OFF");
         cfg.define("SDL_STATIC", "ON");


### PR DESCRIPTION
Versions of SDL since https://github.com/libsdl-org/SDL/commit/5b65e0af01873e26673c11da43001e7075986290 fail to build if this isn't set.

Credit to @ciciplusplus for finding this issue while porting touchHLE to Android.

Btw, I've only tested the dynamically-linked bundled build. I think statically-linked builds might still be broken for other reasons, but they're unrelated to this commit.