### PR TITLE
Bump minimum cmake dependency to 0.1.47

### DIFF
--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -32,7 +32,7 @@ version = "^0.2.12"
 optional = true
 
 [build-dependencies.cmake]
-version = "^0.1"
+version = "^0.1.4"
 optional = true
 
 [build-dependencies.flate2]

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -32,7 +32,7 @@ version = "^0.2.12"
 optional = true
 
 [build-dependencies.cmake]
-version = "^0.1.4"
+version = "^0.1.47"
 optional = true
 
 [build-dependencies.flate2]


### PR DESCRIPTION
The `profile()` function used in `build.rs` was added to the `cmake` crate starting with version 0.1.4. Because of this, building projects that depend on SDL2 with `-Zminimal-versions` fails. I bumped it to 0.1.47 because this allows it to build with VS 2022 using `-Zminimal-versions`.