### PR TITLE
Fix SDL_PIXELFORMAT_{RGBA,ARGB,BGRA,ABGR}32 being backward on big-endian targets by having big-endian imply use-bindgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rust-SDL2 uses the MIT license, but SDL2 itself is under the zlib license.
 * `ttf` to link against SDL2\_ttf and have access to various font features
 * `raw-window-handle` to enable the crate `raw-window-handle`, which is useful to interop with various other backends.
 * `unsafe-textures` to not have a lifetime in `Texture` structs. Texture are only freed when the program exits, or can be done manually through `unsafe`.
-* `use-bindgen` to customize bindings instead of using pre-generated `sdl_bindings` which were created from a Linux environment. It generates your own custom SDL2 bindings, tailored to your distro. Useful for specific window-related scenarios.
+* `use-bindgen` to customize bindings instead of using pre-generated `sdl_bindings` which were created from a Linux environment. It generates your own custom SDL2 bindings, tailored to your distro. Useful for specific window-related scenarios. This is forcibly enabled on big-endian targets.
 * `use-vcpkg` to pull SDL2 from vcpkg instead of looking in your system.
 * `use-pkgconfig` use pkg-config to detect where your library is located on your system. Mostly useful on unix systems for static linking.
 * `static-link` to link to SDL2 statically instead of dynamically.

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1427](https://github.com/Rust-SDL2/rust-sdl2/pull/1427) **BREAKING CHANGE** Add system locale support. A new event type `Event::LocaleChanged` has been added.
 
+[PR #1468](https://github.com/Rust-SDL2/rust-sdl2/pull/1468) **BREAKING CHANGE** Big-endian targets behave as-if the `use-bindgen` were always enabled.
+
 ### v0.37.0
 
 [PR #1406](https://github.com/Rust-SDL2/rust-sdl2/pull/1406) Update bindings to SDL 2.0.26, add Event.is\_touch() for mouse events, upgrade wgpu to 0.20 in examples

--- a/sdl2-sys/Cargo.toml
+++ b/sdl2-sys/Cargo.toml
@@ -19,9 +19,12 @@ path = "src/lib.rs"
 [dependencies]
 libc = "^0.2"
 
-[build-dependencies.bindgen]
+[target.'cfg(target_endian = "little")'.build-dependencies.bindgen]
 version = "^0.69"
 optional = true
+
+[target.'cfg(not(target_endian = "little"))'.build-dependencies.bindgen]
+version = "^0.69"
 
 [build-dependencies.pkg-config]
 version = "^0.3"


### PR DESCRIPTION
```c
    /* Aliases for RGBA byte arrays of color data, for the current platform */
#if SDL_BYTEORDER == SDL_BIG_ENDIAN
    SDL_PIXELFORMAT_RGBA32 = SDL_PIXELFORMAT_RGBA8888,
    SDL_PIXELFORMAT_ARGB32 = SDL_PIXELFORMAT_ARGB8888,
    SDL_PIXELFORMAT_BGRA32 = SDL_PIXELFORMAT_BGRA8888,
    SDL_PIXELFORMAT_ABGR32 = SDL_PIXELFORMAT_ABGR8888,
#else
    SDL_PIXELFORMAT_RGBA32 = SDL_PIXELFORMAT_ABGR8888,
    SDL_PIXELFORMAT_ARGB32 = SDL_PIXELFORMAT_BGRA8888,
    SDL_PIXELFORMAT_BGRA32 = SDL_PIXELFORMAT_ARGB8888,
    SDL_PIXELFORMAT_ABGR32 = SDL_PIXELFORMAT_RGBA8888,
#endif
```