### PR TITLE
Update Windows (MSVC) instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ Instructions to generate a static binary on macOS and other operating systems us
 
   Where current toolchain is likely `stable-x86_64-pc-windows-msvc`.
 
-4. Copy SDL2.dll from
+4. Copy `SDL2.lib` and `SDL2.dll` from
     > SDL2-devel-2.0.x-VC\SDL2-2.0.x\lib\x64\
 
     into your cargo project, right next to your Cargo.toml.
 
- 5. When you're shipping your game make sure to copy SDL2.dll to the same directory that your compiled exe is in, otherwise the game won't launch.
+5. When you're shipping your game make sure to copy `SDL2.dll` to the same directory that your compiled exe is in, otherwise the game won't launch.
 
 #### Static linking with MSVC
 


### PR DESCRIPTION
Following the current instructions for Windows (MSVC) will result in a compile error with the latest Rust 1.83 version:

`LINK : fatal error LNK1181: cannot open input file SDL2.lib`

The issue does not occur with older versions of Rust (1.80).

The solution is to copy the `SDL2.lib` file to the project directory along with the `SDL2.dll` file.

This PR is intended to update the instructions for Windows (MSVC) accordingly.
