### PR TITLE
Fix raw window handle pub

### DIFF
--- a/src/sdl2/raw_window_handle.rs
+++ b/src/sdl2/raw_window_handle.rs
@@ -1,6 +1,6 @@
 extern crate raw_window_handle;
 
-use self::raw_window_handle::{
+pub use self::raw_window_handle::{
     HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 use crate::{sys::SDL_Window, video::Window};


### PR DESCRIPTION
If an end user wants to use raw handles, the trait must be defined as public to be included in external projects.