### PR TITLE
add scale mode - unsafe textures

### DIFF
--- a/src/sdl2/render.rs
+++ b/src/sdl2/render.rs
@@ -2788,6 +2788,18 @@ impl Texture {
         InternalTexture { raw: self.raw }.color_mod()
     }
 
+    /// Sets the scale mode for use when rendered.
+    #[inline]
+    pub fn set_scale_mode(&mut self, scale: ScaleMode) {
+        InternalTexture { raw: self.raw }.set_scale_mode(scale)
+    }
+
+    /// Gets the scale mode for use when rendered.
+    #[inline]
+    pub fn scale_mode(&self) -> ScaleMode {
+        InternalTexture { raw: self.raw }.scale_mode()
+    }
+
     /// Sets an additional alpha value multiplied into render copy operations.
     #[inline]
     pub fn set_alpha_mod(&mut self, alpha: u8) {


### PR DESCRIPTION
no changelog entry needed - wasn't added in both because I didn't realize the dup.

relates: https://github.com/Rust-SDL2/rust-sdl2/pull/1444