### PR TITLE
make ttf raw pub

### DIFF
--- a/src/sdl2/ttf/font.rs
+++ b/src/sdl2/ttf/font.rs
@@ -308,7 +308,7 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
     // this can prevent introducing UB until
     // https://github.com/rust-lang/rust-clippy/issues/5953 is fixed
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    unsafe fn raw(&self) -> *mut ttf::TTF_Font {
+    pub unsafe fn raw(&self) -> *mut ttf::TTF_Font {
         self.raw
     }
 


### PR DESCRIPTION
It not being pub is inconsistent with other places, like rwops.

I want to render something with sdl2-sys, because I have the CStr and don't want to do the conversions.