### PR TITLE
Fix compile error when building for android in raw_display_handle implementation

### DIFF
--- a/src/sdl2/raw_window_handle.rs
+++ b/src/sdl2/raw_window_handle.rs
@@ -156,7 +156,7 @@ unsafe impl HasRawDisplayHandle for Window {
             SDL_SYSWM_WINDOWS | SDL_SYSWM_WINRT => {
                 use self::raw_window_handle::WindowsDisplayHandle;
 
-                let mut handle = WindowsDisplayHandle::empty();
+                let handle = WindowsDisplayHandle::empty();
 
                 RawDisplayHandle::Windows(handle)
             }
@@ -200,7 +200,7 @@ unsafe impl HasRawDisplayHandle for Window {
             SDL_SYSWM_UIKIT => {
                 use self::raw_window_handle::UiKitDisplayHandle;
 
-                let mut handle = UiKitDisplayHandle::empty();
+                let handle = UiKitDisplayHandle::empty();
 
                 RawDisplayHandle::UiKit(handle)
             }
@@ -208,9 +208,7 @@ unsafe impl HasRawDisplayHandle for Window {
             SDL_SYSWM_ANDROID => {
                 use self::raw_window_handle::AndroidDisplayHandle;
 
-                let mut handle = AndroidDisplayHandle::empty();
-                handle.a_native_window =
-                    unsafe { wm_info.info.android }.window as *mut libc::c_void;
+                let handle = AndroidDisplayHandle::empty();
 
                 RawDisplayHandle::Android(handle)
             }


### PR DESCRIPTION
Hi!

Quick PR for a small bug I hit with the android code for 'raw_display_handle'. `a_native_window` got moved onto `AndroidWindowHandle` with the newer version of `raw-window-handle` and was removed from `AndroidDisplayHandle`. I think a simple copy-paste error left the old code assigning to the now missing field and there's no regular android builds so it got missed.

Fix is trivial, remove the assignment. I also removed 'mut' declarations from other handles that weren't assigned to.