### PR TITLE
Fix copy-paste mistake in WindowBuilder::build

### DIFF
--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1145,7 +1145,7 @@ impl WindowBuilder {
             return Err(WidthOverflows(self.width));
         }
         if self.height >= (1 << 31) {
-            return Err(HeightOverflows(self.width));
+            return Err(HeightOverflows(self.height));
         }
 
         let raw_width = self.width as c_int;


### PR DESCRIPTION
Found this bug when looking at recent issues, was a very quick fix.

Is this worthy for the changelog? I don't think library users would be interested because it requires no change on their part.