### PR TITLE
fix documentation on EventPump

### DIFF
--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -329,7 +329,7 @@ subsystem!(SensorSubsystem, sys::SDL_INIT_SENSOR, SENSOR_COUNT, sync);
 
 static IS_EVENT_PUMP_ALIVE: AtomicBool = AtomicBool::new(false);
 
-/// A thread-safe type that encapsulates SDL event-pumping functions.
+/// A type that encapsulates SDL event-pumping functions.
 pub struct EventPump {
     _event_subsystem: EventSubsystem,
 }


### PR DESCRIPTION
EventPump is thread-safe in the sense that it ensures it's only created on the main SDL thread to enforce invariants required by SDL, but it's not thread-safe is the usual meaning of "can be safely accessed from multiple threads".

Fixes #835.