### PR TITLE
make SdlDrop zero sized and use more conventional field name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Unreleased
 
+[PR #1404](https://github.com/Rust-SDL2/rust-sdl2/pull/1404) Make `SdlDrop` a zero sized type.
+
 [PR #1368](https://github.com/Rust-SDL2/rust-sdl2/pull/1368) Remove unnecessary unsafe in Window interface. Make Window `Clone`.
 
 [PR #1366](https://github.com/Rust-SDL2/rust-sdl2/pull/1366) Add Primary Selection bindings.


### PR DESCRIPTION
The field `_anticonstructor` is always initialized with the same value (null pointer), so may be zero sized as well.

SdlDrop will remain !Send and !Sync with a pointer inside PhantomData.