### PR TITLE
fix size_hint implementations in driver iterators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1318](https://github.com/Rust-SDL2/rust-sdl2/pull/1318) Add NV12, NV21 to PixelFormatEnum
 
+[PR #1332](https://github.com/Rust-SDL2/rust-sdl2/pull/1332) Fix `size_hint` implementations for `{audio,video,render}::DriverIterator`
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -372,8 +372,8 @@ impl Iterator for DriverIterator {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let l = self.length as usize;
-        (l, Some(l))
+        let remaining = (self.length - self.index) as usize;
+        (remaining, Some(remaining))
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -2576,8 +2576,8 @@ impl Iterator for DriverIterator {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let l = self.length as usize;
-        (l, Some(l))
+        let remaining = (self.length - self.index) as usize;
+        (remaining, Some(remaining))
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -2012,8 +2012,8 @@ impl Iterator for DriverIterator {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let l = self.length as usize;
-        (l, Some(l))
+        let remaining = (self.length - self.index) as usize;
+        (remaining, Some(remaining))
     }
 }
 


### PR DESCRIPTION
[`size_hint` returns the _remaining_ size of the iterator,](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint) but these iterators have been returning the _total_ size.