### PR TITLE
Added macos check to SDL_Metal_DestroyView call

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -555,6 +555,7 @@ impl Drop for WindowContext {
     #[doc(alias = "SDL_DestroyWindow")]
     fn drop(&mut self) {
         unsafe {
+            #[cfg(target_os = "macos")]
             if !self.metal_view.is_null() {
                 sys::SDL_Metal_DestroyView(self.metal_view);
             }


### PR DESCRIPTION
Added a cfg check to `SDL_Metal_DestroyView` so that it works similar to `SDL_Metal_CreateView`. Without this change, tools like `perf` complain about not finding the function:

`symbol lookup error: /home/somewhat/personal/info: undefined symbol: SDL_Metal_DestroyView`

This change has only been tested on linux

Also should I add this to the changelog or does this count as internal?