### PR TITLE
Made the library no_std by default. Std will become a feature later.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ path = "src/sdl2/lib.rs"
 
 [dependencies]
 bitflags = "1.2.1"
-libc = "0.2.92"
+libc = { version = "0.2.92", default-features = false }
 lazy_static = "1.4.0"
+spin = "0.9.8"
+hashbrown = "0.14.5"
 
 [dependencies.sdl2-sys]
 path = "sdl2-sys"

--- a/src/sdl2/clipboard.rs
+++ b/src/sdl2/clipboard.rs
@@ -1,7 +1,10 @@
+use alloc::borrow::ToOwned;
 use crate::get_error;
 use libc::c_char;
 use libc::c_void;
-use std::ffi::{CStr, CString};
+use core::ffi::CStr;
+use alloc::ffi::CString;
+use alloc::string::String;
 
 use crate::sys;
 

--- a/src/sdl2/common.rs
+++ b/src/sdl2/common.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
-use std::fmt;
+use core::fmt;
+use alloc::string::String;
 
 /// A given integer was so big that its representation as a C integer would be
 /// negative.
@@ -35,5 +35,3 @@ impl fmt::Display for IntegerOrSdlError {
         }
     }
 }
-
-impl Error for IntegerOrSdlError {}

--- a/src/sdl2/controller.rs
+++ b/src/sdl2/controller.rs
@@ -1,21 +1,20 @@
+use alloc::borrow::ToOwned;
 use crate::rwops::RWops;
 use libc::c_char;
-use std::error;
-use std::ffi::{CStr, CString, NulError};
-use std::fmt;
-use std::io;
-use std::path::Path;
+use core::ffi::CStr;
+use alloc::ffi::{CString, NulError};
+use alloc::string::String;
 
 #[cfg(feature = "hidapi")]
 use crate::sensor::SensorType;
 #[cfg(feature = "hidapi")]
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use crate::common::{validate_int, IntegerOrSdlError};
 use crate::get_error;
 use crate::joystick;
 use crate::GameControllerSubsystem;
-use std::mem::transmute;
+use core::mem::transmute;
 
 use crate::sys;
 
@@ -27,8 +26,8 @@ pub enum AddMappingError {
     SdlError(String),
 }
 
-impl fmt::Display for AddMappingError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl core::fmt::Display for AddMappingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use self::AddMappingError::*;
 
         match *self {
@@ -36,15 +35,6 @@ impl fmt::Display for AddMappingError {
             InvalidFilePath(ref value) => write!(f, "Invalid file path ({})", value),
             ReadError(ref e) => write!(f, "Read error: {}", e),
             SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl error::Error for AddMappingError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidMapping(err) => Some(err),
-            Self::InvalidFilePath(_) | Self::ReadError(_) | Self::SdlError(_) => None,
         }
     }
 }
@@ -145,22 +135,10 @@ impl GameControllerSubsystem {
     }
 
     /// Load controller input mappings from a file.
-    pub fn load_mappings<P: AsRef<Path>>(&self, path: P) -> Result<i32, AddMappingError> {
+    pub fn load_mappings(&self, path: &str) -> Result<i32, AddMappingError> {
         use self::AddMappingError::*;
 
         let rw = RWops::from_file(path, "r").map_err(InvalidFilePath)?;
-        self.load_mappings_from_rw(rw)
-    }
-
-    /// Load controller input mappings from a [`Read`](std::io::Read) object.
-    pub fn load_mappings_from_read<R: io::Read>(
-        &self,
-        read: &mut R,
-    ) -> Result<i32, AddMappingError> {
-        use self::AddMappingError::*;
-
-        let mut buffer = Vec::with_capacity(1024);
-        let rw = RWops::from_read(read, &mut buffer).map_err(ReadError)?;
         self.load_mappings_from_rw(rw)
     }
 

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,9 +1,11 @@
+use alloc::borrow::ToOwned;
 use crate::get_error;
 use libc::c_char;
 use libc::c_void;
-use std::error;
-use std::ffi::{CStr, CString, NulError};
-use std::fmt;
+use core::ffi::CStr;
+use alloc::ffi::{CString, NulError};
+use alloc::string::String;
+use core::fmt;
 
 use crate::sys;
 
@@ -38,16 +40,6 @@ impl fmt::Display for PrefPathError {
             InvalidOrganizationName(ref e) => write!(f, "Invalid organization name: {}", e),
             InvalidApplicationName(ref e) => write!(f, "Invalid application name: {}", e),
             SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl error::Error for PrefPathError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidOrganizationName(err) => Some(err),
-            Self::InvalidApplicationName(err) => Some(err),
-            Self::SdlError(_) => None,
         }
     }
 }

--- a/src/sdl2/hint.rs
+++ b/src/sdl2/hint.rs
@@ -1,6 +1,9 @@
+use alloc::borrow::ToOwned;
 use crate::sys;
 use libc::c_char;
-use std::ffi::{CStr, CString};
+use core::ffi::CStr;
+use alloc::ffi::CString;
+use alloc::string::String;
 
 const VIDEO_MINIMIZE_ON_FOCUS_LOSS: &str = "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS";
 
@@ -88,7 +91,7 @@ pub fn set(name: &str, value: &str) -> bool {
 
 #[doc(alias = "SDL_GetHint")]
 pub fn get(name: &str) -> Option<String> {
-    use std::str;
+    use core::str;
 
     let name = CString::new(name).unwrap();
 

--- a/src/sdl2/joystick.rs
+++ b/src/sdl2/joystick.rs
@@ -5,9 +5,11 @@ use crate::clear_error;
 use crate::common::{validate_int, IntegerOrSdlError};
 use crate::get_error;
 use crate::JoystickSubsystem;
+use alloc::ffi::{CString, NulError};
+use alloc::string::{String, ToString};
+use core::ffi::CStr;
+use core::fmt::{Display, Error, Formatter};
 use libc::c_char;
-use std::ffi::{CStr, CString, NulError};
-use std::fmt::{Display, Error, Formatter};
 
 impl JoystickSubsystem {
     /// Retrieve the total number of attached joysticks *and* controllers identified by SDL.

--- a/src/sdl2/keyboard/keycode.rs
+++ b/src/sdl2/keyboard/keycode.rs
@@ -1,8 +1,14 @@
 #![allow(unreachable_patterns)]
 
+use alloc::borrow::ToOwned;
+use alloc::string::String;
 use libc::c_char;
-use std::ffi::{CStr, CString};
-use std::mem::transmute;
+
+use core::mem::transmute;
+use core::ffi::CStr;
+use core::fmt;
+use core::ops::Deref;
+use alloc::ffi::CString;
 
 use crate::sys;
 
@@ -451,15 +457,12 @@ impl Keycode {
     }
 }
 
-use std::fmt;
-
 impl fmt::Display for Keycode {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}", self.name())
     }
 }
 
-use std::ops::Deref;
 
 impl Deref for Keycode {
     type Target = i32;

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -5,9 +5,9 @@ use crate::rect::Rect;
 use crate::video::Window;
 use crate::EventPump;
 
-use std::fmt;
-use std::iter::FilterMap;
-use std::mem::transmute;
+use core::fmt;
+use core::iter::FilterMap;
+use core::mem::transmute;
 
 use crate::sys;
 
@@ -51,7 +51,7 @@ impl<'a> KeyboardState<'a> {
             let mut count = 0;
             let state_ptr = sys::SDL_GetKeyboardState(&mut count);
 
-            ::std::slice::from_raw_parts(state_ptr, count as usize)
+            ::core::slice::from_raw_parts(state_ptr, count as usize)
         };
 
         KeyboardState { keyboard_state }

--- a/src/sdl2/keyboard/scancode.rs
+++ b/src/sdl2/keyboard/scancode.rs
@@ -1,8 +1,9 @@
 #![allow(unreachable_patterns)]
 
 use libc::c_char;
-use std::ffi::{CStr, CString};
-use std::mem::transmute;
+use core::ffi::CStr;
+use core::mem::transmute;
+use alloc::ffi::CString;
 
 use crate::sys;
 use crate::sys::SDL_Scancode;
@@ -505,7 +506,7 @@ impl Scancode {
     }
 }
 
-use std::fmt;
+use core::fmt;
 
 impl fmt::Display for Scancode {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -547,7 +548,7 @@ impl Scancode {
         // Knowing this, we can always return a string slice.
         unsafe {
             let buf = sys::SDL_GetScancodeName(transmute::<u32, SDL_Scancode>(self as u32));
-            ::std::str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
+            ::core::str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }
 }

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -48,6 +48,15 @@
 #![crate_name = "sdl2"]
 #![crate_type = "lib"]
 
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+extern crate spin;
+
+extern crate hashbrown;
+
 pub extern crate libc;
 
 #[macro_use]

--- a/src/sdl2/log.rs
+++ b/src/sdl2/log.rs
@@ -1,6 +1,7 @@
 use crate::sys;
-use std::ffi::{CStr, CString};
-use std::ptr::null_mut;
+use alloc::ffi::CString;
+use core::ffi::CStr;
+use core::ptr::null_mut;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Category {

--- a/src/sdl2/messagebox.rs
+++ b/src/sdl2/messagebox.rs
@@ -1,11 +1,12 @@
 // 0 should not be used in bitflags, but here it is. Removing it will break existing code.
 #![allow(clippy::bad_bit_mask)]
 
-use std::error;
-use std::ffi::{CString, NulError};
-use std::fmt;
-use std::os::raw::{c_char, c_int};
-use std::ptr;
+use alloc::ffi::{CString, NulError};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use core::ptr;
+use core::ffi::{c_char, c_int};
 
 use crate::get_error;
 use crate::video::Window;
@@ -123,17 +124,6 @@ impl fmt::Display for ShowMessageError {
             InvalidMessage(ref e) => write!(f, "Invalid message: {}", e),
             InvalidButton(ref e, value) => write!(f, "Invalid button ({}): {}", value, e),
             SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl error::Error for ShowMessageError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidTitle(err) => Some(err),
-            Self::InvalidMessage(err) => Some(err),
-            Self::InvalidButton(err, _) => Some(err),
-            Self::SdlError(_) => None,
         }
     }
 }

--- a/src/sdl2/mouse/mod.rs
+++ b/src/sdl2/mouse/mod.rs
@@ -2,11 +2,12 @@ use crate::get_error;
 use crate::surface::SurfaceRef;
 use crate::video;
 use crate::EventPump;
-use std::iter::FilterMap;
-use std::mem::transmute;
+use core::iter::FilterMap;
+use core::mem::transmute;
 
 use crate::sys;
 use crate::sys::SDL_SystemCursor;
+use alloc::string::String;
 
 mod relative;
 pub use self::relative::RelativeMouseState;

--- a/src/sdl2/pixels.rs
+++ b/src/sdl2/pixels.rs
@@ -1,6 +1,10 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::Write;
+
 use crate::sys;
-use std::convert::TryFrom;
-use std::mem::transmute;
+use core::convert::TryFrom;
+use core::mem::transmute;
 
 use crate::get_error;
 
@@ -28,7 +32,12 @@ impl Palette {
 
             match validate_int(capacity as u32, "capacity") {
                 Ok(len) => len,
-                Err(e) => return Err(format!("{}", e)),
+                Err(e) => {
+                    let mut buf = String::new();
+                    write!(&mut buf, "{}", e)
+                        .map_err(|_| String::from("Formatting error."))?;
+                    return Err(buf)
+                }
             }
         };
 
@@ -558,7 +567,7 @@ fn test_pixel_format_enum() {
         //PixelFormatEnum::Index4MSB
     ];
 
-    let _sdl_context = crate::sdl::init().unwrap();
+    let _sdl_context = unsafe { crate::sdl::init().unwrap() };
     for format in pixel_formats {
         // If we don't support making a surface of a specific format,
         // that's fine, just keep going the best we can.

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -1,14 +1,14 @@
 //! Rectangles and points.
 
 use crate::sys;
-use std::convert::{AsMut, AsRef};
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::ops::{
+use core::convert::{AsMut, AsRef};
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::ops::{
     Add, AddAssign, BitAnd, BitOr, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Sub,
     SubAssign,
 };
-use std::ptr;
+use core::ptr;
 
 /// The maximal integer value that can be used for rectangles.
 ///
@@ -83,8 +83,8 @@ pub struct Rect {
     raw: sys::SDL_Rect,
 }
 
-impl ::std::fmt::Debug for Rect {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl ::core::fmt::Debug for Rect {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
         fmt.debug_struct("Rect")
             .field("x", &self.raw.x)
             .field("y", &self.raw.y)
@@ -745,8 +745,8 @@ pub struct Point {
     raw: sys::SDL_Point,
 }
 
-impl ::std::fmt::Debug for Point {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl ::core::fmt::Debug for Point {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
         fmt.debug_struct("Point")
             .field("x", &self.raw.x)
             .field("y", &self.raw.y)
@@ -971,7 +971,7 @@ impl DivAssign<i32> for Point {
     }
 }
 
-impl std::iter::Sum for Point {
+impl core::iter::Sum for Point {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Point::new(0, 0), Point::add)
     }
@@ -989,8 +989,8 @@ pub struct FRect {
     raw: sys::SDL_FRect,
 }
 
-impl ::std::fmt::Debug for FRect {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl ::core::fmt::Debug for FRect {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
         fmt.debug_struct("FRect")
             .field("x", &self.raw.x)
             .field("y", &self.raw.y)
@@ -1605,8 +1605,8 @@ pub struct FPoint {
     raw: sys::SDL_FPoint,
 }
 
-impl ::std::fmt::Debug for FPoint {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl ::core::fmt::Debug for FPoint {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
         fmt.debug_struct("FPoint")
             .field("x", &self.raw.x)
             .field("y", &self.raw.y)
@@ -1802,7 +1802,7 @@ impl DivAssign<f32> for FPoint {
     }
 }
 
-impl std::iter::Sum for FPoint {
+impl core::iter::Sum for FPoint {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(FPoint::new(0.0, 0.0), FPoint::add)
     }

--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -39,19 +39,20 @@ use crate::rect::Rect;
 use crate::surface;
 use crate::surface::{Surface, SurfaceContext, SurfaceRef};
 use crate::video::{Window, WindowContext};
+use alloc::string::String;
+use alloc::vec::Vec;
 use libc::c_void;
 use libc::{c_double, c_int};
-use std::convert::TryFrom;
-use std::error::Error;
-use std::ffi::CStr;
-use std::fmt;
+use core::convert::TryFrom;
+use core::ffi::CStr;
+use core::fmt;
 #[cfg(not(feature = "unsafe_textures"))]
-use std::marker::PhantomData;
-use std::mem;
-use std::mem::{transmute, MaybeUninit};
-use std::ops::Deref;
-use std::ptr;
-use std::rc::Rc;
+use core::marker::PhantomData;
+use core::mem;
+use core::mem::{transmute, MaybeUninit};
+use core::ops::Deref;
+use core::ptr;
+use alloc::rc::Rc;
 
 use crate::sys;
 use crate::sys::SDL_BlendMode;
@@ -74,23 +75,12 @@ impl fmt::Display for SdlError {
     }
 }
 
-impl Error for SdlError {}
-
 impl fmt::Display for TargetRenderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::TargetRenderError::*;
         match *self {
             SdlError(ref e) => e.fmt(f),
             NotSupported => write!(f, "The renderer does not support the use of render targets"),
-        }
-    }
-}
-
-impl Error for TargetRenderError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::SdlError(err) => Some(err),
-            Self::NotSupported => None,
         }
     }
 }
@@ -770,8 +760,6 @@ impl fmt::Display for TextureValueError {
         }
     }
 }
-
-impl Error for TextureValueError {}
 
 #[doc(alias = "SDL_CreateTexture")]
 fn ll_create_texture(
@@ -1985,8 +1973,6 @@ impl fmt::Display for UpdateTextureError {
     }
 }
 
-impl Error for UpdateTextureError {}
-
 #[derive(Debug, Clone)]
 pub enum UpdateTextureYUVError {
     PitchOverflows {
@@ -2044,8 +2030,6 @@ impl fmt::Display for UpdateTextureYUVError {
         }
     }
 }
-
-impl Error for UpdateTextureYUVError {}
 
 struct InternalTexture {
     raw: *mut sys::SDL_Texture,
@@ -2360,7 +2344,7 @@ impl InternalTexture {
                     .format
                     .byte_size_from_pitch_and_height(pitch as usize, height);
                 Ok((
-                    ::std::slice::from_raw_parts_mut(pixels as *mut u8, size),
+                    ::core::slice::from_raw_parts_mut(pixels as *mut u8, size),
                     pitch,
                 ))
             } else {
@@ -2787,7 +2771,7 @@ impl Iterator for DriverIterator {
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<RendererInfo> {
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         self.index = match n.try_into().ok().and_then(|n| self.index.checked_add(n)) {
             Some(index) if index < self.length => index,
@@ -2812,7 +2796,7 @@ impl DoubleEndedIterator for DriverIterator {
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<RendererInfo> {
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         self.length = match n.try_into().ok().and_then(|n| self.length.checked_sub(n)) {
             Some(length) if length > self.index => length,
@@ -2825,7 +2809,7 @@ impl DoubleEndedIterator for DriverIterator {
 
 impl ExactSizeIterator for DriverIterator {}
 
-impl std::iter::FusedIterator for DriverIterator {}
+impl core::iter::FusedIterator for DriverIterator {}
 
 /// Gets an iterator of all render drivers compiled into the SDL2 library.
 #[inline]

--- a/src/sdl2/surface.rs
+++ b/src/sdl2/surface.rs
@@ -1,8 +1,9 @@
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::path::Path;
-use std::rc::Rc;
+use alloc::borrow::ToOwned;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use alloc::rc::Rc;
+use alloc::string::String;
 
 use crate::get_error;
 use crate::pixels;
@@ -11,9 +12,9 @@ use crate::render::{BlendMode, Canvas};
 use crate::render::{Texture, TextureCreator, TextureValueError};
 use crate::rwops::RWops;
 use libc::c_int;
-use std::convert::TryFrom;
-use std::mem::transmute;
-use std::ptr;
+use core::convert::TryFrom;
+use core::mem::transmute;
+use core::ptr;
 
 use crate::sys;
 
@@ -66,7 +67,7 @@ impl AsRef<SurfaceRef> for SurfaceRef {
 #[test]
 fn test_surface_ref_size() {
     // `SurfaceRef` must be 0 bytes.
-    assert_eq!(::std::mem::size_of::<SurfaceRef>(), 0);
+    assert_eq!(::core::mem::size_of::<SurfaceRef>(), 0);
 }
 
 impl<'a> Deref for Surface<'a> {
@@ -295,11 +296,6 @@ impl<'a> Surface<'a> {
         }
     }
 
-    pub fn load_bmp<P: AsRef<Path>>(path: P) -> Result<Surface<'static>, String> {
-        let mut file = RWops::from_file(path, "rb")?;
-        Surface::load_bmp_rw(&mut file)
-    }
-
     /// Creates a Software Canvas to allow rendering in the Surface itself. This `Canvas` will
     /// never be accelerated materially, so there is no performance change between `Surface` and
     /// `Canvas` coming from a `Surface`.
@@ -380,7 +376,7 @@ impl SurfaceRef {
 
             let raw_pixels = self.raw_ref().pixels as *const u8;
             let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
-            let pixels = ::std::slice::from_raw_parts(raw_pixels, len);
+            let pixels = ::core::slice::from_raw_parts(raw_pixels, len);
             let rv = f(pixels);
             sys::SDL_UnlockSurface(self.raw());
             rv
@@ -397,7 +393,7 @@ impl SurfaceRef {
 
             let raw_pixels = self.raw_ref().pixels as *mut u8;
             let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
-            let pixels = ::std::slice::from_raw_parts_mut(raw_pixels, len);
+            let pixels = ::core::slice::from_raw_parts_mut(raw_pixels, len);
             let rv = f(pixels);
             sys::SDL_UnlockSurface(self.raw());
             rv
@@ -414,7 +410,7 @@ impl SurfaceRef {
                 let raw_pixels = self.raw_ref().pixels as *const u8;
                 let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
 
-                Some(::std::slice::from_raw_parts(raw_pixels, len))
+                Some(::core::slice::from_raw_parts(raw_pixels, len))
             }
         }
     }
@@ -429,7 +425,7 @@ impl SurfaceRef {
                 let raw_pixels = self.raw_ref().pixels as *mut u8;
                 let len = self.raw_ref().pitch as usize * (self.raw_ref().h as usize);
 
-                Some(::std::slice::from_raw_parts_mut(raw_pixels, len))
+                Some(::core::slice::from_raw_parts_mut(raw_pixels, len))
             }
         }
     }
@@ -448,11 +444,6 @@ impl SurfaceRef {
         } else {
             Err(get_error())
         }
-    }
-
-    pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
-        let mut file = RWops::from_file(path, "wb")?;
-        self.save_bmp_rw(&mut file)
     }
 
     #[doc(alias = "SDL_SetSurfacePalette")]

--- a/src/sdl2/timer.rs
+++ b/src/sdl2/timer.rs
@@ -1,7 +1,8 @@
 use crate::sys;
+use alloc::boxed::Box;
 use libc::c_void;
-use std::marker::PhantomData;
-use std::mem;
+use core::marker::PhantomData;
+use core::mem;
 
 use crate::TimerSubsystem;
 
@@ -129,96 +130,3 @@ extern "C" fn c_timer_callback(_interval: u32, param: *mut c_void) -> u32 {
     unsafe { (*f)() }
 }
 
-#[cfg(not(target_os = "macos"))]
-#[cfg(test)]
-mod test {
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-
-    #[test]
-    fn test_timer() {
-        test_timer_runs_multiple_times();
-        test_timer_runs_at_least_once();
-        test_timer_can_be_recreated();
-    }
-
-    fn test_timer_runs_multiple_times() {
-        let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
-
-        let local_num = Arc::new(Mutex::new(0));
-        let timer_num = local_num.clone();
-
-        let _timer = timer_subsystem.add_timer(
-            20,
-            Box::new(|| {
-                // increment up to 10 times (0 -> 9)
-                // tick again in 100ms after each increment
-                //
-                let mut num = timer_num.lock().unwrap();
-                if *num < 9 {
-                    *num += 1;
-                    20
-                } else {
-                    0
-                }
-            }),
-        );
-
-        // tick the timer at least 10 times w/ 200ms of "buffer"
-        ::std::thread::sleep(Duration::from_millis(250));
-        let num = local_num.lock().unwrap(); // read the number back
-        assert_eq!(*num, 9); // it should have incremented at least 10 times...
-    }
-
-    fn test_timer_runs_at_least_once() {
-        let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
-
-        let local_flag = Arc::new(Mutex::new(false));
-        let timer_flag = local_flag.clone();
-
-        let _timer = timer_subsystem.add_timer(
-            20,
-            Box::new(|| {
-                let mut flag = timer_flag.lock().unwrap();
-                *flag = true;
-                0
-            }),
-        );
-
-        ::std::thread::sleep(Duration::from_millis(50));
-        let flag = local_flag.lock().unwrap();
-        assert!(*flag);
-    }
-
-    fn test_timer_can_be_recreated() {
-        let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
-
-        let local_num = Arc::new(Mutex::new(0));
-        let timer_num = local_num.clone();
-
-        // run the timer once and reclaim its closure
-        let timer_1 = timer_subsystem.add_timer(
-            20,
-            Box::new(move || {
-                let mut num = timer_num.lock().unwrap();
-                *num += 1; // increment the number
-                0 // do not run timer again
-            }),
-        );
-
-        // reclaim closure after timer runs
-        ::std::thread::sleep(Duration::from_millis(50));
-        let closure = timer_1.into_inner();
-
-        // create a second timer and increment again
-        let _timer_2 = timer_subsystem.add_timer(20, closure);
-        ::std::thread::sleep(Duration::from_millis(50));
-
-        // check that timer was incremented twice
-        let num = local_num.lock().unwrap();
-        assert_eq!(*num, 2);
-    }
-}

--- a/src/sdl2/url.rs
+++ b/src/sdl2/url.rs
@@ -1,8 +1,8 @@
 //! Opening URLs in default system handlers
 
-use std::error;
-use std::ffi::{CString, NulError};
-use std::fmt;
+use alloc::ffi::{CString, NulError};
+use alloc::string::String;
+use core::fmt;
 
 use crate::get_error;
 
@@ -21,15 +21,6 @@ impl fmt::Display for OpenUrlError {
         match *self {
             InvalidUrl(ref e) => write!(f, "Invalid URL: {}", e),
             SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl error::Error for OpenUrlError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidUrl(err) => Some(err),
-            Self::SdlError(_) => None,
         }
     }
 }

--- a/src/sdl2/version.rs
+++ b/src/sdl2/version.rs
@@ -1,7 +1,10 @@
 //! Querying SDL Version
 
-use std::ffi::CStr;
-use std::fmt;
+use alloc::borrow::ToOwned;
+use core::ffi::CStr;
+use core::fmt;
+
+use alloc::string::String;
 
 use crate::sys;
 

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1,10 +1,13 @@
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
 use libc::{c_char, c_float, c_int, c_uint};
-use std::convert::TryFrom;
-use std::error::Error;
-use std::ffi::{CStr, CString, NulError};
-use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
-use std::{fmt, mem, ptr};
+use core::convert::TryFrom;
+use alloc::ffi::{CString, NulError};
+use core::ffi::CStr;
+use core::ops::{Deref, DerefMut};
+use alloc::rc::Rc;
+use core::{fmt, mem, ptr};
 
 use crate::common::{validate_int, IntegerOrSdlError};
 use crate::pixels::PixelFormatEnum;
@@ -203,7 +206,7 @@ pub mod gl_attr {
     use super::{GLAttrTypeUtil, GLProfile};
     use crate::get_error;
     use crate::sys;
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     /// OpenGL context getters and setters. Obtain with `VideoSubsystem::gl_attr()`.
     pub struct GLAttr<'a> {
@@ -715,7 +718,7 @@ impl VideoSubsystem {
 
     #[doc(alias = "SDL_GetCurrentVideoDriver")]
     pub fn current_video_driver(&self) -> &'static str {
-        use std::str;
+        use core::str;
 
         unsafe {
             let buf = sys::SDL_GetCurrentVideoDriver();
@@ -918,10 +921,10 @@ impl VideoSubsystem {
     ///
     /// If a different library is already loaded, this function will return an error.
     #[doc(alias = "SDL_GL_LoadLibrary")]
-    pub fn gl_load_library<P: AsRef<::std::path::Path>>(&self, path: P) -> Result<(), String> {
+    pub fn gl_load_library(&self, path: &str) -> Result<(), String> {
         unsafe {
             // TODO: use OsStr::to_cstring() once it's stable
-            let path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+            let path = CString::new(path).unwrap();
             if sys::SDL_GL_LoadLibrary(path.as_ptr() as *const c_char) == 0 {
                 Ok(())
             } else {
@@ -1033,10 +1036,10 @@ impl VideoSubsystem {
     ///
     /// If a different library is already loaded, this function will return an error.
     #[doc(alias = "SDL_Vulkan_LoadLibrary")]
-    pub fn vulkan_load_library<P: AsRef<::std::path::Path>>(&self, path: P) -> Result<(), String> {
+    pub fn vulkan_load_library(&self, path: &str) -> Result<(), String> {
         unsafe {
             // TODO: use OsStr::to_cstring() once it's stable
-            let path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+            let path = CString::new(path).unwrap();
             if sys::SDL_Vulkan_LoadLibrary(path.as_ptr() as *const c_char) == 0 {
                 Ok(())
             } else {
@@ -1088,15 +1091,6 @@ impl fmt::Display for WindowBuildError {
             WidthOverflows(w) => write!(f, "Window width ({}) is too high.", w),
             InvalidTitle(ref e) => write!(f, "Invalid window title: {}", e),
             SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl Error for WindowBuildError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::InvalidTitle(err) => Some(err),
-            Self::HeightOverflows(_) | Self::WidthOverflows(_) | Self::SdlError(_) => None,
         }
     }
 }
@@ -1495,7 +1489,7 @@ impl Window {
                 return Err(get_error());
             }
             let mut result = vec![0; size as usize];
-            result.copy_from_slice(std::slice::from_raw_parts(data as *const u8, size as usize));
+            result.copy_from_slice(core::slice::from_raw_parts(data as *const u8, size as usize));
             sys::SDL_free(data);
             Ok(result)
         }
@@ -2052,7 +2046,7 @@ pub struct DriverIterator {
 // which only happens if index is outside the range
 // 0..SDL_GetNumVideoDrivers()
 fn get_video_driver(index: i32) -> &'static str {
-    use std::str;
+    use core::str;
 
     unsafe {
         let buf = sys::SDL_GetVideoDriver(index);
@@ -2085,7 +2079,7 @@ impl Iterator for DriverIterator {
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<&'static str> {
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         self.index = match n.try_into().ok().and_then(|n| self.index.checked_add(n)) {
             Some(index) if index < self.length => index,
@@ -2110,7 +2104,7 @@ impl DoubleEndedIterator for DriverIterator {
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<&'static str> {
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         self.length = match n.try_into().ok().and_then(|n| self.length.checked_sub(n)) {
             Some(length) if length > self.index => length,
@@ -2123,7 +2117,7 @@ impl DoubleEndedIterator for DriverIterator {
 
 impl ExactSizeIterator for DriverIterator {}
 
-impl std::iter::FusedIterator for DriverIterator {}
+impl core::iter::FusedIterator for DriverIterator {}
 
 /// Gets an iterator of all video drivers compiled into the SDL2 library.
 #[inline]

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -15,7 +15,7 @@ lazy_static! {
 #[test]
 fn test_events() {
     let _lock = CONTEXT_MUTEX.lock();
-    let sdl = sdl2::init().unwrap();
+    let sdl = unsafe { sdl2::init().unwrap() };
     let ev = sdl.event().unwrap();
     let mut ep = sdl.event_pump().unwrap();
 
@@ -122,7 +122,7 @@ fn test4(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
 #[test]
 fn test_event_sender_no_subsystem() {
     let _lock = CONTEXT_MUTEX.lock();
-    let sdl = sdl2::init().unwrap();
+    let sdl = unsafe { sdl2::init().unwrap() };
     let ev = sdl.event().unwrap();
     let tx = ev.event_sender();
 


### PR DESCRIPTION
- Now using core, alloc, hashbrown and spin.
- Had to remove any uses of Path and replace them with plain string slices.
- Initialization is now unsafe.
- Removed std::error::Error impls (will be back later)