### PR TITLE
Fixed typo in comment/documentation

### DIFF
--- a/src/sdl2/event.rs
+++ b/src/sdl2/event.rs
@@ -648,7 +648,7 @@ pub enum Event {
         precise_y: f32,
         /// The X position of the mouse from the window's origin
         mouse_x: i32,
-        /// The X position of the mouse from the window's origin
+        /// The Y position of the mouse from the window's origin
         mouse_y: i32,
     },
 


### PR DESCRIPTION
Fixed comment describing `mouse_y`'s behaviour as being responsible for the x position of the mouse.

Fixes #1422 