### PR TITLE
Fix some undefined behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Unreleased
 
+[PR #1389](https://github.com/Rust-SDL2/rust-sdl2/pull/1389) Fix some undefined behavior.
+
 [PR #1368](https://github.com/Rust-SDL2/rust-sdl2/pull/1368) Remove unnecessary unsafe in Window interface. Make Window `Clone`.
 
 [PR #1366](https://github.com/Rust-SDL2/rust-sdl2/pull/1366) Add Primary Selection bindings.

--- a/sdl2-sys/examples/no_std.rs
+++ b/sdl2-sys/examples/no_std.rs
@@ -11,7 +11,9 @@ fn main() {
             panic!("failed to initialize sdl2 with video");
         };
         _window = SDL_CreateWindow(
-            b"hello_sdl2" as *const _ as *const i8,
+            // If you use Rust 1.77 or newer, you can also use a C string literal
+            // c"hello_sdl2".as_ptr(),
+            b"hello_sdl2\0".as_ptr() as *const i8,
             SDL_WINDOWPOS_UNDEFINED_MASK as i32,
             SDL_WINDOWPOS_UNDEFINED_MASK as i32,
             640,

--- a/sdl2-sys/sdl_bindings.rs
+++ b/sdl2-sys/sdl_bindings.rs
@@ -24387,7 +24387,7 @@ extern "C" {
         dstrect: *const SDL_Rect,
         angle: f64,
         center: *const SDL_Point,
-        flip: SDL_RendererFlip,
+        flip: u32,
     ) -> libc::c_int;
 }
 extern "C" {

--- a/sdl2-sys/sdl_bindings.rs
+++ b/sdl2-sys/sdl_bindings.rs
@@ -24387,7 +24387,7 @@ extern "C" {
         dstrect: *const SDL_Rect,
         angle: f64,
         center: *const SDL_Point,
-        flip: u32,
+        flip: SDL_RendererFlip,
     ) -> libc::c_int;
 }
 extern "C" {

--- a/src/sdl2/log.rs
+++ b/src/sdl2/log.rs
@@ -101,6 +101,6 @@ pub fn log(message: &str) {
     let message = message.replace('%', "%%");
     let message = CString::new(message).unwrap();
     unsafe {
-        crate::sys::SDL_Log(message.into_raw());
+        crate::sys::SDL_Log(message.as_ptr());
     }
 }

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -47,14 +47,9 @@ impl Palette {
         // Already validated, so don't check again
         let ncolors = colors.len() as ::libc::c_int;
 
-        let result = unsafe {
-            let mut raw_colors: Vec<sys::SDL_Color> =
-                colors.iter().map(|color| color.raw()).collect();
+        let colors = colors.iter().map(|color| color.raw()).collect::<Vec<_>>();
 
-            let pal_ptr = (&mut raw_colors[0]) as *mut sys::SDL_Color;
-
-            sys::SDL_SetPaletteColors(pal.raw, pal_ptr, 0, ncolors)
-        };
+        let result = unsafe { sys::SDL_SetPaletteColors(pal.raw, colors.as_ptr(), 0, ncolors) };
 
         if result < 0 {
             Err(get_error())

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -485,7 +485,7 @@ impl Rect {
     }
 
     pub fn raw_mut(&mut self) -> *mut sys::SDL_Rect {
-        self.raw() as *mut _
+        &mut self.raw
     }
 
     #[doc(alias = "SDL_Rect")]

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -67,6 +67,8 @@ fn clamped_mul(a: i32, b: i32) -> i32 {
 /// recommended to use `Option<Rect>`, with `None` representing an empty
 /// rectangle (see, for example, the output of the
 /// [`intersection`](#method.intersection) method).
+// Uses repr(transparent) to allow pointer casting between Rect and SDL_Rect (see
+// `Rect::raw_slice`)
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct Rect {
@@ -729,6 +731,8 @@ impl BitOr<Rect> for Rect {
 }
 
 /// Immutable point type, consisting of x and y.
+// Uses repr(transparent) to allow pointer casting between Point and SDL_Point (see
+// `Point::raw_slice`)
 #[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct Point {

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -67,6 +67,7 @@ fn clamped_mul(a: i32, b: i32) -> i32 {
 /// recommended to use `Option<Rect>`, with `None` representing an empty
 /// rectangle (see, for example, the output of the
 /// [`intersection`](#method.intersection) method).
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct Rect {
     raw: sys::SDL_Rect,
@@ -728,6 +729,7 @@ impl BitOr<Rect> for Rect {
 }
 
 /// Immutable point type, consisting of x and y.
+#[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct Point {
     raw: sys::SDL_Point,

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -1396,6 +1396,22 @@ impl<T: RenderTarget> Canvas<T> {
         R2: Into<Option<Rect>>,
         P: Into<Option<Point>>,
     {
+        // This function doesn't use sys::SDL_RenderCopyEx because its signature does not allow
+        // SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL for parameter 'flip'. Here, a u32 is used
+        // instead of SDL_RendererFlip, which does allow that value.
+
+        extern "C" {
+            fn SDL_RenderCopyEx(
+                renderer: *mut sys::SDL_Renderer,
+                texture: *mut sys::SDL_Texture,
+                srcrect: *const sys::SDL_Rect,
+                dstrect: *const sys::SDL_Rect,
+                angle: f64,
+                center: *const sys::SDL_Point,
+                flip: u32,
+            ) -> libc::c_int;
+        }
+
         use crate::sys::SDL_RendererFlip::*;
         let mut flip = 0;
         if flip_horizontal {
@@ -1406,7 +1422,7 @@ impl<T: RenderTarget> Canvas<T> {
         }
 
         let ret = unsafe {
-            sys::SDL_RenderCopyEx(
+            SDL_RenderCopyEx(
                 self.context.raw,
                 texture.raw,
                 match src.into() {

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -1397,17 +1397,13 @@ impl<T: RenderTarget> Canvas<T> {
         P: Into<Option<Point>>,
     {
         use crate::sys::SDL_RendererFlip::*;
-        let flip = unsafe {
-            match (flip_horizontal, flip_vertical) {
-                (false, false) => SDL_FLIP_NONE,
-                (true, false) => SDL_FLIP_HORIZONTAL,
-                (false, true) => SDL_FLIP_VERTICAL,
-                (true, true) => transmute::<u32, sys::SDL_RendererFlip>(
-                    transmute::<sys::SDL_RendererFlip, u32>(SDL_FLIP_HORIZONTAL)
-                        | transmute::<sys::SDL_RendererFlip, u32>(SDL_FLIP_VERTICAL),
-                ),
-            }
-        };
+        let mut flip = 0;
+        if flip_horizontal {
+            flip |= SDL_FLIP_HORIZONTAL as u32;
+        }
+        if flip_vertical {
+            flip |= SDL_FLIP_VERTICAL as u32;
+        }
 
         let ret = unsafe {
             sys::SDL_RenderCopyEx(

--- a/src/sdl2/rwops.rs
+++ b/src/sdl2/rwops.rs
@@ -4,7 +4,6 @@ use libc::{c_char, c_int, size_t};
 use std::ffi::CString;
 use std::io;
 use std::marker::PhantomData;
-use std::mem::transmute;
 use std::path::Path;
 
 use crate::sys;
@@ -179,7 +178,7 @@ impl<'a> io::Seek for RWops<'a> {
             io::SeekFrom::End(pos) => (sys::RW_SEEK_END, pos),
             io::SeekFrom::Current(pos) => (sys::RW_SEEK_CUR, pos),
         };
-        let ret = unsafe { ((*self.raw).seek.unwrap())(self.raw, offset, transmute(whence)) };
+        let ret = unsafe { ((*self.raw).seek.unwrap())(self.raw, offset, whence as i32) };
         if ret == -1 {
             Err(io::Error::last_os_error())
         } else {

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -510,20 +510,21 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
 
     /// Returns the glyph metrics of the given character in this font face.
     pub fn find_glyph_metrics(&self, ch: char) -> Option<GlyphMetrics> {
-        let minx = 0;
-        let maxx = 0;
-        let miny = 0;
-        let maxy = 0;
-        let advance = 0;
+        let mut minx = 0;
+        let mut maxx = 0;
+        let mut miny = 0;
+        let mut maxy = 0;
+        let mut advance = 0;
+
         let ret = unsafe {
             ttf::TTF_GlyphMetrics(
                 self.raw,
                 ch as u16,
-                &minx as *const _ as *mut _,
-                &maxx as *const _ as *mut _,
-                &miny as *const _ as *mut _,
-                &maxy as *const _ as *mut _,
-                &advance as *const _ as *mut _,
+                &mut minx,
+                &mut maxx,
+                &mut miny,
+                &mut maxy,
+                &mut advance,
             )
         };
         if ret == 0 {

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -361,18 +361,12 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
 
     /// Returns the width and height of the given text when rendered using this
     /// font.
-    #[allow(unused_mut)]
     pub fn size_of_latin1(&self, text: &[u8]) -> FontResult<(u32, u32)> {
         let c_string = RenderableText::Latin1(text).convert()?;
         let (res, size) = unsafe {
-            let mut w: i32 = 0; // mutated by C code
-            let mut h: i32 = 0; // mutated by C code
-            let ret = ttf::TTF_SizeText(
-                self.raw,
-                c_string.as_ptr(),
-                &w as *const _ as *mut i32,
-                &h as *const _ as *mut i32,
-            );
+            let mut w: i32 = 0;
+            let mut h: i32 = 0;
+            let ret = ttf::TTF_SizeText(self.raw, c_string.as_ptr(), &mut w, &mut h);
             (ret, (w as u32, h as u32))
         };
         if res == 0 {


### PR DESCRIPTION
review note: read_pixels had some indentation changed, word diff looks better to see what changed there

fix some undefined behavior (not all changes are)
f374447d103898542afcc789e0f00d0667759ae2 removes an unnecessary call to an unsafe function and 2accf9909cc3342176084897d4819ef5b08d43b6 fixes a memory leak

