### PR TITLE
Fix "Cannot initialize Sdl from more than one thread" for tests / CI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1332](https://github.com/Rust-SDL2/rust-sdl2/pull/1332) Fix `size_hint` implementations for `{audio,video,render}::DriverIterator`
 
+[PR #1337](https://github.com/Rust-SDL2/rust-sdl2/pull/1337) Fix "Cannot initialize Sdl from more than one thread" for tests / CI
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -86,7 +86,7 @@ impl Sdl {
         IS_MAIN_THREAD.with(|is_main_thread| {
             if was_main_thread_declared {
                 if !is_main_thread.get() {
-                    return Err("Cannot initialize `Sdl` from more than once thread.".to_owned());
+                    return Err("Cannot initialize `Sdl` from more than one thread.".to_owned());
                 }
             } else {
                 is_main_thread.set(true);
@@ -209,6 +209,7 @@ impl Drop for SdlDrop {
             unsafe {
                 sys::SDL_Quit();
             }
+            IS_MAIN_THREAD_DECLARED.swap(false, Ordering::SeqCst);
         }
     }
 }


### PR DESCRIPTION
Fix #1323

This addresses the issue above, which seems to have been introduced by #1254, which added a flag to indicate which thread was initialized as the main thread. This flag was never cleared which meant that only one thread would ever be the main, if SDL was then quit and attempted to initialize on another thread (while still only having 1 context) it would fail.

If the intention of `IS_MAIN_THREAD` was to only allow `SDL_Init` to be invoked once per application, I can find another solution. But I believe there is nothing wrong with this, `SDL_Init` itself is reference counted, and the tests show an expectation to be able to do so.