### PR TITLE
Prevent users from creating `Sdl2TtfContext` out of nothing and use SDL's reference counting init/quit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Next
 
+[PR #1437](https://github.com/Rust-SDL2/rust-sdl2/pull/1437) **BREAKING CHANGE** Prevent users from creating `Sdl2TtfContext` out of nothing and use SDL's reference counting init/quit
+
 [PR #1464](https://github.com/Rust-SDL2/rust-sdl2/pull/1464) Added binding for `Mix_OpenAudioDevice`
 
 [PR #1451](https://github.com/Rust-SDL2/rust-sdl2/pull/1451) Add `gamma_ramp_arrays` and `calculate_gamma_ramp`.

--- a/src/sdl2/ttf/context.rs
+++ b/src/sdl2/ttf/context.rs
@@ -91,41 +91,14 @@ pub fn get_linked_version() -> Version {
     Version::from_ll(unsafe { *ttf::TTF_Linked_Version() })
 }
 
-/// An error for when `sdl2_ttf` is attempted initialized twice
-/// Necessary for context management, unless we find a way to have a singleton
-#[derive(Debug)]
-pub enum InitError {
-    InitializationError(String),
-    AlreadyInitializedError,
-}
-
-impl error::Error for InitError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            InitError::InitializationError(_) | InitError::AlreadyInitializedError => None,
-        }
-    }
-}
-
-impl fmt::Display for InitError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::AlreadyInitializedError => {
-                write!(f, "SDL2_TTF has already been initialized")
-            }
-            Self::InitializationError(error) => write!(f, "SDL2_TTF initialization error: {error}"),
-        }
-    }
-}
-
 /// Initializes the truetype font API and returns a context manager which will
 /// clean up the library once it goes out of scope.
 #[doc(alias = "TTF_Init")]
-pub fn init() -> Result<Sdl2TtfContext, InitError> {
+pub fn init() -> Result<Sdl2TtfContext, String> {
     if unsafe { ttf::TTF_Init() } == 0 {
         Ok(Sdl2TtfContext(()))
     } else {
-        Err(InitError::InitializationError(get_error()))
+        Err(get_error())
     }
 }
 

--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -251,7 +251,7 @@ impl<'ttf, 'r> Drop for Font<'ttf, 'r> {
 }
 
 /// Internally used to load a font (for internal visibility).
-pub fn internal_load_font<'ttf, P: AsRef<Path>>(
+pub(super) fn internal_load_font<'ttf, P: AsRef<Path>>(
     path: P,
     ptsize: u16,
 ) -> Result<Font<'ttf, 'static>, String> {
@@ -271,7 +271,10 @@ pub fn internal_load_font<'ttf, P: AsRef<Path>>(
 }
 
 /// Internally used to load a font (for internal visibility).
-pub fn internal_load_font_from_ll<'ttf, 'r, R>(raw: *mut ttf::TTF_Font, rwops: R) -> Font<'ttf, 'r>
+pub(super) fn internal_load_font_from_ll<'ttf, 'r, R>(
+    raw: *mut ttf::TTF_Font,
+    rwops: R,
+) -> Font<'ttf, 'r>
 where
     R: Into<Option<RWops<'r>>>,
 {
@@ -283,7 +286,7 @@ where
 }
 
 /// Internally used to load a font (for internal visibility).
-pub fn internal_load_font_at_index<'ttf, P: AsRef<Path>>(
+pub(super) fn internal_load_font_at_index<'ttf, P: AsRef<Path>>(
     path: P,
     index: u32,
     ptsize: u16,

--- a/src/sdl2/ttf/mod.rs
+++ b/src/sdl2/ttf/mod.rs
@@ -23,9 +23,7 @@
 mod context;
 mod font;
 
-pub use self::context::{
-    get_linked_version, has_been_initialized, init, InitError, Sdl2TtfContext,
-};
+pub use self::context::{get_linked_version, has_been_initialized, init, Sdl2TtfContext};
 pub use self::font::{
     Font, FontError, FontResult, FontStyle, GlyphMetrics, Hinting, PartialRendering,
 };


### PR DESCRIPTION
Detailed description of the changes are in the commit messages