### PR TITLE
implement `FusedIterator`, `DoubleEndedIterator`, and `nth[_back]` for driver iterators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1332](https://github.com/Rust-SDL2/rust-sdl2/pull/1332) Fix `size_hint` implementations for `{audio,video,render}::DriverIterator`
 
+[PR #1333](https://github.com/Rust-SDL2/rust-sdl2/pull/1333) Implement `FusedIterator`, `DoubleEndedIterator`, `and nth[_back]` for `{audio,video,render}::DriverIterator`
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -379,6 +379,8 @@ impl Iterator for DriverIterator {
 
 impl ExactSizeIterator for DriverIterator {}
 
+impl std::iter::FusedIterator for DriverIterator {}
+
 /// Gets an iterator of all audio drivers compiled into the SDL2 library.
 #[doc(alias = "SDL_GetAudioDriver")]
 #[inline]

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -384,6 +384,18 @@ impl Iterator for DriverIterator {
         let remaining = (self.length - self.index) as usize;
         (remaining, Some(remaining))
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<&'static str> {
+        use std::convert::TryInto;
+
+        self.index = match n.try_into().ok().and_then(|n| self.index.checked_add(n)) {
+            Some(index) if index < self.length => index,
+            _ => self.length,
+        };
+
+        self.next()
+    }
 }
 
 impl DoubleEndedIterator for DriverIterator {
@@ -396,6 +408,18 @@ impl DoubleEndedIterator for DriverIterator {
 
             Some(get_audio_driver(self.length))
         }
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<&'static str> {
+        use std::convert::TryInto;
+
+        self.length = match n.try_into().ok().and_then(|n| self.length.checked_sub(n)) {
+            Some(length) if length > self.index => length,
+            _ => self.index,
+        };
+
+        self.next_back()
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -2588,6 +2588,18 @@ impl Iterator for DriverIterator {
         let remaining = (self.length - self.index) as usize;
         (remaining, Some(remaining))
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<RendererInfo> {
+        use std::convert::TryInto;
+
+        self.index = match n.try_into().ok().and_then(|n| self.index.checked_add(n)) {
+            Some(index) if index < self.length => index,
+            _ => self.length,
+        };
+
+        self.next()
+    }
 }
 
 impl DoubleEndedIterator for DriverIterator {
@@ -2600,6 +2612,18 @@ impl DoubleEndedIterator for DriverIterator {
 
             Some(get_render_driver_info(self.length))
         }
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<RendererInfo> {
+        use std::convert::TryInto;
+
+        self.length = match n.try_into().ok().and_then(|n| self.length.checked_sub(n)) {
+            Some(length) if length > self.index => length,
+            _ => self.index,
+        };
+
+        self.next_back()
     }
 }
 

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -2583,6 +2583,8 @@ impl Iterator for DriverIterator {
 
 impl ExactSizeIterator for DriverIterator {}
 
+impl std::iter::FusedIterator for DriverIterator {}
+
 /// Gets an iterator of all render drivers compiled into the SDL2 library.
 #[inline]
 #[doc(alias = "SDL_GetNumRenderDrivers")]

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -2556,6 +2556,17 @@ pub struct DriverIterator {
     index: i32,
 }
 
+// panics if SDL_GetRenderDriverInfo returns a nonzero value,
+// which should only happen if index is outside the range
+// 0..SDL_GetNumRenderDrivers()
+fn get_render_driver_info(index: i32) -> RendererInfo {
+    let mut out = mem::MaybeUninit::uninit();
+    let result = unsafe { sys::SDL_GetRenderDriverInfo(index, out.as_mut_ptr()) };
+    assert_eq!(result, 0);
+
+    unsafe { RendererInfo::from_ll(&out.assume_init()) }
+}
+
 impl Iterator for DriverIterator {
     type Item = RendererInfo;
 
@@ -2565,12 +2576,10 @@ impl Iterator for DriverIterator {
         if self.index >= self.length {
             None
         } else {
-            let mut out = mem::MaybeUninit::uninit();
-            let result = unsafe { sys::SDL_GetRenderDriverInfo(self.index, out.as_mut_ptr()) == 0 };
-            assert!(result, "{}", 0);
+            let driver = get_render_driver_info(self.index);
             self.index += 1;
 
-            unsafe { Some(RendererInfo::from_ll(&out.assume_init())) }
+            Some(driver)
         }
     }
 
@@ -2578,6 +2587,19 @@ impl Iterator for DriverIterator {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = (self.length - self.index) as usize;
         (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for DriverIterator {
+    #[inline]
+    fn next_back(&mut self) -> Option<RendererInfo> {
+        if self.index >= self.length {
+            None
+        } else {
+            self.length -= 1;
+
+            Some(get_render_driver_info(self.length))
+        }
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -2024,6 +2024,18 @@ impl Iterator for DriverIterator {
         let remaining = (self.length - self.index) as usize;
         (remaining, Some(remaining))
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<&'static str> {
+        use std::convert::TryInto;
+
+        self.index = match n.try_into().ok().and_then(|n| self.index.checked_add(n)) {
+            Some(index) if index < self.length => index,
+            _ => self.length,
+        };
+
+        self.next()
+    }
 }
 
 impl DoubleEndedIterator for DriverIterator {
@@ -2036,6 +2048,18 @@ impl DoubleEndedIterator for DriverIterator {
 
             Some(get_video_driver(self.length))
         }
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<&'static str> {
+        use std::convert::TryInto;
+
+        self.length = match n.try_into().ok().and_then(|n| self.length.checked_sub(n)) {
+            Some(length) if length > self.index => length,
+            _ => self.index,
+        };
+
+        self.next_back()
     }
 }
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -2019,6 +2019,8 @@ impl Iterator for DriverIterator {
 
 impl ExactSizeIterator for DriverIterator {}
 
+impl std::iter::FusedIterator for DriverIterator {}
+
 /// Gets an iterator of all video drivers compiled into the SDL2 library.
 #[inline]
 #[doc(alias = "SDL_GetVideoDriver")]


### PR DESCRIPTION
After writing #1332, I figured I'd offer these for good measure.