### PR TITLE
Exposing window always on top functionality

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1262,6 +1262,12 @@ impl WindowBuilder {
         self
     }
 
+    /// Window should always above others (>= SDL 2.0.5)
+    pub fn always_on_top(&mut self) -> &mut WindowBuilder {
+        self.window_flags |= sys::SDL_WindowFlags::SDL_WINDOW_ALWAYS_ON_TOP as u32;
+        self
+    }
+
     /// Create a SDL_MetalView when constructing the window.
     /// This is required when using the raw_window_handle feature on MacOS.
     /// Has no effect no other platforms.
@@ -1510,6 +1516,11 @@ impl Window {
     /// Is the window minimized?
     pub fn is_minimized(&self) -> bool {
         0 != self.window_flags() & sys::SDL_WindowFlags::SDL_WINDOW_MINIMIZED as u32
+    }
+
+    /// Is the windows always on top?
+    pub fn is_always_on_top(&self) -> bool {
+        0 != self.window_flags() & sys::SDL_WindowFlags::SDL_WINDOW_ALWAYS_ON_TOP as u32
     }
 
     #[doc(alias = "SDL_SetWindowTitle")]
@@ -1953,6 +1964,21 @@ impl Window {
         } else {
             Err(get_error())
         }
+    }
+
+    /// Makes window appear on top others
+    #[doc(alias = "SDL_SetWindowAlwaysOnTop")]
+    pub fn set_always_on_top(&mut self, on_top: bool) {
+        unsafe {
+            sys::SDL_SetWindowAlwaysOnTop(
+                self.context.raw,
+                if on_top {
+                    sys::SDL_bool::SDL_TRUE
+                } else {
+                    sys::SDL_bool::SDL_FALSE
+                },
+            )
+        };
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1518,7 +1518,7 @@ impl Window {
         0 != self.window_flags() & sys::SDL_WindowFlags::SDL_WINDOW_MINIMIZED as u32
     }
 
-    /// Is the windows always on top?
+    /// Is the window always on top?
     pub fn is_always_on_top(&self) -> bool {
         0 != self.window_flags() & sys::SDL_WindowFlags::SDL_WINDOW_ALWAYS_ON_TOP as u32
     }
@@ -1966,7 +1966,7 @@ impl Window {
         }
     }
 
-    /// Makes window appear on top others
+    /// Makes window appear on top of others
     #[doc(alias = "SDL_SetWindowAlwaysOnTop")]
     pub fn set_always_on_top(&mut self, on_top: bool) {
         unsafe {


### PR DESCRIPTION
`sdl2-sys` has been updated since its latest release and exposes `SDL_WINDOWS_ALWAYS_ON_TOP`.

The [documentation](https://wiki.libsdl.org/SDL2/SDL_WindowFlags) for `SDL_WindowFlags` says it's *X11 only*, but that's not the case anymore since it seems to be used in the [windows](https://github.com/libsdl-org/SDL/blob/07d0f51fa292895443f563f0cbde4cb3802d87fa/src/video/windows/SDL_windowswindow.c#L239) and [cocoa](https://github.com/libsdl-org/SDL/blob/07d0f51fa292895443f563f0cbde4cb3802d87fa/src/video/cocoa/SDL_cocoawindow.m#L1036) backends as well in the same tagged version of the headers currently used by sdl2-sys (I checked those arbitrarily so it may be supported by more plataforms).

Tested on Linux under X11 with version 2.26.5