### PR TITLE
Upgrade to raw-window-handle 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ optional = true
 
 [dev-dependencies]
 rand = "0.7"
-wgpu = { version = "0.15", features = ["spirv"] }
+wgpu = { version = "0.19", features = ["spirv"] }
 pollster = "0.2.4"
 env_logger = "0.9.0"
 
 [dependencies.raw-window-handle]
-version = "0.5.0"
+version = "0.6.0"
 optional = true
 
 [features]

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -27,9 +27,10 @@ fn main() -> Result<(), String> {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::PRIMARY,
         dx12_shader_compiler: Default::default(),
+        ..Default::default()
     });
     let surface = unsafe {
-        match instance.create_surface(&window) {
+        match instance.create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(&window).unwrap()) {
             Ok(s) => s,
             Err(e) => return Err(e.to_string()),
         }
@@ -46,9 +47,9 @@ fn main() -> Result<(), String> {
 
     let (device, queue) = match pollster::block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
-            limits: wgpu::Limits::default(),
+            required_limits: wgpu::Limits::default(),
             label: Some("device"),
-            features: wgpu::Features::empty(),
+            required_features: wgpu::Features::empty(),
         },
         None,
     )) {
@@ -117,7 +118,7 @@ fn main() -> Result<(), String> {
         .formats
         .iter()
         .copied()
-        .find(|f| f.describe().srgb)
+        .find(|f| f.is_srgb())
         .unwrap_or(surface_caps.formats[0]);
 
     let mut config = wgpu::SurfaceConfiguration {
@@ -128,6 +129,7 @@ fn main() -> Result<(), String> {
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: wgpu::CompositeAlphaMode::Auto,
         view_formats: Vec::default(),
+        desired_maximum_frame_latency: 2,
     };
     surface.configure(&device, &config);
 
@@ -166,7 +168,8 @@ fn main() -> Result<(), String> {
                     SurfaceError::Lost => "Lost",
                     SurfaceError::OutOfMemory => "OutOfMemory",
                 };
-                panic!("Failed to get current surface texture! Reason: {}", reason)
+                println!("Failed to get current surface texture! Reason: {}", reason);
+                continue 'running;
             }
         };
 
@@ -184,11 +187,13 @@ fn main() -> Result<(), String> {
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: None,
                 label: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
             rpass.set_pipeline(&render_pipeline);
             rpass.set_bind_group(0, &bind_group, &[]);

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -4,7 +4,7 @@ mod raw_window_handle_test {
     extern crate sdl2;
 
     use self::raw_window_handle::{
-        HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+        HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
     };
     use self::sdl2::video::Window;
 
@@ -12,24 +12,38 @@ mod raw_window_handle_test {
     #[test]
     fn get_windows_handle() {
         let window = new_hidden_window();
-        match window.raw_window_handle() {
-            RawWindowHandle::Win32(windows_handle) => {
-                assert_ne!(windows_handle.hwnd, 0 as *mut libc::c_void);
-                println!("Successfully received Windows RawWindowHandle!");
+        match window.window_handle() {
+            Ok(window_handle) => {
+                match window_handle.as_raw()  {
+                    RawWindowHandle::Win32(_) => {
+                        println!("Successfully received Win32 window handle")
+                    },
+                    RawWindowHandle::WinRt(_) => {
+                        println!("Successfully received WinRt window handle")
+                    }
+                    raw_handle => {
+                        assert!(false, "Wrong window handle type for Windows: {:?}", raw_handle)
+                    }
+                }
+            },
+            Err(e) => {
+                assert!(false, "Failed to recieve window handle on Windows: {:?}", e)
             }
-            x => assert!(
-                false,
-                "Received wrong RawWindowHandle type for Windows: {:?}",
-                x
-            ),
         }
-        match window.raw_display_handle() {
-            RawDisplayHandle::Windows(_) => {}
-            x => assert!(
-                false,
-                "Received wrong RawDisplayHandle type for Windows: {:?}",
-                x
-            ),
+        match window.display_handle() {
+            Ok(display_handle) => {
+                match display_handle.as_raw() {
+                    RawDisplayHandle::Windows(_) => {
+                        println!("Successfully received Windows display handle")
+                    },
+                    raw_handle => {
+                        assert!(false, "Wrong display handle type for Windows: {:?}", raw_handle)
+                    }
+                }
+            },
+            Err(e) => {
+                assert!(false, "Failed to recieve display handle on Windows: {:?}", e)
+            }
         }
     }
 
@@ -43,42 +57,41 @@ mod raw_window_handle_test {
     #[test]
     fn get_linux_handle() {
         let window = new_hidden_window();
-        match window.raw_window_handle() {
-            RawWindowHandle::Xlib(x11_handle) => {
-                assert_ne!(x11_handle.window, 0, "Window for X11 should not be 0");
-                println!("Successfully received linux X11 RawWindowHandle!");
+        match window.window_handle() {
+            Ok(handle) => {
+                match handle.as_raw() {
+                    RawWindowHandle::Xlib(_) => {
+                        println!("Successfully received X11 window handle")
+                    }
+                    RawWindowHandle::Wayland(_) => {
+                        println!("Successfully received Wayland window handle")
+                    }
+                    raw_handle => {
+                        assert!(false, "Wrong window handle type for Linux: {:?}", raw_handle)
+                    }
+                }
+            },
+            Err(e) => {
+                assert!(false, "Failed to recieve window handle on Linux: {:?}", e)
             }
-            RawWindowHandle::Wayland(wayland_handle) => {
-                assert_ne!(
-                    wayland_handle.surface, 0 as *mut libc::c_void,
-                    "Surface for Wayland should not be null"
-                );
-                println!("Successfully received linux Wayland RawWindowHandle!");
-            }
-            x => assert!(
-                false,
-                "Received wrong RawWindowHandle type for linux: {:?}",
-                x
-            ),
         }
-        match window.raw_display_handle() {
-            RawDisplayHandle::Xlib(x11_display) => {
-                assert_ne!(
-                    x11_display.display, 0 as *mut libc::c_void,
-                    "Display for X11 should not be null"
-                );
+        match window.display_handle() {
+            Ok(handle) => {
+                match handle.as_raw() {
+                    RawDisplayHandle::Xlib(_) => {
+                        println!("Successfully recieved X11 display handle")
+                    }
+                    RawDisplayHandle::Wayland(_) => {
+                        println!("Successfully recieved Wayland display handle")
+                    }
+                    raw_handle => {
+                        assert!(false, "Wrong display handle type for Linux: {:?}", raw_handle)
+                    }
+                }
             }
-            RawDisplayHandle::Wayland(wayland_display) => {
-                assert_ne!(
-                    wayland_display.display, 0 as *mut libc::c_void,
-                    "Display for Wayland should not be null"
-                );
-            }
-            x => assert!(
-                false,
-                "Received wrong RawDisplayHandle type for linux: {:?}",
-                x
-            ),
+            Err(e) => {
+                assert!(false, "Failed to recieve display handle on Linux: {:?}", e)
+            },
         }
     }
 
@@ -86,31 +99,35 @@ mod raw_window_handle_test {
     #[test]
     fn get_macos_handle() {
         let window = new_hidden_window();
-        match window.raw_window_handle() {
-            RawWindowHandle::AppKit(macos_handle) => {
-                assert_ne!(
-                    macos_handle.ns_window, 0 as *mut libc::c_void,
-                    "ns_window should not be null"
-                );
-                assert_ne!(
-                    macos_handle.ns_view, 0 as *mut libc::c_void,
-                    "nw_view should not be null"
-                );
-                println!("Successfully received macOS RawWindowHandle!");
+        match window.window_handle() {
+            Ok(handle) => {
+                match handle.as_raw() {
+                    RawWindowHandle::AppKit(_) => {
+                        println!("Successfully recieved AppKit window handle")
+                    }
+                    raw_handle => {
+                        assert!(false, "Wrong window handle type for macOS: {:?}", raw_handle)
+                    }
+                }
             }
-            x => assert!(
-                false,
-                "Received wrong RawWindowHandle type for macOS: {:?}",
-                x
-            ),
+            Err(e) => {
+                assert!(false, "Failed to recieve window handle on macOS: {:?}", e)
+            }
         };
-        match window.raw_display_handle() {
-            RawDisplayHandle::AppKit(_) => {}
-            x => assert!(
-                false,
-                "Received wrong RawDisplayHandle type for macOS: {:?}",
-                x
-            ),
+        match window.display_handle() {
+            Ok(handle) => {
+                match handle.as_raw(){
+                    RawDisplayHandle::AppKit(_) => {
+                        println!("Successfully recieved AppKit display handle")
+                    }
+                    raw_handle =>  {
+                        assert!(false, "Wrong display handle type for macOS: {:?}", raw_handle)
+                    }
+                }
+            },
+            Err(e) => {
+                assert!(false, "Failed to recieve display handle on macOS: {:?}", e)
+            }
         }
     }
 


### PR DESCRIPTION
I implemented HasWindowHandle and HasDisplayHandle for Window, though its not send/sync due to it containing the underlying pointer to SDL_Window, preventing it from being used with wgpu without unsafe. Still, I updated the raw-window-handle/wgpu example to work with the most current version of both libraries.

Should fix https://github.com/Rust-SDL2/rust-sdl2/issues/1376

I ran cargo check on the code for other platforms, but I don't have access to anything but my linux machine right now. I feel especially iffy about iOS code, as the required field changed from UI_Window to UI_View.

I'm hoping to find a better solution to implement send/sync for Window than just wrapping it in Arc<Mutex<>>, partially because it smells bad, and partially because it looks like it'll take a long time.