### PR TITLE
Fix ub and shrink unsafe blocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Next
 
+[PR #1435](https://github.com/Rust-SDL2/rust-sdl2/pull/1435) **BREAKING CHANGE** Fix some undefined behavior. Breaking changes: `mixer::Chunk`'s fields are now private and callbacks to `TimerSubsystem::add_timer` must now live for `'static`, also allowing some lifetime parameters to be removed.
+
 [PR #1461](https://github.com/Rust-SDL2/rust-sdl2/pull/1461) **BREAKING CHANGE** Added new SensorType variants: LeftGyroscope, RightGyroscope, LeftAccelerometer, RightAccelerometer
 
 [PR #1461](https://github.com/Rust-SDL2/rust-sdl2/pull/1461) **BREAKING CHANGE** Sensor::get_data now returns correct SensorData::Gyro enum

--- a/src/sdl2/audio.rs
+++ b/src/sdl2/audio.rs
@@ -337,10 +337,15 @@ impl TryFrom<u32> for AudioStatus {
         use self::AudioStatus::*;
         use crate::sys::SDL_AudioStatus::*;
 
-        Ok(match unsafe { mem::transmute(n) } {
-            SDL_AUDIO_STOPPED => Stopped,
-            SDL_AUDIO_PLAYING => Playing,
-            SDL_AUDIO_PAUSED => Paused,
+        const STOPPED: u32 = SDL_AUDIO_STOPPED as u32;
+        const PLAYING: u32 = SDL_AUDIO_PLAYING as u32;
+        const PAUSED: u32 = SDL_AUDIO_PAUSED as u32;
+
+        Ok(match n {
+            STOPPED => Stopped,
+            PLAYING => Playing,
+            PAUSED => Paused,
+            _ => return Err(()),
         })
     }
 }

--- a/src/sdl2/mixer/mod.rs
+++ b/src/sdl2/mixer/mod.rs
@@ -278,8 +278,8 @@ pub fn get_chunk_decoder(index: i32) -> String {
 /// The internal format for an audio chunk.
 #[derive(PartialEq)]
 pub struct Chunk {
-    pub raw: *mut mixer::Mix_Chunk,
-    pub owned: bool,
+    raw: *mut mixer::Mix_Chunk,
+    owned: bool,
 }
 
 impl Drop for Chunk {

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -984,6 +984,9 @@ impl std::iter::Sum for Point {
 /// recommended to use `Option<FRect>`, with `None` representing an empty
 /// rectangle (see, for example, the output of the
 /// [`intersection`](#method.intersection) method).
+// Uses repr(transparent) to allow pointer casting between FRect and SDL_FRect (see
+// `FRect::raw_slice`)
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct FRect {
     raw: sys::SDL_FRect,
@@ -1600,6 +1603,9 @@ impl BitOr<FRect> for FRect {
 }
 
 /// Immutable point type with float precision, consisting of x and y.
+// Uses repr(transparent) to allow pointer casting between FPoint and SDL_FPoint (see
+// `FPoint::raw_slice`)
+#[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct FPoint {
     raw: sys::SDL_FPoint,

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -1360,7 +1360,7 @@ impl FRect {
     }
 
     pub fn raw_mut(&mut self) -> *mut sys::SDL_FRect {
-        self.raw() as *mut _
+        &mut self.raw
     }
 
     #[doc(alias = "SDL_FRect")]


### PR DESCRIPTION
Breaking changes:
- `mixer::Chunk` fields were made private because the struct relied on these pointer being valid, but users could set them to any value
- Timer callback must live for `'static` because the callback can be called after the scope ends (by using `std::mem::forget`).

timer ub reproduction (ran from a `#[test]`):
```rust
let sdl_context = crate::sdl::init().unwrap();
let timer_subsystem = sdl_context.timer().unwrap();

let mut v = Box::new(123);

std::mem::forget(timer_subsystem.add_timer(
    20,
    Box::new(|| {
        dbg!(std::mem::take(&mut v));
        0
    }),
));

drop(v);

// v is used after dropping (from the timer callback)

std::thread::sleep(Duration::from_millis(30));
```