### PR TITLE
API: Proper error types instead of String

### DIFF
--- a/src/sdl2/common.rs
+++ b/src/sdl2/common.rs
@@ -1,16 +1,49 @@
-use std::error::Error;
-use std::fmt;
+use std::ffi::{CString, NulError};
+use std::{error, fmt};
 
-/// A given integer was so big that its representation as a C integer would be
-/// negative.
-#[derive(Debug, Clone, PartialEq)]
-pub enum IntegerOrSdlError {
-    IntegerOverflows(&'static str, u32),
-    SdlError(String),
+#[derive(Debug)]
+pub enum Error {
+    Sdl(String),
+    /// An integer was larger than [`i32::MAX`] in a parameter, and it can't be converted to a C int
+    IntOverflow(&'static str, u32),
+    /// A null byte was found within a parameter, and it can't be sent to SDL
+    InvalidString(NulError, &'static str),
 }
+
+impl Error {
+    pub fn from_sdl_error() -> Self {
+        Self::Sdl(crate::get_error())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sdl(msg) => write!(f, "SDL error: {msg}"),
+            Self::IntOverflow(name, value) => write!(f, "Integer '{name}' overflows: {value}"),
+            Self::InvalidString(name, nul) => write!(f, "Invalid string '{name}': {nul}"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Sdl(..) | Self::IntOverflow(..) => None,
+            Self::InvalidString(nul, _) => Some(nul),
+        }
+    }
+}
+
+pub fn validate_string(str: impl Into<Vec<u8>>, name: &'static str) -> Result<CString, Error> {
+    match CString::new(str) {
+        Ok(c) => Ok(c),
+        Err(nul) => Err(Error::InvalidString(nul, name)),
+    }
+}
+
 /// Validates and converts the given u32 to a positive C integer.
-pub fn validate_int(value: u32, name: &'static str) -> Result<::libc::c_int, IntegerOrSdlError> {
-    use self::IntegerOrSdlError::*;
+pub fn validate_int(value: u32, name: &'static str) -> Result<libc::c_int, Error> {
     // Many SDL functions will accept `int` values, even if it doesn't make sense
     // for the values to be negative.
     // In the cases that SDL doesn't check negativity, passing negative values
@@ -18,22 +51,9 @@ pub fn validate_int(value: u32, name: &'static str) -> Result<::libc::c_int, Int
     // For example, `SDL_JoystickGetButton` uses the index argument to access an
     // array without checking if it's negative, which could potentially lead to
     // segmentation faults.
-    if value >= 1 << 31 {
-        Err(IntegerOverflows(name, value))
+    if value > libc::c_int::MAX as u32 {
+        Err(Error::IntOverflow(name, value))
     } else {
-        Ok(value as ::libc::c_int)
+        Ok(value as libc::c_int)
     }
 }
-
-impl fmt::Display for IntegerOrSdlError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::IntegerOrSdlError::*;
-
-        match *self {
-            IntegerOverflows(name, value) => write!(f, "Integer '{}' overflows ({})", name, value),
-            SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl Error for IntegerOrSdlError {}

--- a/src/sdl2/filesystem.rs
+++ b/src/sdl2/filesystem.rs
@@ -1,9 +1,6 @@
-use crate::get_error;
-use libc::c_char;
+use crate::{get_error, Error};
 use libc::c_void;
-use std::error;
-use std::ffi::{CStr, CString, NulError};
-use std::fmt;
+use std::ffi::CStr;
 
 use crate::sys;
 
@@ -23,58 +20,20 @@ pub fn base_path() -> Result<String, String> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum PrefPathError {
-    InvalidOrganizationName(NulError),
-    InvalidApplicationName(NulError),
-    SdlError(String),
-}
-
-impl fmt::Display for PrefPathError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::PrefPathError::*;
-
-        match *self {
-            InvalidOrganizationName(ref e) => write!(f, "Invalid organization name: {}", e),
-            InvalidApplicationName(ref e) => write!(f, "Invalid application name: {}", e),
-            SdlError(ref e) => write!(f, "SDL error: {}", e),
-        }
-    }
-}
-
-impl error::Error for PrefPathError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidOrganizationName(err) => Some(err),
-            Self::InvalidApplicationName(err) => Some(err),
-            Self::SdlError(_) => None,
-        }
-    }
-}
-
 // TODO: Change to OsStr or something?
 /// Return the preferred directory for the application to write files on this
 /// system, based on the given organization and application name.
 #[doc(alias = "SDL_GetPrefPath")]
-pub fn pref_path(org_name: &str, app_name: &str) -> Result<String, PrefPathError> {
-    use self::PrefPathError::*;
-    let result = unsafe {
-        let org = match CString::new(org_name) {
-            Ok(s) => s,
-            Err(err) => return Err(InvalidOrganizationName(err)),
-        };
-        let app = match CString::new(app_name) {
-            Ok(s) => s,
-            Err(err) => return Err(InvalidApplicationName(err)),
-        };
-        let buf =
-            sys::SDL_GetPrefPath(org.as_ptr() as *const c_char, app.as_ptr() as *const c_char);
-        CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned()
-    };
-
-    if result.is_empty() {
-        Err(SdlError(get_error()))
-    } else {
-        Ok(result)
+pub fn pref_path(org_name: &str, app_name: &str) -> Result<String, Error> {
+    unsafe {
+        let buf = sys::SDL_GetPrefPath(
+            as_cstring!(org_name)?.as_ptr(),
+            as_cstring!(app_name)?.as_ptr(),
+        );
+        if buf.is_null() {
+            Err(Error::from_sdl_error())
+        } else {
+            Ok(CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned())
+        }
     }
 }

--- a/src/sdl2/haptic.rs
+++ b/src/sdl2/haptic.rs
@@ -1,15 +1,14 @@
 //! Haptic Functions
 use crate::sys;
 
-use crate::common::{validate_int, IntegerOrSdlError};
-use crate::get_error;
+use crate::common::validate_int;
+use crate::Error;
 use crate::HapticSubsystem;
 
 impl HapticSubsystem {
     /// Attempt to open the joystick at index `joystick_index` and return its haptic device.
     #[doc(alias = "SDL_JoystickOpen")]
-    pub fn open_from_joystick_id(&self, joystick_index: u32) -> Result<Haptic, IntegerOrSdlError> {
-        use crate::common::IntegerOrSdlError::*;
+    pub fn open_from_joystick_id(&self, joystick_index: u32) -> Result<Haptic, Error> {
         let joystick_index = validate_int(joystick_index, "joystick_index")?;
 
         let haptic = unsafe {
@@ -18,7 +17,7 @@ impl HapticSubsystem {
         };
 
         if haptic.is_null() {
-            Err(SdlError(get_error()))
+            Err(Error::from_sdl_error())
         } else {
             unsafe { sys::SDL_HapticRumbleInit(haptic) };
             Ok(Haptic {

--- a/src/sdl2/lib.rs
+++ b/src/sdl2/lib.rs
@@ -103,7 +103,7 @@ pub mod ttf;
 
 mod common;
 // Export return types and such from the common module.
-pub use crate::common::IntegerOrSdlError;
+pub use crate::common::Error;
 
 #[cfg(feature = "raw-window-handle")]
 pub mod raw_window_handle;

--- a/src/sdl2/macros.rs
+++ b/src/sdl2/macros.rs
@@ -24,3 +24,9 @@ macro_rules! impl_raw_constructor(
         )+
     )
 );
+
+macro_rules! as_cstring {
+    ($i:ident) => {
+        $crate::common::validate_string($i, stringify!($i))
+    };
+}

--- a/src/sdl2/sdl.rs
+++ b/src/sdl2/sdl.rs
@@ -1,39 +1,10 @@
 use libc::c_char;
 use std::cell::Cell;
-use std::error;
 use std::ffi::{CStr, CString, NulError};
-use std::fmt;
 use std::marker::PhantomData;
-use std::mem::transmute;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use crate::sys;
-
-#[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub enum Error {
-    NoMemError = sys::SDL_errorcode::SDL_ENOMEM as i32,
-    ReadError = sys::SDL_errorcode::SDL_EFREAD as i32,
-    WriteError = sys::SDL_errorcode::SDL_EFWRITE as i32,
-    SeekError = sys::SDL_errorcode::SDL_EFSEEK as i32,
-    UnsupportedError = sys::SDL_errorcode::SDL_UNSUPPORTED as i32,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            NoMemError => write!(f, "Out of memory"),
-            ReadError => write!(f, "Error reading from datastream"),
-            WriteError => write!(f, "Error writing to datastream"),
-            SeekError => write!(f, "Error seeking in datastream"),
-            UnsupportedError => write!(f, "Unknown SDL error"),
-        }
-    }
-}
-
-impl error::Error for Error {}
 
 /// True if the main thread has been declared. The main thread is declared when
 /// SDL is first initialized.
@@ -389,13 +360,6 @@ pub fn set_error(err: &str) -> Result<(), NulError> {
         sys::SDL_SetError(b"%s\0".as_ptr() as *const c_char, c_string.as_ptr());
     }
     Ok(())
-}
-
-#[doc(alias = "SDL_Error")]
-pub fn set_error_from_code(err: Error) {
-    unsafe {
-        sys::SDL_Error(transmute::<Error, sys::SDL_errorcode>(err));
-    }
 }
 
 #[doc(alias = "SDL_ClearError")]

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -1,7 +1,7 @@
 // 0 should not be used in bitflags, but here it is. Removing it will break existing code.
 #![allow(clippy::bad_bit_mask)]
 
-use get_error;
+use crate::Error;
 use pixels::Color;
 use rwops::RWops;
 use std::error;
@@ -47,40 +47,6 @@ pub struct GlyphMetrics {
     pub advance: i32,
 }
 
-/// The result of an `SDL2_TTF` font operation.
-pub type FontResult<T> = Result<T, FontError>;
-
-/// A font-related error.
-#[derive(Debug, Clone)]
-pub enum FontError {
-    /// A Latin-1 encoded byte string is invalid.
-    InvalidLatin1Text(NulError),
-    /// A SDL2-related error occured.
-    SdlError(String),
-}
-
-impl error::Error for FontError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            FontError::InvalidLatin1Text(ref error) => Some(error),
-            FontError::SdlError(_) => None,
-        }
-    }
-}
-
-impl fmt::Display for FontError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            FontError::InvalidLatin1Text(ref err) => {
-                write!(f, "Invalid Latin-1 bytes: {}", err)
-            }
-            FontError::SdlError(ref msg) => {
-                write!(f, "SDL2 error: {}", msg)
-            }
-        }
-    }
-}
-
 /// A renderable piece of text in the UTF8 or Latin-1 format.
 enum RenderableText<'a> {
     Utf8(&'a str),
@@ -89,12 +55,10 @@ enum RenderableText<'a> {
 }
 impl<'a> RenderableText<'a> {
     /// Converts the given text to a c-style string if possible.
-    fn convert(&self) -> FontResult<CString> {
+    fn convert(&self) -> Result<CString, Error> {
         match *self {
             RenderableText::Utf8(text) => Ok(CString::new(text).unwrap()),
-            RenderableText::Latin1(bytes) => {
-                CString::new(bytes).map_err(FontError::InvalidLatin1Text)
-            }
+            RenderableText::Latin1(text) => as_cstring!(text),
             RenderableText::Char(ch) => {
                 Ok(CString::new(ch.encode_utf8(&mut [0; 4]).as_bytes()).unwrap())
             }
@@ -110,9 +74,9 @@ pub struct PartialRendering<'f, 'text> {
 }
 
 /// Converts the given raw pointer to a surface.
-fn convert_to_surface<'a>(raw: *mut SDL_Surface) -> FontResult<Surface<'a>> {
+fn convert_to_surface<'a>(raw: *mut SDL_Surface) -> Result<Surface<'a>, Error> {
     if (raw as *mut ()).is_null() {
-        Err(FontError::SdlError(get_error()))
+        Err(Error::from_sdl_error())
     } else {
         Ok(unsafe { Surface::from_ll(raw) })
     }
@@ -122,7 +86,7 @@ impl<'f, 'text> PartialRendering<'f, 'text> {
     /// Renders the text in *solid* mode.
     /// See [the SDL2_TTF docs](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC42)
     /// for an explanation.
-    pub fn solid<'b, T>(self, color: T) -> FontResult<Surface<'b>>
+    pub fn solid<'b, T>(self, color: T) -> Result<Surface<'b>, Error>
     where
         T: Into<Color>,
     {
@@ -144,7 +108,7 @@ impl<'f, 'text> PartialRendering<'f, 'text> {
     /// Renders the text in *shaded* mode.
     /// See [the SDL2_TTF docs](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC42)
     /// for an explanation.
-    pub fn shaded<'b, T>(self, color: T, background: T) -> FontResult<Surface<'b>>
+    pub fn shaded<'b, T>(self, color: T, background: T) -> Result<Surface<'b>, Error>
     where
         T: Into<Color>,
     {
@@ -173,7 +137,7 @@ impl<'f, 'text> PartialRendering<'f, 'text> {
     /// Renders the text in *blended* mode.
     /// See [the SDL2_TTF docs](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC42)
     /// for an explanation.
-    pub fn blended<'b, T>(self, color: T) -> FontResult<Surface<'b>>
+    pub fn blended<'b, T>(self, color: T) -> Result<Surface<'b>, Error>
     where
         T: Into<Color>,
     {
@@ -196,7 +160,7 @@ impl<'f, 'text> PartialRendering<'f, 'text> {
     /// exceeds the given maximum width.
     /// See [the SDL2_TTF docs](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC42)
     /// for an explanation of the mode.
-    pub fn blended_wrapped<'b, T>(self, color: T, wrap_max_width: u32) -> FontResult<Surface<'b>>
+    pub fn blended_wrapped<'b, T>(self, color: T, wrap_max_width: u32) -> Result<Surface<'b>, Error>
     where
         T: Into<Color>,
     {
@@ -338,7 +302,7 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
 
     /// Returns the width and height of the given text when rendered using this
     /// font.
-    pub fn size_of(&self, text: &str) -> FontResult<(u32, u32)> {
+    pub fn size_of(&self, text: &str) -> Result<(u32, u32), Error> {
         let c_string = RenderableText::Utf8(text).convert()?;
         let (res, size) = unsafe {
             let mut w = 0; // mutated by C code
@@ -349,13 +313,13 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
         if res == 0 {
             Ok(size)
         } else {
-            Err(FontError::SdlError(get_error()))
+            Err(Error::from_sdl_error())
         }
     }
 
     /// Returns the width and height of the given text when rendered using this
     /// font.
-    pub fn size_of_latin1(&self, text: &[u8]) -> FontResult<(u32, u32)> {
+    pub fn size_of_latin1(&self, text: &[u8]) -> Result<(u32, u32), Error> {
         let c_string = RenderableText::Latin1(text).convert()?;
         let (res, size) = unsafe {
             let mut w: i32 = 0;
@@ -366,13 +330,13 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
         if res == 0 {
             Ok(size)
         } else {
-            Err(FontError::SdlError(get_error()))
+            Err(Error::from_sdl_error())
         }
     }
 
     /// Returns the width and height of the given text when rendered using this
     /// font.
-    pub fn size_of_char(&self, ch: char) -> FontResult<(u32, u32)> {
+    pub fn size_of_char(&self, ch: char) -> Result<(u32, u32), Error> {
         self.size_of(ch.encode_utf8(&mut [0; 4]))
     }
 


### PR DESCRIPTION
Work in progress. I am also taking time to unify all error types, since there were many `SdlError`s before. I would like to discuss if compatibility is necessary, e.g. it could be a feature-flag that does `type SdlError = String;`

See also: #1053

Summary:
- Removed `OpenUrlError`, `PrefPathError`, `ShowMessageError`, `WindowBuildError`, `FontError` and `common::IntegerOrSdlError` in favor of `Error::InvalidString`
- Removed `set_error_from_code` (internal SDL api, shouldn't be here? could add back as `SdlErrorCode`)
- Fixed `pref_path` checking for empty string instead of null

TODO:

- Figure out `TargetRenderError`, `TextureValueError`, `UpdateTextureError`, `UpdateTextureYUVError`
- `ttf::InitError` could be removed, if same ref-counting as subsystems is implemented for it
- `ttf::FontError` was removed, it might be good to review removing `RendererableText`, as a `CString` is always allocated anyway?
