### PR TITLE
Fix static linking

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -244,29 +244,29 @@ fn link_sdl2(target_os: &str) {
         if cfg!(feature = "bundled")
             || (cfg!(feature = "use-pkgconfig") == false && cfg!(feature = "use-vcpkg") == false)
         {
-            println!("cargo:rustc-link-lib=SDL2main");
+            println!("cargo:rustc-link-lib=static=SDL2main");
             if target_os == "windows-msvc" {
-                println!("cargo:rustc-link-lib=SDL2-static");
+                println!("cargo:rustc-link-lib=static=SDL2-static");
             } else {
-                println!("cargo:rustc-link-lib=SDL2");
+                println!("cargo:rustc-link-lib=static=SDL2");
             }
 
-            // bundled not support the other feature
+            // Additional SDL libraries are not supported when using "bundled"
             if !cfg!(feature = "bundled") {
                 if cfg!(feature = "gfx") {
-                    println!("cargo:rustc-link-lib=SDL2_gfx");
+                    println!("cargo:rustc-link-lib=static=SDL2_gfx");
                 }
 
                 if cfg!(feature = "mixer") {
-                    println!("cargo:rustc-link-lib=SDL2_mixer");
+                    println!("cargo:rustc-link-lib=static=SDL2_mixer");
                 }
 
                 if cfg!(feature = "image") {
-                    println!("cargo:rustc-link-lib=SDL2_image");
+                    println!("cargo:rustc-link-lib=static=SDL2_image");
                 }
 
                 if cfg!(feature = "ttf") {
-                    println!("cargo:rustc-link-lib=SDL2_ttf");
+                    println!("cargo:rustc-link-lib=static=SDL2_ttf");
                 }
             }
         }


### PR DESCRIPTION
Re-enables static linking when `static-link` is enabled on its own, without any other packaging features, like `use-pkgconfig`. This fixes a regression introduced in https://github.com/Rust-SDL2/rust-sdl2/pull/1352.