### PR TITLE
Use `SDL_GetError` for `sdl2::ttf::init` instead of the last OS error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1337](https://github.com/Rust-SDL2/rust-sdl2/pull/1337) Fix "Cannot initialize Sdl from more than one thread" for tests / CI
 
+[PR #1348](https://github.com/Rust-SDL2/rust-sdl2/pull/1348) Use `SDL_GetError` for `sdl2::ttf::init` instead of the last OS error
+
 ### v0.35.2
 
 [PR #1173](https://github.com/Rust-SDL2/rust-sdl2/pull/1173) Fix segfault when using timer callbacks

--- a/src/sdl2/ttf/context.rs
+++ b/src/sdl2/ttf/context.rs
@@ -124,7 +124,10 @@ pub fn init() -> Result<Sdl2TtfContext, InitError> {
         } else if ttf::TTF_Init() == 0 {
             Ok(Sdl2TtfContext)
         } else {
-            Err(InitError::InitializationError(io::Error::last_os_error()))
+            Err(InitError::InitializationError(io::Error::new(
+                io::ErrorKind::Other,
+                get_error(),
+            )))
         }
     }
 }


### PR DESCRIPTION
Previously, the code use the last OS error. However, not all errors returned by `TTF_Init` are OS errors, and the expected behaviour is that the caller instead use `SDL_GetError` when an error is encountered.

To limit breakage for existing callers the error is still returned as an `io::Error`, albeit one with `io::ErrorKind::Other`. It is worth noting that this does lead to an observable difference in behaviour for callers – the error has a different kind – although any code that is inspecting this was already relying on an unreliable source of data.

This fixes issue #1347.