### PR TITLE
Fix windows builds with `--features use-bindgen`

### DIFF
--- a/sdl2-sys/build.rs
+++ b/sdl2-sys/build.rs
@@ -657,7 +657,6 @@ fn generate_bindings(target: &str, host: &str, headers_paths: &[String]) {
     let mut bindings = bindgen::Builder::default()
         // enable no_std-friendly output by only using core definitions
         .use_core()
-        .clang_arg("-fms-compatibility")
         .allowlist_item("(SDL|AUDIO|RW)_.*")
         .bitfield_enum("SDL_RendererFlip")
         .newtype_enum("SDL_Keymod")

--- a/src/sdl2/keyboard/mod.rs
+++ b/src/sdl2/keyboard/mod.rs
@@ -191,7 +191,10 @@ impl KeyboardUtil {
 
     #[doc(alias = "SDL_SetModState")]
     pub fn set_mod_state(&self, flags: Mod) {
-        let arg = sys::SDL_Keymod(flags.bits() as i32);
+        // Note: Clang (and therefore bindgen) generates different integer types
+        // for C-style enums on different platforms. On Windows, the underlying
+        // type is `i32`, while on Linux it is `u32`.
+        let arg = sys::SDL_Keymod(flags.bits().into());
         unsafe {
             sys::SDL_SetModState(arg);
         }


### PR DESCRIPTION
The current `master` commit does not compile with `--features use-bindgen`. Specifically, here:
https://github.com/Rust-SDL2/rust-sdl2/blob/0545cad99253b4c9faa0573b52884eff5af2c064/src/sdl2/keyboard/mod.rs#L194

The compiler complains:
```
error[E0308]: mismatched types
    --> src\sdl2\keyboard\mod.rs:197:35
     |
 194 |         let arg = sys::SDL_Keymod(flags.bits() as u32);
     |                   --------------- ^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
     |                   |
     |                   arguments to this struct are incorrect
```

Clang generates different integer types for C-style enums on different platforms, `i32` on Windows and `u32` on Linux. After some digging, there seems to be no neat way around this as far as I can tell, other than keeping this in mind whenever we care about the specific type of the underlying value.

More info: https://github.com/rust-lang/rust-bindgen/issues/1966

Also somewhat related to https://github.com/Rust-SDL2/rust-sdl2/issues/1511, which is the original reason why I'm building with `use-bindgen` in the first place.