### PR TITLE
Fix cmake build failure when using multi-config generators

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -96,8 +96,10 @@ fn compile_sdl2(sdl2_build_path: &Path, target_os: &str) -> PathBuf {
     let mut cfg = cmake::Config::new(sdl2_build_path);
     if let Ok(profile) = env::var("SDL2_BUILD_PROFILE") {
         cfg.profile(&profile);
+        cfg.define("CMAKE_CONFIGURATION_TYPES", &profile);
     } else {
         cfg.profile("Release");
+        cfg.define("CMAKE_CONFIGURATION_TYPES", "Release");
     }
 
     // Allow specifying custom toolchain specifically for SDL2.


### PR DESCRIPTION
While playing around with this library I notices an annoying problem.

When building the library with the `bundled` feature and having the [CMAKE_GENERATOR](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR.html) environment variable set to a so called multi-config generator like [Ninja Multi-Config](https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html) the build for sdl2 fails.

This patch fixes this annoyance by simply also settings the [CMAKE_CONFIGURATION_TYPES](https://cmake.org/cmake/help/latest/variable/CMAKE_CONFIGURATION_TYPES.html) for these builds since the normal [CMAKE_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) variable is ignored when using multi-config generators.

With that we essentially create a single-config build for our multi-config generator which builds without problems.