### PR TITLE
add ClippingRect

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -406,6 +406,7 @@ impl RenderTarget for Window {
     type Context = WindowContext;
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum ClippingRect {
     /// a non-zero area clipping rect
     Some(Rect),


### PR DESCRIPTION
in rust-sdl2, Rect can't have a zero width or height. This is instead represented with Option<Rect>, where None covers this case.

The Canvas `set_clip_rect` and `clip_rect` function work with Option<Rect> as well. However, for those functions None instead represents the lack of a clipping rect. This is distinctly differently, as clearing the clipping rect is like setting a Rect with an infinite area, and not a zero area (which would instead disable drawing).

This is value aliasing which can be corrected with a better type representation; it's impossible with current API to set a clipping rect with a zero area, which is a valid request that disabled drawing. Since this has been [fixed](https://github.com/libsdl-org/SDL/pull/8229/files) in sdl2, this MR keep in sync with upstream.

This is not backwards compatible, but imo necessary