### PR TITLE
chore(link): Fix not build link libraries

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -251,20 +251,23 @@ fn link_sdl2(target_os: &str) {
                 println!("cargo:rustc-link-lib=SDL2");
             }
 
-            if cfg!(feature = "gfx") {
-                println!("cargo:rustc-link-lib=SDL2_gfx");
-            }
+            // bundled not support the other feature
+            if !cfg!(feature = "bundled") {
+                if cfg!(feature = "gfx") {
+                    println!("cargo:rustc-link-lib=SDL2_gfx");
+                }
 
-            if cfg!(feature = "mixer") {
-                println!("cargo:rustc-link-lib=SDL2_mixer");
-            }
+                if cfg!(feature = "mixer") {
+                    println!("cargo:rustc-link-lib=SDL2_mixer");
+                }
 
-            if cfg!(feature = "image") {
-                println!("cargo:rustc-link-lib=SDL2_image");
-            }
+                if cfg!(feature = "image") {
+                    println!("cargo:rustc-link-lib=SDL2_image");
+                }
 
-            if cfg!(feature = "ttf") {
-                println!("cargo:rustc-link-lib=SDL2_ttf");
+                if cfg!(feature = "ttf") {
+                    println!("cargo:rustc-link-lib=SDL2_ttf");
+                }
             }
         }
 


### PR DESCRIPTION
    1. fix the link SDL2-static in the `target_os == "windows-msvc",
       not `target_os.contains("windows"), becuase the windows-gnu
       is same `SDL2`.
    2. when you not select any [vcpkg, pkg-config, bundled] feature,
       and select the any [gfx, mixer, image, ttf] feature, it won't
       link the libraries.