### PR TITLE
Fix LocaleIterator for platforms where c_char is u8 (better fix?)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sdl2"
 description = "SDL2 bindings for Rust"
-repository = "https://github.com/Rust-SDL2/rust-sdl2"
+repository = "https://github.com/geniot/rust-sdl2"
 documentation = "https://docs.rs/sdl2"
 version = "0.37.0"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sdl2"
 description = "SDL2 bindings for Rust"
-repository = "https://github.com/geniot/rust-sdl2"
+repository = "https://github.com/Rust-SDL2/rust-sdl2"
 documentation = "https://docs.rs/sdl2"
 version = "0.37.0"
 license = "MIT"

--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,8 @@ when upgrading from a version of rust-sdl2 to another.
 
 [PR #1427](https://github.com/Rust-SDL2/rust-sdl2/pull/1427) **BREAKING CHANGE** Add system locale support. A new event type `Event::LocaleChanged` has been added.
 
+[PR #1479](https://github.com/Rust-SDL2/rust-sdl2/pull/1479) Fix get_locale in locale.rs for platforms where c_char is u8.
+
 ### v0.37.0
 
 [PR #1406](https://github.com/Rust-SDL2/rust-sdl2/pull/1406) Update bindings to SDL 2.0.26, add Event.is\_touch() for mouse events, upgrade wgpu to 0.20 in examples

--- a/src/sdl2/locale.rs
+++ b/src/sdl2/locale.rs
@@ -84,7 +84,6 @@ unsafe fn get_locale(ptr: *const sys::SDL_Locale) -> Option<Locale> {
                 .into_owned(),
         )
     };
-    // let region = try_get_string(sdl_locale.country);
 
     Some(Locale {
         lang,

--- a/src/sdl2/locale.rs
+++ b/src/sdl2/locale.rs
@@ -75,18 +75,19 @@ unsafe fn get_locale(ptr: *const sys::SDL_Locale) -> Option<Locale> {
         .to_string_lossy()
         .into_owned();
 
-    let region = try_get_string(sdl_locale.country);
+    let region = if sdl_locale.country.is_null() {
+        None
+    } else {
+        Some(
+            std::ffi::CStr::from_ptr(sdl_locale.country)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    };
+    // let region = try_get_string(sdl_locale.country);
 
     Some(Locale {
         lang,
         country: region,
     })
-}
-
-unsafe fn try_get_string(ptr: *const i8) -> Option<String> {
-    if ptr.is_null() {
-        None
-    } else {
-        Some(std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned())
-    }
 }


### PR DESCRIPTION
I had the same problem as the previous pull-requester when compiling on aarch64:
```
error[E0308]: mismatched types
  --> /root/.cargo/git/checkouts/rust-sdl2-4bcf6005ccaf1a39/ecd03de/src/sdl2/locale.rs:78:33
   |
78 |     let region = try_get_string(sdl_locale.country);
   |                  -------------- ^^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
   |                  |
   |                  arguments to this function are incorrect
   |
   = note: expected raw pointer `*const i8`
              found raw pointer `*const u8`
note: function defined here
  --> /root/.cargo/git/checkouts/rust-sdl2-4bcf6005ccaf1a39/ecd03de/src/sdl2/locale.rs:86:11
   |
86 | unsafe fn try_get_string(ptr: *const i8) -> Option<String> {
   |           ^^^^^^^^^^^^^^ --------------

error[E0308]: mismatched types
  --> /root/.cargo/git/checkouts/rust-sdl2-4bcf6005ccaf1a39/ecd03de/src/sdl2/locale.rs:90:39
   |
90 |         Some(std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned())
   |              ------------------------ ^^^ expected `*const u8`, found `*const i8`
   |              |
   |              arguments to this function are incorrect
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`
note: associated function defined here
  --> /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/ffi/c_str.rs:264:25
```
Anyway, I believe my fix is a better one... Choose one :)