### PR TITLE
Add `Rect::origin` and update `Rect::new` to specify the origin location of rectangles.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ when upgrading from a version of rust-sdl2 to another.
 
 ### Next
 [PR #1493](https://github.com/Rust-SDL2/rust-sdl2/pull/1493) Add `Rect::origin` and specifies origin location in `Rect::new`.
+
 [PR #1472](https://github.com/Rust-SDL2/rust-sdl2/pull/1472) Add `Canvas::render_geometry`, `Canvas::render_geometry_raw` and an example that uses them both. Both these bindings use `SDL_RenderGeometryRaw`.
 
 [PR #1473](https://github.com/Rust-SDL2/rust-sdl2/pull/1473) **BREAKING CHANGE** Fix UB in `ToColor` implementations and remove implementation for `isize`.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@ In this file will be listed the changes, especially the breaking ones that one s
 when upgrading from a version of rust-sdl2 to another.
 
 ### Next
-
+[PR #1493](https://github.com/Rust-SDL2/rust-sdl2/pull/1493) Add `Rect::origin` and specifies origin location in `Rect::new`.
 [PR #1472](https://github.com/Rust-SDL2/rust-sdl2/pull/1472) Add `Canvas::render_geometry`, `Canvas::render_geometry_raw` and an example that uses them both. Both these bindings use `SDL_RenderGeometryRaw`.
 
 [PR #1473](https://github.com/Rust-SDL2/rust-sdl2/pull/1473) **BREAKING CHANGE** Fix UB in `ToColor` implementations and remove implementation for `isize`.

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -115,7 +115,7 @@ impl Hash for Rect {
 }
 
 impl Rect {
-    /// Creates a new rectangle from the given values.
+    /// Creates a new rectangle from the given values with an origin in the Upper Left.
     ///
     /// The width and height are clamped to ensure that the right and bottom
     /// sides of the rectangle does not exceed i32::MAX (the value
@@ -236,7 +236,6 @@ impl Rect {
     pub fn bottom(&self) -> i32 {
         self.raw.y + self.raw.h
     }
-
     /// Shifts this rectangle to the left by `offset`.
     ///
     /// # Example

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -236,6 +236,15 @@ impl Rect {
     pub fn bottom(&self) -> i32 {
         self.raw.y + self.raw.h
     }
+    /// Returns the origin of the rectangle (Top Left)
+    ///
+    /// ```
+    /// use sdl2::rect::Rect;
+    /// assert_eq!(Rect::new(5, 5, 10, 10).origin(), (5,5));
+    /// ```
+    pub fn origin(&self) -> (i32, i32) {
+        (self.left(), self.top())
+    }
     /// Shifts this rectangle to the left by `offset`.
     ///
     /// # Example

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -12,7 +12,7 @@ use std::ptr;
 
 /// The maximal integer value that can be used for rectangles.
 ///
-/// This value is smaller than st isrictly needed, but is useful in ensuring that
+/// This value is smaller than is strictly needed, but is useful in ensuring that
 /// rect sizes will never have to be truncated when clamping.
 pub fn max_int_value() -> u32 {
     i32::MAX as u32 / 2

--- a/src/sdl2/rect.rs
+++ b/src/sdl2/rect.rs
@@ -12,7 +12,7 @@ use std::ptr;
 
 /// The maximal integer value that can be used for rectangles.
 ///
-/// This value is smaller than strictly needed, but is useful in ensuring that
+/// This value is smaller than st isrictly needed, but is useful in ensuring that
 /// rect sizes will never have to be truncated when clamping.
 pub fn max_int_value() -> u32 {
     i32::MAX as u32 / 2
@@ -236,6 +236,7 @@ impl Rect {
     pub fn bottom(&self) -> i32 {
         self.raw.y + self.raw.h
     }
+    
     /// Returns the origin of the rectangle (Top Left)
     ///
     /// ```
@@ -245,6 +246,7 @@ impl Rect {
     pub fn origin(&self) -> (i32, i32) {
         (self.left(), self.top())
     }
+    
     /// Shifts this rectangle to the left by `offset`.
     ///
     /// # Example


### PR DESCRIPTION
Answers #1492

The goal is to ensure the origin location is understood and made available to users, as this point is used as a basis for transformations and positioning. Would work in stride with [`Rect::center`](https://github.com/Rust-SDL2/rust-sdl2/blob/master/src/sdl2/rect.rs#L304C18-L304C20).