### PR TITLE
Animation example fix

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -41,18 +41,18 @@ fn main() -> Result<(), String> {
     let sprite_tile_size = (32, 32);
 
     // Baby - walk animation
-    let mut source_rect_0 = Rect::new(0, 0, sprite_tile_size.0, sprite_tile_size.0);
-    let mut dest_rect_0 = Rect::new(0, 0, sprite_tile_size.0 * 4, sprite_tile_size.0 * 4);
+    let mut source_rect_0 = Rect::new(0, 0, sprite_tile_size.0, sprite_tile_size.1);
+    let mut dest_rect_0 = Rect::new(0, 0, sprite_tile_size.0 * 4, sprite_tile_size.1 * 4);
     dest_rect_0.center_on(Point::new(-64, 120));
 
     // King - walk animation
-    let mut source_rect_1 = Rect::new(0, 32, sprite_tile_size.0, sprite_tile_size.0);
-    let mut dest_rect_1 = Rect::new(0, 32, sprite_tile_size.0 * 4, sprite_tile_size.0 * 4);
+    let mut source_rect_1 = Rect::new(0, 32, sprite_tile_size.0, sprite_tile_size.1);
+    let mut dest_rect_1 = Rect::new(0, 32, sprite_tile_size.0 * 4, sprite_tile_size.1 * 4);
     dest_rect_1.center_on(Point::new(0, 240));
 
     // Soldier - walk animation
-    let mut source_rect_2 = Rect::new(0, 64, sprite_tile_size.0, sprite_tile_size.0);
-    let mut dest_rect_2 = Rect::new(0, 64, sprite_tile_size.0 * 4, sprite_tile_size.0 * 4);
+    let mut source_rect_2 = Rect::new(0, 64, sprite_tile_size.0, sprite_tile_size.1);
+    let mut dest_rect_2 = Rect::new(0, 64, sprite_tile_size.0 * 4, sprite_tile_size.1 * 4);
     dest_rect_2.center_on(Point::new(440, 360));
 
     let mut running = true;


### PR DESCRIPTION
This PR uses the correct y variable for source and destination rects in the animation example.
Maybe helps new users like myself.