### PR TITLE
fix: Change type signature of try_get_string in locale.rs

### DIFF
--- a/src/sdl2/locale.rs
+++ b/src/sdl2/locale.rs
@@ -83,7 +83,7 @@ unsafe fn get_locale(ptr: *const sys::SDL_Locale) -> Option<Locale> {
     })
 }
 
-unsafe fn try_get_string(ptr: *const i8) -> Option<String> {
+unsafe fn try_get_string(ptr: *const libc::c_char) -> Option<String> {
     if ptr.is_null() {
         None
     } else {


### PR DESCRIPTION
The type of the pointer from libc may change depending on the target architecture. Pass the libc type instead.