### PR TITLE
add gamma_ramp_arrays and calculate_gamma_ramp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Next
 
+[PR #1451](https://github.com/Rust-SDL2/rust-sdl2/pull/1451) Add `gamma_ramp_arrays` and `calculate_gamma_ramp`.
+
 [PR #1459](https://github.com/Rust-SDL2/rust-sdl2/pull/1459) Fix image and mixer init flag logic
 
 [PR #1444](https://github.com/Rust-SDL2/rust-sdl2/pull/1444) Add texture scale mode api + fix unsafe

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1984,6 +1984,20 @@ impl Window {
         }
     }
 
+    #[doc(alias = "SDL_GetWindowGammaRamp")]
+    pub fn gamma_ramp_arrays(&self) -> Result<[[u16; 256]; 3], String> {
+        let mut ret = mem::MaybeUninit::<[[u16; 256]; 3]>::uninit();
+        let ptr = ret.as_mut_ptr().cast::<u16>();
+        let result = unsafe {
+            sys::SDL_GetWindowGammaRamp(self.context.raw, ptr, ptr.add(256), ptr.add(512))
+        };
+        if result == 0 {
+            Ok(unsafe { ret.assume_init() })
+        } else {
+            Err(get_error())
+        }
+    }
+
     /// Set the transparency of the window. The given value will be clamped internally between
     /// `0.0` (fully transparent), and `1.0` (fully opaque).
     ///
@@ -2136,5 +2150,14 @@ pub fn drivers() -> DriverIterator {
     DriverIterator {
         length: unsafe { sys::SDL_GetNumVideoDrivers() },
         index: 0,
+    }
+}
+
+#[doc(alias = "SDL_CalculateGammaRamp")]
+pub fn calculate_gamma_ramp(gamma: f32) -> [u16; 256] {
+    unsafe {
+        let mut ret = mem::MaybeUninit::<[u16; 256]>::uninit();
+        sys::SDL_CalculateGammaRamp(gamma as c_float, ret.as_mut_ptr().cast::<u16>());
+        ret.assume_init()
     }
 }

--- a/src/sdl2/video.rs
+++ b/src/sdl2/video.rs
@@ -1986,13 +1986,17 @@ impl Window {
 
     #[doc(alias = "SDL_GetWindowGammaRamp")]
     pub fn gamma_ramp_arrays(&self) -> Result<[[u16; 256]; 3], String> {
-        let mut ret = mem::MaybeUninit::<[[u16; 256]; 3]>::uninit();
-        let ptr = ret.as_mut_ptr().cast::<u16>();
+        let [mut red, mut green, mut blue] = [mem::MaybeUninit::<[u16; 256]>::uninit(); 3];
         let result = unsafe {
-            sys::SDL_GetWindowGammaRamp(self.context.raw, ptr, ptr.add(256), ptr.add(512))
+            sys::SDL_GetWindowGammaRamp(
+                self.context.raw,
+                red.as_mut_ptr().cast::<u16>(),
+                green.as_mut_ptr().cast::<u16>(),
+                blue.as_mut_ptr().cast::<u16>(),
+            )
         };
         if result == 0 {
-            Ok(unsafe { ret.assume_init() })
+            Ok(unsafe { [red.assume_init(), green.assume_init(), blue.assume_init()] })
         } else {
             Err(get_error())
         }


### PR DESCRIPTION
- gamma_ramp_arrays is similar to gamma_ramp, but returns the gamma ramps as an array of 3 arrays, this way no heap allocations are made and users get a compile time guarantee that each ramp contains 256 values
- calculate_gamma_ramp wraps SDL_CalculateGammaRamp, which calculates the gamma ramp for a gives gamma value, see https://wiki.libsdl.org/SDL2/SDL_CalculateGammaRamp