### PR TITLE
Sdl2TtfContext should need lifetime

### DIFF
--- a/examples/resource-manager.rs
+++ b/examples/resource-manager.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), String> {
 }
 
 type TextureManager<'l, T> = ResourceManager<'l, String, Texture<'l>, TextureCreator<T>>;
-type FontManager<'l> = ResourceManager<'l, FontDetails, Font<'l, 'static>, Sdl2TtfContext>;
+type FontManager<'l> = ResourceManager<'l, FontDetails, Font<'l, 'static>, Sdl2TtfContext<'l>>;
 
 // Generic struct to cache any resource loaded by a ResourceLoader
 pub struct ResourceManager<'l, K, R, L>
@@ -134,7 +134,7 @@ impl<'l, T> ResourceLoader<'l, Texture<'l>> for TextureCreator<T> {
 }
 
 // Font Context knows how to load Fonts
-impl<'l> ResourceLoader<'l, Font<'l, 'static>> for Sdl2TtfContext {
+impl<'l> ResourceLoader<'l, Font<'l, 'static>> for Sdl2TtfContext<'l> {
     type Args = FontDetails;
     fn load(&'l self, details: &FontDetails) -> Result<Font<'l, 'static>, String> {
         println!("LOADED A FONT");

--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -36,7 +36,7 @@ fn init_submodule(sdl_path: &Path) {
     if !sdl_path.join("CMakeLists.txt").exists() {
         Command::new("git")
             .args(&["submodule", "update", "--init"])
-            .current_dir(sdl_path.clone())
+            .current_dir(sdl_path)
             .status()
             .expect("Git is needed to retrieve the SDL source files");
     }

--- a/src/sdl2/ttf/context.rs
+++ b/src/sdl2/ttf/context.rs
@@ -95,14 +95,7 @@ pub enum InitError {
     AlreadyInitializedError,
 }
 
-impl error::Error for InitError {
-    fn description(&self) -> &str {
-        match *self {
-            InitError::AlreadyInitializedError => "SDL2_TTF has already been initialized",
-            InitError::InitializationError(ref error) => error.description(),
-        }
-    }
-
+impl error::Error for InitError {   
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             InitError::AlreadyInitializedError => None,

--- a/src/sdl2/ttf/context.rs
+++ b/src/sdl2/ttf/context.rs
@@ -95,7 +95,7 @@ pub enum InitError {
     AlreadyInitializedError,
 }
 
-impl error::Error for InitError {   
+impl error::Error for InitError {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             InitError::AlreadyInitializedError => None,
@@ -117,7 +117,9 @@ pub fn init<'ttf_module>() -> Result<Sdl2TtfContext<'ttf_module>, InitError> {
         if ttf::TTF_WasInit() == 1 {
             Err(InitError::AlreadyInitializedError)
         } else if ttf::TTF_Init() == 0 {
-            Ok(Sdl2TtfContext { _phantom: std::marker::PhantomData })
+            Ok(Sdl2TtfContext {
+                _phantom: std::marker::PhantomData,
+            })
         } else {
             Err(InitError::InitializationError(io::Error::last_os_error()))
         }

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -2,7 +2,6 @@ use get_error;
 use pixels::Color;
 use rwops::RWops;
 use std::error;
-use std::error::Error;
 use std::ffi::NulError;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -58,13 +57,6 @@ pub enum FontError {
 }
 
 impl error::Error for FontError {
-    fn description(&self) -> &str {
-        match *self {
-            FontError::InvalidLatin1Text(ref error) => error.description(),
-            FontError::SdlError(ref message) => message,
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             FontError::InvalidLatin1Text(ref error) => Some(error),
@@ -77,7 +69,7 @@ impl fmt::Display for FontError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
             FontError::InvalidLatin1Text(ref err) => {
-                write!(f, "Invalid Latin-1 bytes: {}", err.description())
+                write!(f, "Invalid Latin-1 bytes: {}", err)
             }
             FontError::SdlError(ref msg) => {
                 write!(f, "SDL2 error: {}", msg)


### PR DESCRIPTION
```rust

pub struct FontManager<'ttf_module> {
    ttf_ctx: sdl2::ttf::Sdl2TtfContext,
    fonts: HashMap<String, sdl2::ttf::Font<'ttf_module, 'static>>,
}

impl<'ttf_module> FontManager<'ttf_module> {
    pub fn new() -> Result<Self, Error> {
        let ttf_ctx = sdl2::ttf::init()?;

        Ok(Self {
            ttf_ctx,
            fonts: HashMap::new(),
        })
    }

    pub fn load_font<P: AsRef<std::path::Path>>(
        &mut self,
        path: P,
        name: &str,
        point_size: u16,
    ) -> Result<&mut sdl2::ttf::Font<'ttf_module, 'static>, Error> {
        let font = self.ttf_ctx.load_font(path, point_size);
        // lifetime error
        self.fonts.insert(name.to_string(), font?);
        Ok(self.fonts.get_mut(name).unwrap())
    }
}
```